### PR TITLE
feat!: align client API with firmware paths

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,9 @@ repos:
     hooks:
       - id: ruff
         args: ["--fix"]
+        exclude: ^src/busylib/state_stream_proto/.*_pb2\.py$
       - id: ruff-format
+        exclude: ^src/busylib/state_stream_proto/.*_pb2\.py$
   - repo: https://github.com/tox-dev/pyproject-fmt
     rev: v2.21.0
     hooks:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,6 @@
+# Repository Instructions
+
+- Keep repository-facing text in English: code comments, docstrings, README updates, PR titles, PR descriptions, commit messages, review notes intended for GitHub, and user-visible library messages.
+- Do not introduce Russian text or references to internal conversation language in this repository.
+- Preserve Python 3.10+ runtime compatibility unless `pyproject.toml` is intentionally updated to raise the minimum supported version.
+- Run `python -m pre_commit run --all-files` and `python -m pytest -q` before pushing PR updates.

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ from busylib import BusyBar
 
 bb = BusyBar("10.0.4.20")
 
-version_info = bb.get_version()
+version_info = bb.version()
 print(f"Device version: {version_info.version}")
 ```
 
@@ -47,7 +47,7 @@ You can also use context manager.
 from busylib import BusyBar
 
 with BusyBar("10.0.4.20") as bb:
-    version_info = bb.get_version()
+    version_info = bb.version()
     print(f"Device version: {version_info.version}")
 ```
 
@@ -61,7 +61,7 @@ from busylib import AsyncBusyBar
 
 async def main() -> None:
     async with AsyncBusyBar("10.0.4.20") as bb:
-        version_info = await bb.get_version()
+        version_info = await bb.version()
         print(f"Device version: {version_info.version}")
 
 
@@ -73,6 +73,11 @@ if __name__ == "__main__":
 
 Here are some examples of how to use the library to control your Busy Bar device.
 
+Client method names follow Busy Bar API path segments instead of generic
+`get_*`/`set_*` prefixes. For example, `/api/display/draw` maps to
+`display_draw`, `/api/audio/play` maps to `audio_play`, and
+`/api/storage/remove` maps to `storage_remove`.
+
 ### Uploading an Asset
 
 You can upload files (like images or sounds) to be used by your application on the device.
@@ -80,7 +85,7 @@ You can upload files (like images or sounds) to be used by your application on t
 ```python
 with open("path/to/your/image.png", "rb") as f:
     file_bytes = f.read()
-    response = bb.upload_asset(
+    response = bb.assets_upload(
         application_name="my-app",
         filename="logo.png",
         data=file_bytes,
@@ -90,7 +95,7 @@ with open("path/to/your/image.png", "rb") as f:
 
 with open("path/to/your/sound.wav", "rb") as f:
     file_bytes = f.read()
-    response = bb.upload_asset(
+    response = bb.assets_upload(
         application_name="my-app",
         filename="notification.wav",
         data=file_bytes,
@@ -99,7 +104,7 @@ with open("path/to/your/sound.wav", "rb") as f:
 
 ### Drawing on the Display
 
-Draw text or images on the device's screen. The `draw_on_display` method accepts a `DisplayElements` object containing a list of elements to render.
+Draw text or images on the device's screen. The `display_draw` method accepts a `DisplayElements` object containing a list of elements to render.
 
 ```python
 from busylib import types
@@ -129,7 +134,7 @@ display_data = types.DisplayElements(
     elements=[text_element, image_element]
 )
 
-response = bb.draw_on_display(display_data)
+response = bb.display_draw(display_data)
 print(f"Draw result: {response.result}")
 ```
 
@@ -138,7 +143,7 @@ print(f"Draw result: {response.result}")
 To clear everything from the screen:
 
 ```python
-response = bb.clear_display()
+response = bb.display_clear()
 print(f"Clear result: {response.result}")
 ```
 
@@ -147,7 +152,7 @@ print(f"Clear result: {response.result}")
 Play an audio file that you have already uploaded.
 
 ```python
-response = bb.play_audio(application_name="my-app", path="notification.wav")
+response = bb.audio_play(application_name="my-app", path="notification.wav")
 print(f"Play result: {response.result}")
 ```
 
@@ -156,7 +161,7 @@ print(f"Play result: {response.result}")
 To stop any audio that is currently playing:
 
 ```python
-response = bb.stop_audio()
+response = bb.audio_stop()
 print(f"Stop result: {response.result}")
 ```
 
@@ -165,7 +170,7 @@ print(f"Stop result: {response.result}")
 This will remove all files associated with a specific `application_name`.
 
 ```python
-response = bb.delete_app_assets(application_name="my-app")
+response = bb.assets_delete(application_name="my-app")
 print(f"Delete result: {response.result}")
 ```
 
@@ -174,19 +179,19 @@ print(f"Delete result: {response.result}")
 You can get various status information from the device:
 
 ```python
-version = bb.get_version()
+version = bb.version()
 print(f"Version: {version.version}, Branch: {version.branch}")
 
-status = bb.get_status()
+status = bb.status()
 if status.system:
     print(f"Uptime: {status.system.uptime}")
 if status.power:
     print(f"Battery: {status.power.battery_charge}%")
 
-brightness = bb.get_display_brightness()
+brightness = bb.display_brightness()
 print(f"Front brightness: {brightness.front}, Back brightness: {brightness.back}")
 
-volume = bb.get_audio_volume()
+volume = bb.audio_volume()
 print(f"Volume: {volume.volume}")
 ```
 
@@ -219,21 +224,21 @@ You can manage files in the device's storage:
 
 ```python
 file_data = b"Hello, world!"
-response = bb.write_storage_file(path="/my-app/data.txt", data=file_data)
+response = bb.storage_write(path="/my-app/data.txt", data=file_data)
 
-file_content = bb.read_storage_file(path="/my-app/data.txt")
+file_content = bb.storage_read(path="/my-app/data.txt")
 print(file_content.decode('utf-8'))
 
-storage_list = bb.list_storage_files(path="/my-app")
+storage_list = bb.storage_list(path="/my-app")
 for item in storage_list.list:
     if item.type == "file":
         print(f"File: {item.name} ({item.size} bytes)")
     else:
         print(f"Directory: {item.name}")
 
-response = bb.create_storage_directory(path="/my-app/subdirectory")
+response = bb.storage_mkdir(path="/my-app/subdirectory")
 
-response = bb.remove_storage_file(path="/my-app/data.txt")
+response = bb.storage_remove(path="/my-app/data.txt")
 ```
 
 ## Links

--- a/examples/bc/main.py
+++ b/examples/bc/main.py
@@ -52,7 +52,7 @@ def run_client(client: AsyncBusyBar, runner: AsyncRunner, *, app: str) -> None:
     Ensures the client is closed and runner stopped on exit.
     """
     runner.start(client)
-    runner.run(client.list_storage_files("/ext"))
+    runner.run(client.storage_list("/ext"))
     app_dir = ensure_app_directory(runner, app)
     try:
         curses.wrapper(run_ui, client, runner, app_dir=app_dir)

--- a/examples/bc/panels.py
+++ b/examples/bc/panels.py
@@ -244,14 +244,14 @@ class RemotePanel(Panel):
         """
         try:
             client = self.runner.require_client()
-            listing = self.runner.run(client.list_storage_files(self.cwd))
+            listing = self.runner.run(client.storage_list(self.cwd))
             self._apply_listing(listing)
         except BusyBarAPIError as exc:
             if exc.code == 400 and self.cwd != "/ext":
                 self.cwd = "/ext"
                 try:
                     client = self.runner.require_client()
-                    listing = self.runner.run(client.list_storage_files(self.cwd))
+                    listing = self.runner.run(client.storage_list(self.cwd))
                     self._apply_listing(
                         listing,
                         error="Reset to /ext after 400 error",
@@ -304,7 +304,7 @@ class RemotePanel(Panel):
         Delegates to the BusyBar client via AsyncRunner.
         """
         client = self.runner.require_client()
-        runner.run(client.remove_storage_file(self.path_of(entry)))  # type: ignore[arg-type]
+        runner.run(client.storage_remove(self.path_of(entry)))  # type: ignore[arg-type]
 
     def _apply_listing(self, listing: object, *, error: str | None = None) -> None:
         """

--- a/examples/bc/preview.py
+++ b/examples/bc/preview.py
@@ -38,7 +38,7 @@ class FilePreviewer(Protocol):
         runner: "AsyncRunner",
         status: list[str],
         *,
-        app_id: str,
+        application_name: str,
         rel_path: str,
     ) -> None:
         """
@@ -84,7 +84,7 @@ class WavPreviewer:
         runner: "AsyncRunner",
         status: list[str],
         *,
-        app_id: str,
+        application_name: str,
         rel_path: str,
     ) -> None:
         """
@@ -93,7 +93,9 @@ class WavPreviewer:
         Adds a status message on success or failure.
         """
         try:
-            runner.run(client.play_audio(app_id, rel_path))
+            runner.run(
+                client.audio_play(application_name=application_name, path=rel_path)
+            )
             status.append(f"Playing {entry.name} (press space to stop)")
         except Exception as exc:  # noqa: BLE001
             status.append(f"Audio play failed: {exc}")
@@ -121,7 +123,7 @@ class TxtPreviewer:
         runner: "AsyncRunner",
         status: list[str],
         *,
-        app_id: str,
+        application_name: str,
         rel_path: str,
     ) -> None:
         """
@@ -130,11 +132,11 @@ class TxtPreviewer:
         Shows text on the front display using the small font.
         """
         try:
-            data = runner.run(client.read_storage_file(entry.path or entry.name))
+            data = runner.run(client.storage_read(entry.path or entry.name))
             text = data.decode("utf-8", errors="ignore")
             first_line = text.splitlines()[0] if text else ""
             payload = types.DisplayElements(
-                app_id=app_id,
+                application_name=application_name,
                 elements=[
                     types.TextElement(
                         id="text-preview",
@@ -146,7 +148,7 @@ class TxtPreviewer:
                     )
                 ],
             )
-            runner.run(client.draw_on_display(payload))
+            runner.run(client.display_draw(payload))
             status.append(f"Preview: {first_line[:60]}")
         except Exception as exc:  # noqa: BLE001
             status.append(f"Text preview failed: {exc}")
@@ -174,7 +176,7 @@ class PngPreviewer:
         runner: "AsyncRunner",
         status: list[str],
         *,
-        app_id: str,
+        application_name: str,
         rel_path: str,
     ) -> None:
         """
@@ -184,7 +186,7 @@ class PngPreviewer:
         """
         try:
             payload = types.DisplayElements(
-                app_id=app_id,
+                application_name=application_name,
                 elements=[
                     types.ImageElement(
                         id="png-preview",
@@ -195,7 +197,7 @@ class PngPreviewer:
                     )
                 ],
             )
-            runner.run(client.draw_on_display(payload))
+            runner.run(client.display_draw(payload))
             status.append(f"Shown {entry.name} on display")
         except Exception as exc:  # noqa: BLE001
             status.append(f"PNG preview failed: {exc}")
@@ -223,7 +225,7 @@ class DefaultPreviewer:
         runner: "AsyncRunner",
         status: list[str],
         *,
-        app_id: str,
+        application_name: str,
         rel_path: str,
     ) -> None:
         """
@@ -245,7 +247,7 @@ _preview_cancel = threading.Event()
 
 
 def start_text_preview_thread(
-    app_id: str,
+    application_name: str,
     rel_path: str,
     client: AsyncBusyBar,
     runner: "AsyncRunner",
@@ -272,13 +274,13 @@ def start_text_preview_thread(
             spec = display.get_display_spec(display.DisplayName.FRONT)
             width = spec.width
             height = spec.height
-            runner.run(client.clear_display())
+            runner.run(client.display_clear())
             center_y = height // 4
             for line in lines:
                 if _preview_cancel.is_set():
                     break
                 payload = types.DisplayElements(
-                    app_id=app_id,
+                    application_name=application_name,
                     elements=[
                         types.TextElement(
                             id="text-preview",
@@ -292,12 +294,12 @@ def start_text_preview_thread(
                         )
                     ],
                 )
-                runner.run(client.draw_on_display(payload))
+                runner.run(client.display_draw(payload))
                 for _ in range(5):
                     if _preview_cancel.is_set():
                         break
                     time.sleep(0.5)
-            runner.run(client.clear_display())
+            runner.run(client.display_clear())
         except Exception as exc:  # noqa: BLE001
             logging.getLogger(__name__).debug("Preview thread failed: %s", exc)
         finally:
@@ -371,16 +373,16 @@ def preview_remote(
     if not parts or not parts[0]:
         status.append("Select app folder under /ext/assets")
         return PreviewMode.NONE
-    app_id = parts[0]
+    application_name = parts[0]
     rel_path = parts[1] if len(parts) > 1 else entry.name
     if entry.name.lower().endswith(
         (".txt", ".log", ".cfg", ".ini", ".json", ".yaml", ".yml", ".toml")
     ):
         try:
-            data = runner.run(client.read_storage_file(entry.path))  # type: ignore[arg-type]
+            data = runner.run(client.storage_read(entry.path))  # type: ignore[arg-type]
             text = data.decode("utf-8", errors="ignore").splitlines()
             start_text_preview_thread(
-                app_id,
+                application_name,
                 rel_path,
                 client,
                 runner,
@@ -398,7 +400,7 @@ def preview_remote(
                 entry,
                 runner,
                 status,
-                app_id=app_id,
+                application_name=application_name,
                 rel_path=rel_path,
             )  # type: ignore[arg-type]
             return preview_mode_for_entry(entry)

--- a/examples/bc/startup.py
+++ b/examples/bc/startup.py
@@ -15,10 +15,10 @@ def ensure_app_directory(runner: AsyncRunner, app: str) -> str:
     assets_path = app_assets_dir(app)
     client = runner.require_client()
     try:
-        runner.run(client.list_storage_files(assets_path))
+        runner.run(client.storage_list(assets_path))
     except BusyBarAPIError as exc:
         if exc.code in {400, 404}:
-            runner.run(client.create_storage_directory(assets_path))
+            runner.run(client.storage_mkdir(assets_path))
         else:
             raise
     return assets_path

--- a/examples/bc/transfer.py
+++ b/examples/bc/transfer.py
@@ -77,7 +77,7 @@ def copy_file(
         if isinstance(dst_panel, RemotePanel):
             client = dst_panel.runner.require_client()
             listing = dst_panel.runner.run(
-                client.list_storage_files(directory or dst_panel.cwd)
+                client.storage_list(directory or dst_panel.cwd)
             )  # type: ignore[attr-defined]
             names = {e.name for e in listing.list if e.type == "file"}
             name = Path(path).name
@@ -150,7 +150,7 @@ def copy_file(
                 )
 
             runner.run(
-                client.write_storage_file(
+                client.storage_write(
                     new_path,
                     payload,
                     progress_callback=_progress,
@@ -164,7 +164,7 @@ def copy_file(
                     return
                 dst_path = str(Path(dst_panel.cwd) / choice)
             client = src_panel.runner.require_client()
-            data = runner.run(client.read_storage_file(src_path))
+            data = runner.run(client.storage_read(src_path))
             draw_progress_modal(stdscr, f"Copying {entry.name}", 0.5)
             Path(dst_path).write_bytes(data)
             dst_panel.refresh()

--- a/examples/bc/ui.py
+++ b/examples/bc/ui.py
@@ -159,9 +159,9 @@ def run_ui(
                 if preview_mode is not PreviewMode.NONE:
                     try:
                         stop_preview_thread(timeout=0.1)
-                        runner.run(client.stop_sound())
+                        runner.run(client.audio_stop())
                         right_client = right.runner.require_client()
-                        runner.run(right_client.clear_display())  # type: ignore[attr-defined]
+                        runner.run(right_client.display_clear())  # type: ignore[attr-defined]
                         status.append("Preview cleared")
                     except Exception as exc:  # noqa: BLE001
                         status.append(f"Failed to clear preview: {exc}")
@@ -177,8 +177,8 @@ def run_ui(
         try:
             if preview_mode is not PreviewMode.NONE:
                 stop_preview_thread(timeout=0.2)
-                runner.run(client.stop_sound())
-                runner.run(client.clear_display())
+                runner.run(client.audio_stop())
+                runner.run(client.display_clear())
         except Exception:
             pass
         save_state(str(left.cwd), str(right.cwd), active_left)

--- a/examples/remote/commands/audio.py
+++ b/examples/remote/commands/audio.py
@@ -70,25 +70,25 @@ def _audio_cache_key(data: bytes) -> str:
     return hashlib.md5(data, usedforsecurity=False).hexdigest()
 
 
-def _remote_assets_dir(app_id: str) -> str:
+def _remote_assets_dir(application_name: str) -> str:
     """
     Build the storage path where app assets are kept on device.
     """
-    return f"/ext/assets/{app_id}"
+    return f"/ext/assets/{application_name}"
 
 
 async def _list_remote_assets(
     client: AsyncBusyBar,
-    app_id: str,
+    application_name: str,
 ) -> set[str]:
     """
     Return a set of asset names currently present on the device.
 
     Errors are treated as an empty listing to keep audio flow resilient.
     """
-    remote_dir = _remote_assets_dir(app_id)
+    remote_dir = _remote_assets_dir(application_name)
     try:
-        listing = await client.list_storage_files(remote_dir)
+        listing = await client.storage_list(remote_dir)
     except Exception as exc:  # noqa: BLE001
         logger.debug("audio: failed to list remote assets: %s", exc)
         return set()
@@ -253,7 +253,9 @@ class AudioCommand(CommandBase):
                 _store_cached_audio(cache_dir, cache_key, filename, converted_data)
 
             self._status_message("audio: checking remote assets")
-            remote_assets = await _list_remote_assets(self._client, settings.app_id)
+            remote_assets = await _list_remote_assets(
+                self._client, settings.application_name
+            )
             self._status_message(f"audio: remote has {len(remote_assets)} assets")
             if filename in remote_assets:
                 self._status_message(f"audio: refreshing {filename}")
@@ -262,15 +264,15 @@ class AudioCommand(CommandBase):
 
             upload_timeout = _audio_timeout(settings.audio_upload_timeout_seconds)
             if upload_timeout is None:
-                await self._client.upload_asset(
-                    settings.app_id,
+                await self._client.assets_upload(
+                    settings.application_name,
                     filename,
                     converted_data,
                 )
             else:
                 await asyncio.wait_for(
-                    self._client.upload_asset(
-                        settings.app_id,
+                    self._client.assets_upload(
+                        settings.application_name,
                         filename,
                         converted_data,
                     ),
@@ -280,10 +282,14 @@ class AudioCommand(CommandBase):
 
             play_timeout = _audio_timeout(settings.audio_play_timeout_seconds)
             if play_timeout is None:
-                await self._client.play_audio(settings.app_id, filename)
+                await self._client.audio_play(
+                    application_name=settings.application_name, path=filename
+                )
             else:
                 await asyncio.wait_for(
-                    self._client.play_audio(settings.app_id, filename),
+                    self._client.audio_play(
+                        application_name=settings.application_name, path=filename
+                    ),
                     timeout=play_timeout,
                 )
             self._status_message("audio: done")
@@ -337,7 +343,7 @@ class AudioStopCommand(CommandBase):
         """
         logger.info("command:audio_stop")
         try:
-            await self._client.stop_audio()
+            await self._client.audio_stop()
             self._status_message("audio: stopped")
         except Exception as exc:  # noqa: BLE001
             logger.exception("command:audio_stop failed")

--- a/examples/remote/commands/call.py
+++ b/examples/remote/commands/call.py
@@ -9,20 +9,26 @@ from busylib.client import AsyncBusyBar
 
 logger = logging.getLogger(__name__)
 
-DANGEROUS_PREFIXES = (
-    "set_",
-    "delete_",
-    "update_",
-    "upload_",
-    "write_",
-    "install_",
-    "abort_",
-    "unlink_",
+DANGEROUS_METHOD_PARTS = (
+    "_abort",
+    "_clear",
+    "_connect",
+    "_delete",
+    "_disable",
+    "_enable",
+    "_forget",
+    "_install",
+    "_mkdir",
+    "_remove",
+    "_set",
+    "_stop",
+    "_unlink",
+    "_upload",
+    "_write",
     "reboot",
     "reset",
     "usb_",
     "format_",
-    "clear_",
 )
 BLACKLISTED_METHODS = {
     "aclose",
@@ -95,7 +101,7 @@ def build_call_handler(
                 return
             kwargs[key] = value
 
-        if method_name.startswith(DANGEROUS_PREFIXES) and not force:
+        if any(part in method_name for part in DANGEROUS_METHOD_PARTS) and not force:
             logger.warning("call: method %s requires --force", method_name)
             status_message(f"call {method_name}: requires --force")
             return

--- a/examples/remote/commands/clear.py
+++ b/examples/remote/commands/clear.py
@@ -45,4 +45,4 @@ class ClearCommand(CommandBase):
         Clear the remote display.
         """
         logger.info("command:clear")
-        await self._client.clear_display()
+        await self._client.display_clear()

--- a/examples/remote/commands/clock.py
+++ b/examples/remote/commands/clock.py
@@ -46,8 +46,8 @@ class ClockCommand(CommandBase):
         Trigger the clock app sequence.
         """
         logger.info("command:clock")
-        await self._client.send_input_key(types.InputKey.APPS)
+        await self._client.input(types.InputKey.APPS)
         await asyncio.sleep(0.2)
-        await self._client.send_input_key(types.InputKey.OK)
+        await self._client.input(types.InputKey.OK)
         await asyncio.sleep(0.2)
-        await self._client.send_input_key(types.InputKey.OK)
+        await self._client.input(types.InputKey.OK)

--- a/examples/remote/commands/record_audio.py
+++ b/examples/remote/commands/record_audio.py
@@ -238,8 +238,8 @@ class RecordAudioCommand(CommandBase):
             )
             filename = Path(converted_path).name
             self._status_message(f"record_audio: uploading {filename}")
-            await self._client.upload_asset(
-                settings.app_id,
+            await self._client.assets_upload(
+                settings.application_name,
                 filename,
                 converted_data,
             )

--- a/examples/remote/commands/text.py
+++ b/examples/remote/commands/text.py
@@ -106,5 +106,7 @@ class TextCommand(CommandBase):
             scroll_rate=scroll_rate,
             display=types.DisplayName.FRONT,
         )
-        payload = types.DisplayElements(app_id="remote_command", elements=[element])
-        await self._client.draw_on_display(payload)
+        payload = types.DisplayElements(
+            application_name="remote_command", elements=[element]
+        )
+        await self._client.display_draw(payload)

--- a/examples/remote/commands/timezone_set.py
+++ b/examples/remote/commands/timezone_set.py
@@ -179,7 +179,7 @@ class TimezoneSetCommand(CommandBase):
 
         self._status_message(f"timezone_set: setting {timezone}")
         try:
-            await self._client.set_time_timezone(timezone)
+            await self._client.time_timezone(timezone)
         except Exception as exc:  # noqa: BLE001
             logger.exception("command:timezone_set failed")
             self._status_message(f"timezone_set: error {exc}")

--- a/examples/remote/periodic_tasks.py
+++ b/examples/remote/periodic_tasks.py
@@ -57,7 +57,7 @@ async def cloud_link(client: AsyncBusyBar, renderer: TerminalRenderer) -> None:
     Refresh cloud link status and update the renderer.
     """
     try:
-        info = await client.get_account_info()
+        info = await client.account_info()
         if info.linked:
             renderer.update_info(
                 link_connected=True,
@@ -65,7 +65,7 @@ async def cloud_link(client: AsyncBusyBar, renderer: TerminalRenderer) -> None:
                 link_email=info.email,
             )
             return
-        link_info = await client.link_account()
+        link_info = await client.account_link()
         renderer.update_info(
             link_connected=False,
             link_key=link_info.code,
@@ -79,8 +79,8 @@ async def update_check(client: AsyncBusyBar, renderer: TerminalRenderer) -> None
     Request a firmware update check and update the renderer.
     """
     try:
-        await client.check_firmware_update()
-        status = await client.get_update_status()
+        await client.update_check()
+        status = await client.update_status()
         available = False
         if status.check and status.check.available_version:
             available = True

--- a/examples/remote/runner.py
+++ b/examples/remote/runner.py
@@ -147,7 +147,7 @@ async def _forward_keys(
                     if key_event is None:
                         continue
                     try:
-                        await client.send_input_key(key_event)
+                        await client.input(key_event)
                     except Exception as exc:  # noqa: BLE001 pragma: no cover - network dependent
                         logger.debug("Failed to send key %s: %s", key_event.value, exc)
                 return False
@@ -389,8 +389,8 @@ async def _stream_ws(
     status_message(TEXT_INIT_WAIT_FRAME)
     first_frame = True
     try:
-        # stream_screen_ws yields bytes | str
-        async for message in client.stream_screen_ws(spec):
+        # screen_ws yields bytes | str
+        async for message in client.screen_ws(spec):
             if stop_event.is_set():
                 break
             if not message:
@@ -440,7 +440,7 @@ async def _poll_http(
     try:
         while not stop_event.is_set():
             try:
-                frame_bytes = await client.get_screen_frame(spec)
+                frame_bytes = await client.screen(spec)
             except Exception as exc:  # noqa: BLE001
                 logger.warning(TEXT_POLL_FAIL, exc)
                 await asyncio.sleep(interval)
@@ -644,7 +644,9 @@ async def _run(
             )
 
         try:
-            done, pending = await asyncio.wait(tasks, return_when=asyncio.FIRST_COMPLETED)
+            done, pending = await asyncio.wait(
+                tasks, return_when=asyncio.FIRST_COMPLETED
+            )
             stop_event.set()
             for task in pending:
                 task.cancel()

--- a/examples/remote/settings.py
+++ b/examples/remote/settings.py
@@ -11,7 +11,7 @@ class RemoteSettings(BaseSettings):
 
     model_config = SettingsConfigDict(env_prefix="BUSYBAR_REMOTE_")
 
-    app_id: str = Field(default="remote")
+    application_name: str = Field(default="remote")
     icon_mode: str = Field(default="text")
     spacer: str = Field(default=" ")
     pixel_char: str | None = Field(default=None)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,10 +24,11 @@ dynamic = [ "version" ]
 dependencies = [
   "httpx>=0.28.1",
   "pillow>=12",
+  "protobuf>=6.31.1",
   "pydantic>=2.9",
   "pydantic-extra-types>=2.9",
   "pydantic-settings>=2.12",
-  "protobuf>=6.31.1",
+  "typing-extensions>=4.6",
   "websockets>=12",
 ]
 urls.Documentation = "https://busylib.readthedocs.io"

--- a/src/busylib/client/access.py
+++ b/src/busylib/client/access.py
@@ -16,19 +16,19 @@ class AccessMixin(SyncClientBase):
     HTTP access mode helpers.
     """
 
-    def get_http_access(self) -> types.HttpAccessInfo:
+    def access(self) -> types.HttpAccessInfo:
         """
         Fetch HTTP access mode via GET /api/access.
         """
-        logger.info("get_http_access")
+        logger.info("access")
         data = self._request("GET", "/api/access")
         return types.HttpAccessInfo.model_validate(data)
 
-    def set_http_access(self, mode: HttpAccessMode, key: str) -> types.SuccessResponse:
+    def access_set(self, mode: HttpAccessMode, key: str) -> types.SuccessResponse:
         """
         Set HTTP access mode via POST /api/access.
         """
-        logger.info("set_http_access mode=%s", mode)
+        logger.info("access_set mode=%s", mode)
         params = {"mode": mode, "key": key}
         data = self._request("POST", "/api/access", params=params)
         return types.SuccessResponse.model_validate(data)
@@ -39,21 +39,19 @@ class AsyncAccessMixin(AsyncClientBase):
     Async HTTP access mode helpers.
     """
 
-    async def get_http_access(self) -> types.HttpAccessInfo:
+    async def access(self) -> types.HttpAccessInfo:
         """
         Fetch HTTP access mode via GET /api/access.
         """
-        logger.info("async get_http_access")
+        logger.info("async access")
         data = await self._request("GET", "/api/access")
         return types.HttpAccessInfo.model_validate(data)
 
-    async def set_http_access(
-        self, mode: HttpAccessMode, key: str
-    ) -> types.SuccessResponse:
+    async def access_set(self, mode: HttpAccessMode, key: str) -> types.SuccessResponse:
         """
         Set HTTP access mode via POST /api/access.
         """
-        logger.info("async set_http_access mode=%s", mode)
+        logger.info("async access_set mode=%s", mode)
         params = {"mode": mode, "key": key}
         data = await self._request("POST", "/api/access", params=params)
         return types.SuccessResponse.model_validate(data)

--- a/src/busylib/client/account.py
+++ b/src/busylib/client/account.py
@@ -16,47 +16,47 @@ class AccountMixin(SyncClientBase):
     Account linking and MQTT profile helpers.
     """
 
-    def unlink_account(self) -> types.SuccessResponse:
+    def account_unlink(self) -> types.SuccessResponse:
         """
         Unlink the device from the account via DELETE /api/account.
         """
-        logger.info("unlink_account")
+        logger.info("account_unlink")
         data = self._request("DELETE", "/api/account")
         return types.SuccessResponse.model_validate(data)
 
-    def link_account(self) -> types.AccountLink:
+    def account_link(self) -> types.AccountLink:
         """
         Request an account link code via POST /api/account/link.
         """
-        logger.info("link_account")
+        logger.info("account_link")
         data = self._request("POST", "/api/account/link")
         return types.AccountLink.model_validate(data)
 
-    def get_account_info(self) -> types.AccountInfo:
+    def account_info(self) -> types.AccountInfo:
         """
         Fetch linked account info via GET /api/account/info.
         """
-        logger.info("get_account_info")
+        logger.info("account_info")
         data = self._request("GET", "/api/account/info")
         return types.AccountInfo.model_validate(data)
 
-    def get_account_status(self) -> types.AccountState:
+    def account_status(self) -> types.AccountState:
         """
         Fetch MQTT status info via GET /api/account/status.
         """
-        logger.info("get_account_status")
+        logger.info("account_status")
         data = self._request("GET", "/api/account/status")
         return types.AccountState.model_validate(data)
 
-    def get_account_profile(self) -> types.AccountProfile:
+    def account_profile(self) -> types.AccountProfile:
         """
         Fetch MQTT profile via GET /api/account/profile.
         """
-        logger.info("get_account_profile")
+        logger.info("account_profile")
         data = self._request("GET", "/api/account/profile")
         return types.AccountProfile.model_validate(data)
 
-    def set_account_profile(
+    def account_profile_set(
         self,
         profile: AccountProfileName,
         custom_url: str | None = None,
@@ -64,7 +64,7 @@ class AccountMixin(SyncClientBase):
         """
         Set MQTT profile via POST /api/account/profile.
         """
-        logger.info("set_account_profile profile=%s", profile)
+        logger.info("account_profile_set profile=%s", profile)
         params: dict[str, str] = {"profile": profile}
         if custom_url:
             params["custom_url"] = custom_url
@@ -81,47 +81,47 @@ class AsyncAccountMixin(AsyncClientBase):
     Async account linking and MQTT profile helpers.
     """
 
-    async def unlink_account(self) -> types.SuccessResponse:
+    async def account_unlink(self) -> types.SuccessResponse:
         """
         Unlink the device from the account via DELETE /api/account.
         """
-        logger.info("async unlink_account")
+        logger.info("async account_unlink")
         data = await self._request("DELETE", "/api/account")
         return types.SuccessResponse.model_validate(data)
 
-    async def link_account(self) -> types.AccountLink:
+    async def account_link(self) -> types.AccountLink:
         """
         Request an account link code via POST /api/account/link.
         """
-        logger.info("async link_account")
+        logger.info("async account_link")
         data = await self._request("POST", "/api/account/link")
         return types.AccountLink.model_validate(data)
 
-    async def get_account_info(self) -> types.AccountInfo:
+    async def account_info(self) -> types.AccountInfo:
         """
         Fetch linked account info via GET /api/account/info.
         """
-        logger.info("async get_account_info")
+        logger.info("async account_info")
         data = await self._request("GET", "/api/account/info")
         return types.AccountInfo.model_validate(data)
 
-    async def get_account_status(self) -> types.AccountState:
+    async def account_status(self) -> types.AccountState:
         """
         Fetch MQTT status info via GET /api/account/status.
         """
-        logger.info("async get_account_status")
+        logger.info("async account_status")
         data = await self._request("GET", "/api/account/status")
         return types.AccountState.model_validate(data)
 
-    async def get_account_profile(self) -> types.AccountProfile:
+    async def account_profile(self) -> types.AccountProfile:
         """
         Fetch MQTT profile via GET /api/account/profile.
         """
-        logger.info("async get_account_profile")
+        logger.info("async account_profile")
         data = await self._request("GET", "/api/account/profile")
         return types.AccountProfile.model_validate(data)
 
-    async def set_account_profile(
+    async def account_profile_set(
         self,
         profile: AccountProfileName,
         custom_url: str | None = None,
@@ -129,7 +129,7 @@ class AsyncAccountMixin(AsyncClientBase):
         """
         Set MQTT profile via POST /api/account/profile.
         """
-        logger.info("async set_account_profile profile=%s", profile)
+        logger.info("async account_profile_set profile=%s", profile)
         params: dict[str, str] = {"profile": profile}
         if custom_url:
             params["custom_url"] = custom_url

--- a/src/busylib/client/assets.py
+++ b/src/busylib/client/assets.py
@@ -22,7 +22,7 @@ class AssetsMixin(SyncClientBase):
     Asset upload and deletion helpers.
     """
 
-    def upload_asset(
+    def assets_upload(
         self,
         application_name: str,
         filename: str,
@@ -31,12 +31,12 @@ class AssetsMixin(SyncClientBase):
         timeout: float | httpx.Timeout | None = ASSET_UPLOAD_TIMEOUT,
     ) -> types.SuccessResponse:
         """
-        Upload an asset file for the given app.
+        Upload an asset file for the given application.
 
         Uses a longer default timeout to tolerate large payload uploads.
         """
         logger.info(
-            "upload_asset application_name=%s filename=%s size=%s",
+            "assets_upload application_name=%s filename=%s size=%s",
             application_name,
             filename,
             len(data),
@@ -44,18 +44,19 @@ class AssetsMixin(SyncClientBase):
         payload = self._request(
             "POST",
             "/api/assets/upload",
-            params={"application_name": application_name, "file": filename},
+            params={"file": filename},
+            application_name=application_name,
             data=data,
             timeout=timeout,
         )
         return types.SuccessResponse.model_validate(payload)
 
-    def delete_app_assets(self, application_name: str) -> types.SuccessResponse:
-        logger.info("delete_app_assets application_name=%s", application_name)
+    def assets_delete(self, application_name: str) -> types.SuccessResponse:
+        logger.info("assets_delete application_name=%s", application_name)
         data = self._request(
             "DELETE",
             "/api/assets/upload",
-            params={"application_name": application_name},
+            application_name=application_name,
         )
         return types.SuccessResponse.model_validate(data)
 
@@ -65,7 +66,7 @@ class AsyncAssetsMixin(AsyncClientBase):
     Async asset upload and deletion helpers.
     """
 
-    async def upload_asset(
+    async def assets_upload(
         self,
         application_name: str,
         filename: str,
@@ -74,12 +75,12 @@ class AsyncAssetsMixin(AsyncClientBase):
         timeout: float | httpx.Timeout | None = ASSET_UPLOAD_TIMEOUT,
     ) -> types.SuccessResponse:
         """
-        Upload an asset file for the given app.
+        Upload an asset file for the given application.
 
         Uses a longer default timeout to tolerate large payload uploads.
         """
         logger.info(
-            "async upload_asset app_id=%s filename=%s size=%s",
+            "async assets_upload application_name=%s filename=%s size=%s",
             application_name,
             filename,
             len(data),
@@ -87,17 +88,18 @@ class AsyncAssetsMixin(AsyncClientBase):
         payload = await self._request(
             "POST",
             "/api/assets/upload",
-            params={"application_name": application_name, "file": filename},
+            params={"file": filename},
+            application_name=application_name,
             data=data,
             timeout=timeout,
         )
         return types.SuccessResponse.model_validate(payload)
 
-    async def delete_app_assets(self, application_name: str) -> types.SuccessResponse:
-        logger.info("async delete_app_assets application_name=%s", application_name)
+    async def assets_delete(self, application_name: str) -> types.SuccessResponse:
+        logger.info("async assets_delete application_name=%s", application_name)
         data = await self._request(
             "DELETE",
             "/api/assets/upload",
-            params={"application_name": application_name},
+            application_name=application_name,
         )
         return types.SuccessResponse.model_validate(data)

--- a/src/busylib/client/audio.py
+++ b/src/busylib/client/audio.py
@@ -3,10 +3,14 @@ from __future__ import annotations
 import logging
 from typing import Any
 
-from .. import exceptions, types
-from .base import AsyncClientBase, SyncClientBase
+from typing_extensions import Unpack
+
+from .. import types
+from .base import AsyncClientBase, RequestKwargs, SyncClientBase
 
 logger = logging.getLogger(__name__)
+
+AUDIO_PLAY_PATH = "/api/audio/play"
 
 
 class AudioMixin(SyncClientBase):
@@ -14,82 +18,73 @@ class AudioMixin(SyncClientBase):
     Audio playback and volume control helpers.
     """
 
-    def play_audio(
+    def audio_play(
         self,
-        application_name: str | None = None,
-        path: str | None = None,
         *,
+        path: str | None = None,
         stock_path: str | None = None,
         payload: types.AudioPlayRequest | dict[str, Any] | None = None,
+        **request_kwargs: Unpack[RequestKwargs],
     ) -> types.SuccessResponse:
         """
-        Start audio playback via POST /api/audio/play.
+        Play audio through POST /api/audio/play.
 
-        Preferred payload format matches display draw-style resource
-        references (`stock_path` for shared assets or `application_name+path`
-        for user assets). For older firmware, user-assets payloads fallback to
-        legacy query params.
+        The endpoint payload may reference either an uploaded asset path or a
+        stock path. Explicit `path` and `stock_path` keyword arguments override
+        the same keys provided in `payload`. Request context such as
+        `application_name` and `session_id` is accepted through request kwargs;
+        use `api_request` for fully custom bodies.
         """
         if payload is None:
-            request_model = types.AudioPlayRequest(
-                application_name=application_name,
-                path=path,
-                stock_path=stock_path,
-            )
+            request_payload: dict[str, Any] = {}
         else:
             request_model = (
                 payload
                 if isinstance(payload, types.AudioPlayRequest)
                 else types.AudioPlayRequest.model_validate(payload)
             )
+            request_payload = request_model.model_dump(exclude_none=True)
 
+        if path is not None:
+            request_payload["path"] = path
+            request_payload.pop("stock_path", None)
+        if stock_path is not None:
+            request_payload["stock_path"] = stock_path
+            request_payload.pop("path", None)
+
+        request_model = types.AudioPlayRequest.model_validate(request_payload)
         request_payload = request_model.model_dump(exclude_none=True)
         logger.info(
-            "play_audio application_name=%s path=%s stock_path=%s",
-            request_model.application_name,
+            "audio_play application_name=%s path=%s stock_path=%s",
+            request_kwargs.get("application_name"),
             request_model.path,
             request_model.stock_path,
         )
-        try:
-            data = self._request(
-                "POST",
-                "/api/audio/play",
-                json_payload=request_payload,
-            )
-            return types.SuccessResponse.model_validate(data)
-        except exceptions.BusyBarAPIError as exc:
-            if request_model.stock_path or exc.status_code != 400:
-                raise
-            data = self._request(
-                "POST",
-                "/api/audio/play",
-                params={
-                    "application_name": request_model.application_name,
-                    "path": request_model.path,
-                },
-            )
-            return types.SuccessResponse.model_validate(data)
+        data = self._request(
+            "POST",
+            AUDIO_PLAY_PATH,
+            json_payload=request_payload,
+            **request_kwargs,
+        )
+        return types.SuccessResponse.model_validate(data)
 
-    def stop_audio(self) -> types.SuccessResponse:
-        logger.info("stop_audio")
+    def audio_stop(self) -> types.SuccessResponse:
+        """
+        Stop audio through DELETE /api/audio/play.
+
+        Uses API-like naming for callers that mirror firmware endpoints.
+        """
+        logger.info("audio_stop")
         data = self._request("DELETE", "/api/audio/play")
         return types.SuccessResponse.model_validate(data)
 
-    def stop_sound(self) -> types.SuccessResponse:
-        """
-        Alias for stop_audio.
-
-        Provided for callers that prefer "sound" naming.
-        """
-        return self.stop_audio()
-
-    def get_audio_volume(self) -> types.AudioVolumeInfo:
-        logger.info("get_audio_volume")
+    def audio_volume(self) -> types.AudioVolumeInfo:
+        logger.info("audio_volume")
         data = self._request("GET", "/api/audio/volume")
         return types.AudioVolumeInfo.model_validate(data)
 
-    def set_audio_volume(self, volume: float) -> types.SuccessResponse:
-        logger.info("set_audio_volume volume=%s", volume)
+    def audio_volume_set(self, volume: float) -> types.SuccessResponse:
+        logger.info("audio_volume_set volume=%s", volume)
         model = types.AudioVolumeUpdate(volume=volume)
         payload = model.model_dump()
         data = self._request(
@@ -105,82 +100,73 @@ class AsyncAudioMixin(AsyncClientBase):
     Async audio playback and volume control helpers.
     """
 
-    async def play_audio(
+    async def audio_play(
         self,
-        application_name: str | None = None,
-        path: str | None = None,
         *,
+        path: str | None = None,
         stock_path: str | None = None,
         payload: types.AudioPlayRequest | dict[str, Any] | None = None,
+        **request_kwargs: Unpack[RequestKwargs],
     ) -> types.SuccessResponse:
         """
-        Start audio playback via POST /api/audio/play.
+        Play audio through async POST /api/audio/play.
 
-        Preferred payload format matches display draw-style resource
-        references (`stock_path` for shared assets or `application_name+path`
-        for user assets). For older firmware, user-assets payloads fallback to
-        legacy query params.
+        The endpoint payload may reference either an uploaded asset path or a
+        stock path. Explicit `path` and `stock_path` keyword arguments override
+        the same keys provided in `payload`. Request context such as
+        `application_name` and `session_id` is accepted through request kwargs;
+        use `api_request` for fully custom bodies.
         """
         if payload is None:
-            request_model = types.AudioPlayRequest(
-                application_name=application_name,
-                path=path,
-                stock_path=stock_path,
-            )
+            request_payload: dict[str, Any] = {}
         else:
             request_model = (
                 payload
                 if isinstance(payload, types.AudioPlayRequest)
                 else types.AudioPlayRequest.model_validate(payload)
             )
+            request_payload = request_model.model_dump(exclude_none=True)
 
+        if path is not None:
+            request_payload["path"] = path
+            request_payload.pop("stock_path", None)
+        if stock_path is not None:
+            request_payload["stock_path"] = stock_path
+            request_payload.pop("path", None)
+
+        request_model = types.AudioPlayRequest.model_validate(request_payload)
         request_payload = request_model.model_dump(exclude_none=True)
         logger.info(
-            "async play_audio application_name=%s path=%s stock_path=%s",
-            request_model.application_name,
+            "async audio_play application_name=%s path=%s stock_path=%s",
+            request_kwargs.get("application_name"),
             request_model.path,
             request_model.stock_path,
         )
-        try:
-            data = await self._request(
-                "POST",
-                "/api/audio/play",
-                json_payload=request_payload,
-            )
-            return types.SuccessResponse.model_validate(data)
-        except exceptions.BusyBarAPIError as exc:
-            if request_model.stock_path or exc.status_code != 400:
-                raise
-            data = await self._request(
-                "POST",
-                "/api/audio/play",
-                params={
-                    "application_name": request_model.application_name,
-                    "path": request_model.path,
-                },
-            )
-            return types.SuccessResponse.model_validate(data)
+        data = await self._request(
+            "POST",
+            AUDIO_PLAY_PATH,
+            json_payload=request_payload,
+            **request_kwargs,
+        )
+        return types.SuccessResponse.model_validate(data)
 
-    async def stop_audio(self) -> types.SuccessResponse:
-        logger.info("async stop_audio")
+    async def audio_stop(self) -> types.SuccessResponse:
+        """
+        Stop audio through async DELETE /api/audio/play.
+
+        Uses API-like naming for callers that mirror firmware endpoints.
+        """
+        logger.info("async audio_stop")
         data = await self._request("DELETE", "/api/audio/play")
         return types.SuccessResponse.model_validate(data)
 
-    async def stop_sound(self) -> types.SuccessResponse:
-        """
-        Alias for stop_audio.
-
-        Provided for callers that prefer "sound" naming.
-        """
-        return await self.stop_audio()
-
-    async def get_audio_volume(self) -> types.AudioVolumeInfo:
-        logger.info("async get_audio_volume")
+    async def audio_volume(self) -> types.AudioVolumeInfo:
+        logger.info("async audio_volume")
         data = await self._request("GET", "/api/audio/volume")
         return types.AudioVolumeInfo.model_validate(data)
 
-    async def set_audio_volume(self, volume: float) -> types.SuccessResponse:
-        logger.info("async set_audio_volume volume=%s", volume)
+    async def audio_volume_set(self, volume: float) -> types.SuccessResponse:
+        logger.info("async audio_volume_set volume=%s", volume)
         model = types.AudioVolumeUpdate(volume=volume)
         payload = model.model_dump()
         data = await self._request(

--- a/src/busylib/client/base.py
+++ b/src/busylib/client/base.py
@@ -4,8 +4,9 @@ import asyncio
 import json
 import logging
 import time
+import uuid
 from collections.abc import AsyncIterable, Iterable
-from typing import Any, Literal
+from typing import Any, Literal, TypedDict
 
 import httpx
 from pydantic import BaseModel, ConfigDict, Field
@@ -16,12 +17,30 @@ from ..settings import settings
 JsonType = dict[str, Any] | list[Any] | str | int | float | bool | None
 
 
+class RequestKwargs(TypedDict, total=False):
+    """
+    Type low-level request context accepted by endpoint methods.
+
+    Endpoint methods own their request body. For full body control use
+    `api_request`, `prepare_request`, or `execute_prepared_request`.
+    """
+
+    params: dict[str, Any]
+    headers: dict[str, str]
+    session_id: str | None
+    application_name: str | None
+    timeout: float | httpx.Timeout | None
+
+
 DEFAULT_TIMEOUT = httpx.Timeout(10.0, connect=5.0, read=10.0, write=10.0, pool=5.0)
 DEFAULT_BACKOFF = 0.25
 LOCAL_CHECK_TIMEOUT = httpx.Timeout(1.5, connect=0.5, read=1.0, write=1.0, pool=0.5)
+SESSION_HEADER = "x-session-id"
+REQUEST_ID_HEADER = "X-Request-ID"
 
 logger = logging.getLogger(__name__)
 MAX_ERROR_EXCERPT = 256
+MAX_LOG_BODY_EXCERPT = 512
 
 
 class PreparedRequest(BaseModel):
@@ -48,6 +67,7 @@ class PreparedRequest(BaseModel):
     expect_bytes: bool
     allow_text: bool
     timeout: httpx.Timeout
+    request_id: str
     json_payload: JsonType | None = None
 
     model_config = ConfigDict(arbitrary_types_allowed=True)
@@ -59,7 +79,7 @@ def _mask_headers(headers: dict[str, str] | None) -> dict[str, str] | None:
     """
     if headers is None:
         return None
-    hidden_keys = {"authorization", "x-api-token", "cookie"}
+    hidden_keys = {"authorization", "x-api-token", "cookie", "set-cookie"}
     return {
         key: ("***" if key.lower() in hidden_keys else value)
         for key, value in headers.items()
@@ -112,12 +132,58 @@ def _truncate_text(value: str, limit: int = MAX_ERROR_EXCERPT) -> str:
     return f"{normalized[:limit]}..."
 
 
+def _get_header(headers: dict[str, str], name: str) -> str | None:
+    """
+    Return a header value using case-insensitive lookup.
+    """
+    name_lower = name.lower()
+    return next(
+        (value for key, value in headers.items() if key.lower() == name_lower),
+        None,
+    )
+
+
+def _ensure_request_id(headers: dict[str, str]) -> str:
+    """
+    Return an existing request id or add a generated one to headers.
+    """
+    request_id = _get_header(headers, REQUEST_ID_HEADER)
+    if request_id:
+        return request_id
+    request_id = uuid.uuid4().hex
+    headers[REQUEST_ID_HEADER] = request_id
+    return request_id
+
+
+def _apply_application_name(
+    method: str,
+    application_name: str | None,
+    params: dict[str, Any] | None,
+    json_payload: JsonType | None,
+) -> tuple[dict[str, Any] | None, JsonType | None]:
+    """
+    Attach application context to the request shape expected by the API.
+
+    Mutating endpoints with object JSON carry the application context in the
+    body. Read/delete and binary form endpoints keep it in query params.
+    """
+    if not application_name:
+        return params, json_payload
+    if method.upper() in {"POST", "PUT", "PATCH"} and isinstance(json_payload, dict):
+        return params, {**json_payload, "application_name": application_name}
+    params_local = dict(params or {})
+    params_local["application_name"] = application_name
+    return params_local, json_payload
+
+
 def _prepare_request_payload(
     method: str,
     path: str,
     *,
     params: dict[str, Any] | None,
     headers: dict[str, str] | None,
+    session_id: str | None,
+    application_name: str | None,
     json_payload: JsonType | None,
     data: bytes | Iterable[bytes] | AsyncIterable[bytes] | None,
     expect_bytes: bool,
@@ -128,15 +194,25 @@ def _prepare_request_payload(
     """
     Build a normalized PreparedRequest object from request parameters.
 
-    The helper centralizes payload encoding and header normalization used by
-    both sync and async clients.
+    The helper centralizes context headers, application placement, payload
+    encoding, and safe request logging for sync and async clients.
     """
     headers_local: dict[str, str] = dict(headers or {})
+    request_id = _ensure_request_id(headers_local)
+    if session_id:
+        headers_local[SESSION_HEADER] = session_id
+
+    params_local, json_payload_local = _apply_application_name(
+        method,
+        application_name,
+        params,
+        json_payload,
+    )
     content: bytes | Iterable[bytes] | AsyncIterable[bytes] | None = None
     serialized_json: bytes | None = None
 
-    if json_payload is not None:
-        serialized_json = _json_bytes(json_payload)
+    if json_payload_local is not None:
+        serialized_json = _json_bytes(json_payload_local)
         content = serialized_json
         headers_local["Content-Type"] = "application/json; charset=utf-8"
     elif data is not None:
@@ -144,30 +220,45 @@ def _prepare_request_payload(
 
     mode_label = "async " if async_mode else ""
     logger.debug(
-        "Prepared %srequest %s %s params=%s headers=%s json_body=%s data_len=%s",
+        "Prepared %srequest %s %s request_id=%s params=%s headers=%s json_body=%s data_len=%s",
         mode_label,
         method,
         path,
-        params,
+        request_id,
+        params_local,
         _mask_headers(headers_local or None),
-        None if serialized_json is None else serialized_json.decode("utf-8"),
+        None
+        if serialized_json is None
+        else _truncate_text(serialized_json.decode("utf-8"), MAX_LOG_BODY_EXCERPT),
         None if data is None else _data_length(data),
     )
 
     return PreparedRequest(
         method=method,
         path=path,
-        params=params,
+        params=params_local,
         headers=headers_local or None,
         content=content,
         expect_bytes=expect_bytes,
         allow_text=allow_text,
         timeout=_as_timeout(timeout),
-        json_payload=json_payload,
+        request_id=request_id,
+        json_payload=json_payload_local,
     )
 
 
-def _raise_api_error_from_response(response: httpx.Response, *, prepared: PreparedRequest) -> None:
+def _response_request_id(response: httpx.Response, fallback: str) -> str:
+    """
+    Return response request id or the caller-generated fallback id.
+    """
+    return response.headers.get("X-Request-ID") or response.headers.get(
+        "x-request-id", fallback
+    )
+
+
+def _raise_api_error_from_response(
+    response: httpx.Response, *, prepared: PreparedRequest
+) -> None:
     """
     Raise BusyBarAPIError built from an HTTP error response.
 
@@ -175,7 +266,7 @@ def _raise_api_error_from_response(response: httpx.Response, *, prepared: Prepar
     and async request execution paths.
     """
     payload = None
-    request_id = response.headers.get("X-Request-ID") or response.headers.get("x-request-id")
+    request_id = _response_request_id(response, prepared.request_id)
     response_excerpt = _truncate_text(response.text)
     try:
         payload = response.json()
@@ -186,12 +277,19 @@ def _raise_api_error_from_response(response: httpx.Response, *, prepared: Prepar
             error = None
             code = None
     except ValueError:
-        error = f"HTTP {response.status_code}: {response.text}"
+        error = f"HTTP {response.status_code}: {response_excerpt}"
         code = None
 
     if not error:
-        error = response.text or f"HTTP {response.status_code} error"
+        error = response_excerpt or f"HTTP {response.status_code} error"
 
+    logger.error(
+        "API error %s request_id=%s: %s (body=%s)",
+        code,
+        request_id,
+        error,
+        response_excerpt,
+    )
     raise exceptions.BusyBarAPIError(
         error=error,
         code=(code if isinstance(code, int) else response.status_code),
@@ -204,7 +302,9 @@ def _raise_api_error_from_response(response: httpx.Response, *, prepared: Prepar
     )
 
 
-def _decode_response_payload(response: httpx.Response, *, prepared: PreparedRequest) -> JsonType | bytes | str:
+def _decode_response_payload(
+    response: httpx.Response, *, prepared: PreparedRequest
+) -> JsonType | bytes | str:
     """
     Decode successful HTTP response according to PreparedRequest flags.
 
@@ -235,7 +335,7 @@ def _decode_response_payload(response: httpx.Response, *, prepared: PreparedRequ
                 "Expected JSON response body",
                 method=prepared.method,
                 path=prepared.path,
-                request_id=(response.headers.get("X-Request-ID") or response.headers.get("x-request-id")),
+                request_id=_response_request_id(response, prepared.request_id),
                 response_excerpt=_truncate_text(response.text),
             )
         logger.debug(
@@ -335,7 +435,7 @@ class SyncClientBase:
             return False
         return response.status_code < 400
 
-    def __enter__(self) -> "SyncClientBase":
+    def __enter__(self) -> SyncClientBase:
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb) -> None:
@@ -344,6 +444,41 @@ class SyncClientBase:
     def close(self) -> None:
         self.client.close()
 
+    def api_request(
+        self,
+        method: str,
+        path: str,
+        *,
+        params: dict[str, Any] | None = None,
+        headers: dict[str, str] | None = None,
+        session_id: str | None = None,
+        application_name: str | None = None,
+        json_payload: JsonType | None = None,
+        data: bytes | Iterable[bytes] | None = None,
+        expect_bytes: bool = False,
+        allow_text: bool = False,
+        timeout: float | httpx.Timeout | None = None,
+    ) -> JsonType | bytes | str:
+        """
+        Execute a raw API request through the current client session.
+
+        Advanced callers can control path, params, headers, body, and request
+        context without creating a separate HTTP client.
+        """
+        return self._request(
+            method,
+            path,
+            params=params,
+            headers=headers,
+            session_id=session_id,
+            application_name=application_name,
+            json_payload=json_payload,
+            data=data,
+            expect_bytes=expect_bytes,
+            allow_text=allow_text,
+            timeout=timeout,
+        )
+
     def _request(
         self,
         method: str,
@@ -351,6 +486,8 @@ class SyncClientBase:
         *,
         params: dict[str, Any] | None = None,
         headers: dict[str, str] | None = None,
+        session_id: str | None = None,
+        application_name: str | None = None,
         json_payload: JsonType | None = None,
         data: bytes | Iterable[bytes] | None = None,
         expect_bytes: bool = False,
@@ -368,6 +505,8 @@ class SyncClientBase:
             path,
             params=params,
             headers=headers,
+            session_id=session_id,
+            application_name=application_name,
             json_payload=json_payload,
             data=data,
             expect_bytes=expect_bytes,
@@ -383,6 +522,8 @@ class SyncClientBase:
         *,
         params: dict[str, Any] | None = None,
         headers: dict[str, str] | None = None,
+        session_id: str | None = None,
+        application_name: str | None = None,
         json_payload: JsonType | None = None,
         data: bytes | Iterable[bytes] | None = None,
         expect_bytes: bool = False,
@@ -400,6 +541,8 @@ class SyncClientBase:
             path,
             params=params,
             headers=headers,
+            session_id=session_id,
+            application_name=application_name,
             json_payload=json_payload,
             data=data,
             expect_bytes=expect_bytes,
@@ -418,9 +561,8 @@ class SyncClientBase:
         Execute a previously prepared request.
 
         By default the current `httpx.Client` is used. Callers may inject a
-        custom client (for example, from a pool) while preserving error mapping.
-        Prepared streaming content is single-use and should be regenerated for
-        repeated executions.
+        custom client while preserving error mapping. Prepared streaming content
+        is single-use and should be regenerated for repeated executions.
         """
         request_client = client or self.client
         last_exc: Exception | None = None
@@ -441,6 +583,7 @@ class SyncClientBase:
                         str(exc),
                         method=prepared.method,
                         path=prepared.path,
+                        request_id=prepared.request_id,
                         attempts=attempt + 1,
                         original=exc,
                     ) from exc
@@ -456,6 +599,7 @@ class SyncClientBase:
                 str(last_exc),
                 method=prepared.method,
                 path=prepared.path,
+                request_id=prepared.request_id,
                 attempts=self.max_retries + 1,
                 original=last_exc,
             ) from last_exc
@@ -463,6 +607,7 @@ class SyncClientBase:
             "Unknown request error",
             method=prepared.method,
             path=prepared.path,
+            request_id=prepared.request_id,
             attempts=self.max_retries + 1,
         )
 
@@ -555,7 +700,7 @@ class AsyncClientBase:
             return False
         return response.status_code < 400
 
-    async def __aenter__(self) -> "AsyncClientBase":
+    async def __aenter__(self) -> AsyncClientBase:
         return self
 
     async def __aexit__(self, exc_type, exc_val, exc_tb) -> None:
@@ -564,6 +709,41 @@ class AsyncClientBase:
     async def aclose(self) -> None:
         await self.client.aclose()
 
+    async def api_request(
+        self,
+        method: str,
+        path: str,
+        *,
+        params: dict[str, Any] | None = None,
+        headers: dict[str, str] | None = None,
+        session_id: str | None = None,
+        application_name: str | None = None,
+        json_payload: JsonType | None = None,
+        data: bytes | AsyncIterable[bytes] | None = None,
+        expect_bytes: bool = False,
+        allow_text: bool = False,
+        timeout: float | httpx.Timeout | None = None,
+    ) -> JsonType | bytes | str:
+        """
+        Execute a raw async API request through the current client session.
+
+        Advanced callers can control path, params, headers, body, and request
+        context without creating a separate HTTP client.
+        """
+        return await self._request(
+            method,
+            path,
+            params=params,
+            headers=headers,
+            session_id=session_id,
+            application_name=application_name,
+            json_payload=json_payload,
+            data=data,
+            expect_bytes=expect_bytes,
+            allow_text=allow_text,
+            timeout=timeout,
+        )
+
     async def _request(
         self,
         method: str,
@@ -571,6 +751,8 @@ class AsyncClientBase:
         *,
         params: dict[str, Any] | None = None,
         headers: dict[str, str] | None = None,
+        session_id: str | None = None,
+        application_name: str | None = None,
         json_payload: JsonType | None = None,
         data: bytes | AsyncIterable[bytes] | None = None,
         expect_bytes: bool = False,
@@ -588,6 +770,8 @@ class AsyncClientBase:
             path,
             params=params,
             headers=headers,
+            session_id=session_id,
+            application_name=application_name,
             json_payload=json_payload,
             data=data,
             expect_bytes=expect_bytes,
@@ -603,6 +787,8 @@ class AsyncClientBase:
         *,
         params: dict[str, Any] | None = None,
         headers: dict[str, str] | None = None,
+        session_id: str | None = None,
+        application_name: str | None = None,
         json_payload: JsonType | None = None,
         data: bytes | AsyncIterable[bytes] | None = None,
         expect_bytes: bool = False,
@@ -621,6 +807,8 @@ class AsyncClientBase:
             path,
             params=params,
             headers=headers,
+            session_id=session_id,
+            application_name=application_name,
             json_payload=json_payload,
             data=data,
             expect_bytes=expect_bytes,
@@ -639,9 +827,8 @@ class AsyncClientBase:
         Execute a previously prepared async request.
 
         By default the current `httpx.AsyncClient` is used. Callers may inject
-        a custom client (for example, from a pool) while preserving error
-        mapping. Prepared streaming content is single-use and should be
-        regenerated for repeated executions.
+        a custom client while preserving error mapping. Prepared streaming
+        content is single-use and should be regenerated for repeated executions.
         """
         request_client = client or self.client
         last_exc: Exception | None = None
@@ -662,6 +849,7 @@ class AsyncClientBase:
                         str(exc),
                         method=prepared.method,
                         path=prepared.path,
+                        request_id=prepared.request_id,
                         attempts=attempt + 1,
                         original=exc,
                     ) from exc
@@ -677,6 +865,7 @@ class AsyncClientBase:
                 str(last_exc),
                 method=prepared.method,
                 path=prepared.path,
+                request_id=prepared.request_id,
                 attempts=self.max_retries + 1,
                 original=last_exc,
             ) from last_exc
@@ -684,5 +873,6 @@ class AsyncClientBase:
             "Unknown request error",
             method=prepared.method,
             path=prepared.path,
+            request_id=prepared.request_id,
             attempts=self.max_retries + 1,
         )

--- a/src/busylib/client/ble.py
+++ b/src/busylib/client/ble.py
@@ -28,8 +28,8 @@ class BleMixin(SyncClientBase):
         data = self._request("GET", "/api/ble/status")
         return types.BleStatus.model_validate(data)
 
-    def ble_forget_pairing(self) -> types.SuccessResponse:
-        logger.info("ble_forget_pairing")
+    def ble_pairing_forget(self) -> types.SuccessResponse:
+        logger.info("ble_pairing_forget")
         data = self._request("DELETE", "/api/ble/pairing")
         return types.SuccessResponse.model_validate(data)
 
@@ -54,7 +54,7 @@ class AsyncBleMixin(AsyncClientBase):
         data = await self._request("GET", "/api/ble/status")
         return types.BleStatus.model_validate(data)
 
-    async def ble_forget_pairing(self) -> types.SuccessResponse:
-        logger.info("async ble_forget_pairing")
+    async def ble_pairing_forget(self) -> types.SuccessResponse:
+        logger.info("async ble_pairing_forget")
         data = await self._request("DELETE", "/api/ble/pairing")
         return types.SuccessResponse.model_validate(data)

--- a/src/busylib/client/busy.py
+++ b/src/busylib/client/busy.py
@@ -13,19 +13,19 @@ class BusyMixin(SyncClientBase):
     Busy snapshot helpers.
     """
 
-    def get_busy_snapshot(self) -> types.BusySnapshot:
+    def busy_snapshot(self) -> types.BusySnapshot:
         """
         Fetch busy snapshot via GET /api/busy/snapshot.
         """
-        logger.info("get_busy_snapshot")
+        logger.info("busy_snapshot")
         data = self._request("GET", "/api/busy/snapshot")
         return types.BusySnapshot.model_validate(data)
 
-    def set_busy_snapshot(self, snapshot: types.BusySnapshot) -> types.SuccessResponse:
+    def busy_snapshot_set(self, snapshot: types.BusySnapshot) -> types.SuccessResponse:
         """
         Set busy snapshot via PUT /api/busy/snapshot.
         """
-        logger.info("set_busy_snapshot")
+        logger.info("busy_snapshot_set")
         payload = snapshot.model_dump(mode="json")
         data = self._request(
             "PUT",
@@ -40,21 +40,21 @@ class AsyncBusyMixin(AsyncClientBase):
     Async busy snapshot helpers.
     """
 
-    async def get_busy_snapshot(self) -> types.BusySnapshot:
+    async def busy_snapshot(self) -> types.BusySnapshot:
         """
         Fetch busy snapshot via GET /api/busy/snapshot.
         """
-        logger.info("async get_busy_snapshot")
+        logger.info("async busy_snapshot")
         data = await self._request("GET", "/api/busy/snapshot")
         return types.BusySnapshot.model_validate(data)
 
-    async def set_busy_snapshot(
+    async def busy_snapshot_set(
         self, snapshot: types.BusySnapshot
     ) -> types.SuccessResponse:
         """
         Set busy snapshot via PUT /api/busy/snapshot.
         """
-        logger.info("async set_busy_snapshot")
+        logger.info("async busy_snapshot_set")
         payload = snapshot.model_dump(mode="json")
         data = await self._request(
             "PUT",

--- a/src/busylib/client/display.py
+++ b/src/busylib/client/display.py
@@ -2,18 +2,28 @@ from __future__ import annotations
 
 import json
 import logging
+import re
 from typing import Any, AsyncIterator
 from urllib.parse import quote, urlparse, urlunparse
 
 import websockets
+from typing_extensions import Unpack
 
 from .. import display, exceptions, types
-from .base import AsyncClientBase, SyncClientBase
+from .base import AsyncClientBase, RequestKwargs, SyncClientBase
 
 logger = logging.getLogger(__name__)
 _WS_MAX_SIZE = 4 * 1024 * 1024
 _WS_PING_INTERVAL_SECONDS = 20
 _WS_PING_TIMEOUT_SECONDS = 20
+
+DISPLAY_DRAW_PATH = "/api/display/draw"
+_EMOJI_AND_SYMBOLS_PATTERN = re.compile(
+    "[\U0001f300-\U0001faff\u2600-\u27bf\u200d\ufe0f]",
+)
+_CONTROL_PATTERN = re.compile(r"[\x00-\x1F\x7F]")
+_WHITESPACE_PATTERN = re.compile(r"\s+")
+_SANITIZE_LOG_TEXT_LIMIT = 80
 
 
 def _http_to_ws(addr: str) -> str:
@@ -85,10 +95,45 @@ def _decode_frame_bytes(data: bytes, display_id: int, *, from_ws: bool) -> bytes
     return None
 
 
-def _ws_auth_headers(
-    base_url: str, client_headers: dict[str, str] | None
-) -> dict[str, str]:
-    return dict(client_headers) if client_headers else {}
+def _sanitize_text_value(value: str) -> str:
+    """
+    Sanitize display text for firmware-safe rendering.
+    """
+    without_emoji = _EMOJI_AND_SYMBOLS_PATTERN.sub("", value)
+    without_controls = _CONTROL_PATTERN.sub("", without_emoji)
+    return _WHITESPACE_PATTERN.sub(" ", without_controls).strip()
+
+
+def _truncate_log_text(value: str) -> str:
+    """
+    Shorten sanitized text samples for compact warning logs.
+    """
+    if len(value) <= _SANITIZE_LOG_TEXT_LIMIT:
+        return value
+    return f"{value[:_SANITIZE_LOG_TEXT_LIMIT]}..."
+
+
+def _sanitize_display_payload_text(payload: dict[str, Any]) -> None:
+    """
+    Sanitize text elements in-place and log each changed element.
+    """
+    for element in payload.get("elements", []):
+        if not isinstance(element, dict):
+            continue
+        if element.get("type") != "text":
+            continue
+        text = element.get("text")
+        if isinstance(text, str):
+            sanitized = _sanitize_text_value(text)
+            if sanitized != text:
+                logger.warning(
+                    "Sanitized display text element_id=%s display=%s text_before=%r text_after=%r",
+                    element.get("id", "?"),
+                    element.get("display", types.DisplayName.FRONT.value),
+                    _truncate_log_text(text),
+                    _truncate_log_text(sanitized),
+                )
+            element["text"] = sanitized
 
 
 class DisplayMixin(SyncClientBase):
@@ -96,29 +141,87 @@ class DisplayMixin(SyncClientBase):
     Display drawing, brightness control, and screen capture helpers.
     """
 
-    def draw_on_display(
+    def display_draw(
         self,
         display_data: types.DisplayElements | dict[str, Any],
+        *,
+        clear_before_draw: bool = False,
+        sanitize_text: bool = False,
+        **request_kwargs: Unpack[RequestKwargs],
     ) -> types.SuccessResponse:
         logger.info(
-            "draw_on_display application_name=%s",
+            "display_draw application_name=%s clear_before_draw=%s",
             display_data.application_name
             if isinstance(display_data, types.DisplayElements)
-            else display_data.get("application_name", display_data.get("app_id")),
+            else display_data.get("application_name"),
+            clear_before_draw,
         )
         model = (
             display_data
             if isinstance(display_data, types.DisplayElements)
             else types.DisplayElements.model_validate(display_data)
         )
+        override_name = request_kwargs.get("application_name")
+        if override_name and override_name != model.application_name:
+            logger.warning(
+                "display_draw application_name override payload=%s request=%s",
+                model.application_name,
+                override_name,
+            )
+        if clear_before_draw:
+            clear_request_kwargs = {
+                "application_name": model.application_name,
+                **request_kwargs,
+            }
+            self.display_clear(**clear_request_kwargs)
         payload = model.model_dump(exclude_none=True)
+        if sanitize_text:
+            _sanitize_display_payload_text(payload)
         self._warn_if_out_of_bounds(payload["elements"])
         data = self._request(
             "POST",
-            "/api/display/draw",
+            DISPLAY_DRAW_PATH,
             json_payload=payload,
+            **request_kwargs,
         )
         return types.SuccessResponse.model_validate(data)
+
+    def display(
+        self,
+        display_data: types.DisplayElements | dict[str, Any],
+        *,
+        clear_before_draw: bool = False,
+        sanitize_text: bool = False,
+        audio_payload: types.AudioPlayRequest | dict[str, Any] | None = None,
+        **request_kwargs: Unpack[RequestKwargs],
+    ) -> types.SuccessResponse:
+        """
+        Render display content and optionally play audio after draw.
+
+        Operations are sequential, not atomic: clear may succeed before draw
+        fails, and audio failure may occur after display content is visible.
+        Exceptions include the failed endpoint path for diagnostics.
+        """
+        model = (
+            display_data
+            if isinstance(display_data, types.DisplayElements)
+            else types.DisplayElements.model_validate(display_data)
+        )
+        response = self.display_draw(
+            model,
+            clear_before_draw=clear_before_draw,
+            sanitize_text=sanitize_text,
+            **request_kwargs,
+        )
+        if audio_payload:
+            audio_play = getattr(self, "audio_play", None)
+            if audio_play is None:
+                raise TypeError("display audio_payload requires AudioMixin.audio_play")
+            audio_play(
+                payload=audio_payload,
+                **request_kwargs,
+            )
+        return response
 
     def _warn_if_out_of_bounds(self, elements: list[dict[str, Any]]) -> None:
         for element in elements:
@@ -152,25 +255,36 @@ class DisplayMixin(SyncClientBase):
                     spec.width,
                 )
 
-    def clear_display(
+    def display_clear(
         self,
-        application_name: str | None = None,
+        **request_kwargs: Unpack[RequestKwargs],
     ) -> types.SuccessResponse:
-        logger.info("clear_display application_name=%s", application_name)
-        params = {"application_name": application_name} if application_name else None
-        data = self._request("DELETE", "/api/display/draw", params=params)
+        """
+        Clear display content through DELETE /api/display/draw.
+
+        Uses API-like naming for callers that mirror firmware endpoints.
+        """
+        logger.info(
+            "display_clear application_name=%s",
+            request_kwargs.get("application_name"),
+        )
+        data = self._request(
+            "DELETE",
+            DISPLAY_DRAW_PATH,
+            **request_kwargs,
+        )
         return types.SuccessResponse.model_validate(data)
 
-    def get_display_brightness(self) -> types.DisplayBrightnessInfo:
-        logger.info("get_display_brightness")
+    def display_brightness(self) -> types.DisplayBrightnessInfo:
+        logger.info("display_brightness")
         data = self._request("GET", "/api/display/brightness")
         return types.DisplayBrightnessInfo.model_validate(data)
 
-    def set_display_brightness(
+    def display_brightness_set(
         self,
         value: types.BrightnessValue,
     ) -> types.SuccessResponse:
-        logger.info("set_display_brightness value=%s", value)
+        logger.info("display_brightness_set value=%s", value)
         model = types.DisplayBrightnessUpdate(value=value)
         payload = model.model_dump(exclude_none=True)
         data = self._request(
@@ -180,42 +294,34 @@ class DisplayMixin(SyncClientBase):
         )
         return types.SuccessResponse.model_validate(data)
 
-    def get_screen_frame(self, display_id: int) -> bytes:
+    def screen(self, display_id: int) -> bytes:
         """
         Fetch a single display frame via GET /api/screen.
 
         The handler returns raw framebuffer bytes without compression. Client
         must pass `display` query param: 0 for front (RGB, 24 bpp, 72x16 =>
-        3456 bytes) or 1 for back (L4 grayscale, 160x80 => 6400 bytes). Server
-        replies 200 with `image/bmp` content type or 400 when the display index
-        is invalid. Response is decoded to RGB bytes when possible.
+        3456 bytes) or 1 for back (L4 grayscale, 160x80 => 6400 bytes).
         """
-        logger.info("get_screen_frame display=%s", display_id)
+        logger.info("screen display=%s", display_id)
         target = display.get_display_spec(display_id)
         raw = self._request(
             "GET",
             "/api/screen",
             params={"display": target.index},
             expect_bytes=True,
-        )  # type: ignore[return-value]
+        )
         if not isinstance(raw, (bytes, bytearray)):
             raise TypeError("Expected bytes response for screen frame")
         data = bytes(raw)
         decoded = _decode_frame_bytes(data, target.index, from_ws=False)
         return decoded if decoded is not None else data
 
-    def stream_screen_ws(self, display_id: int) -> None:
+    def screen_ws(self, display_id: int) -> None:
         """
         WebSocket streaming via GET /api/screen/ws.
 
-        Server upgrades HTTP to WebSocket; client must send `{"display": 0|1}`
-        JSON to select front/back. Server streams binary frames compressed with
-        RLE: front encodes runs of 3-byte BGR pixels (source 72x16x24bpp =>
-        3456 bytes before compression); back encodes runs of 1-byte L4 values
-        (source 160x80 L4 => 6400 bytes before compression). Frame sizes vary.
-        Up to 4 clients supported; otherwise 400 Exceed max clients count.
-        Heartbeat: server pings, client must respond with pong. Not implemented
-        in this sync client; use busylib.screen CLI or a WebSocket client.
+        Server upgrades HTTP to WebSocket. This sync client intentionally does
+        not implement streaming; use the async client for WebSocket frames.
         """
         raise NotImplementedError(
             "WebSocket streaming is implemented only for async client."
@@ -227,29 +333,89 @@ class AsyncDisplayMixin(AsyncClientBase):
     Async display drawing, brightness control, and screen capture helpers.
     """
 
-    async def draw_on_display(
+    async def display_draw(
         self,
         display_data: types.DisplayElements | dict[str, Any],
+        *,
+        clear_before_draw: bool = False,
+        sanitize_text: bool = False,
+        **request_kwargs: Unpack[RequestKwargs],
     ) -> types.SuccessResponse:
         logger.info(
-            "async draw_on_display application_name=%s",
+            "async display_draw application_name=%s clear_before_draw=%s",
             display_data.application_name
             if isinstance(display_data, types.DisplayElements)
-            else display_data.get("application_name", display_data.get("app_id")),
+            else display_data.get("application_name"),
+            clear_before_draw,
         )
         model = (
             display_data
             if isinstance(display_data, types.DisplayElements)
             else types.DisplayElements.model_validate(display_data)
         )
+        override_name = request_kwargs.get("application_name")
+        if override_name and override_name != model.application_name:
+            logger.warning(
+                "async display_draw application_name override payload=%s request=%s",
+                model.application_name,
+                override_name,
+            )
+        if clear_before_draw:
+            clear_request_kwargs = {
+                "application_name": model.application_name,
+                **request_kwargs,
+            }
+            await self.display_clear(**clear_request_kwargs)
         payload = model.model_dump(exclude_none=True)
+        if sanitize_text:
+            _sanitize_display_payload_text(payload)
         self._warn_if_out_of_bounds(payload["elements"])
         data = await self._request(
             "POST",
-            "/api/display/draw",
+            DISPLAY_DRAW_PATH,
             json_payload=payload,
+            **request_kwargs,
         )
         return types.SuccessResponse.model_validate(data)
+
+    async def display(
+        self,
+        display_data: types.DisplayElements | dict[str, Any],
+        *,
+        clear_before_draw: bool = False,
+        sanitize_text: bool = False,
+        audio_payload: types.AudioPlayRequest | dict[str, Any] | None = None,
+        **request_kwargs: Unpack[RequestKwargs],
+    ) -> types.SuccessResponse:
+        """
+        Render display content and optionally play audio after draw.
+
+        Operations are sequential, not atomic: clear may succeed before draw
+        fails, and audio failure may occur after display content is visible.
+        Exceptions include the failed endpoint path for diagnostics.
+        """
+        model = (
+            display_data
+            if isinstance(display_data, types.DisplayElements)
+            else types.DisplayElements.model_validate(display_data)
+        )
+        response = await self.display_draw(
+            model,
+            clear_before_draw=clear_before_draw,
+            sanitize_text=sanitize_text,
+            **request_kwargs,
+        )
+        if audio_payload:
+            audio_play = getattr(self, "audio_play", None)
+            if audio_play is None:
+                raise TypeError(
+                    "display audio_payload requires AsyncAudioMixin.audio_play"
+                )
+            await audio_play(
+                payload=audio_payload,
+                **request_kwargs,
+            )
+        return response
 
     def _warn_if_out_of_bounds(self, elements: list[dict[str, Any]]) -> None:
         for element in elements:
@@ -283,25 +449,36 @@ class AsyncDisplayMixin(AsyncClientBase):
                     spec.width,
                 )
 
-    async def clear_display(
+    async def display_clear(
         self,
-        application_name: str | None = None,
+        **request_kwargs: Unpack[RequestKwargs],
     ) -> types.SuccessResponse:
-        logger.info("async clear_display application_name=%s", application_name)
-        params = {"application_name": application_name} if application_name else None
-        data = await self._request("DELETE", "/api/display/draw", params=params)
+        """
+        Clear display content through async DELETE /api/display/draw.
+
+        Uses API-like naming for callers that mirror firmware endpoints.
+        """
+        logger.info(
+            "async display_clear application_name=%s",
+            request_kwargs.get("application_name"),
+        )
+        data = await self._request(
+            "DELETE",
+            DISPLAY_DRAW_PATH,
+            **request_kwargs,
+        )
         return types.SuccessResponse.model_validate(data)
 
-    async def get_display_brightness(self) -> types.DisplayBrightnessInfo:
-        logger.info("async get_display_brightness")
+    async def display_brightness(self) -> types.DisplayBrightnessInfo:
+        logger.info("async display_brightness")
         data = await self._request("GET", "/api/display/brightness")
         return types.DisplayBrightnessInfo.model_validate(data)
 
-    async def set_display_brightness(
+    async def display_brightness_set(
         self,
         value: types.BrightnessValue,
     ) -> types.SuccessResponse:
-        logger.info("async set_display_brightness value=%s", value)
+        logger.info("async display_brightness_set value=%s", value)
         model = types.DisplayBrightnessUpdate(value=value)
         payload = model.model_dump(exclude_none=True)
         data = await self._request(
@@ -311,33 +488,31 @@ class AsyncDisplayMixin(AsyncClientBase):
         )
         return types.SuccessResponse.model_validate(data)
 
-    async def get_screen_frame(self, display_id: int) -> bytes:
+    async def screen(self, display_id: int) -> bytes:
         """
         Fetch a single display frame via GET /api/screen.
 
         The handler returns raw framebuffer bytes without compression. Client
         must pass `display` query param: 0 for front (RGB, 24 bpp, 72x16 =>
-        3456 bytes) or 1 for back (L4 grayscale, 160x80 => 6400 bytes). Server
-        replies 200 with `image/bmp` content type or 400 when the display index
-        is invalid. Response is decoded to RGB bytes when possible.
+        3456 bytes) or 1 for back (L4 grayscale, 160x80 => 6400 bytes).
         """
-        logger.info("async get_screen_frame display=%s", display_id)
+        logger.info("async screen display=%s", display_id)
         target = display.get_display_spec(display_id)
         raw = await self._request(
             "GET",
             "/api/screen",
             params={"display": target.index},
             expect_bytes=True,
-        )  # type: ignore[return-value]
+        )
         if not isinstance(raw, (bytes, bytearray)):
             raise TypeError("Expected bytes response for screen frame")
         data = bytes(raw)
         decoded = _decode_frame_bytes(data, target.index, from_ws=False)
         return decoded if decoded is not None else data
 
-    async def stream_screen_ws(self, display_id: int) -> AsyncIterator[bytes | str]:
+    async def screen_ws(self, display_id: int) -> AsyncIterator[bytes | str]:
         """
-        WebSocket streaming via GET /api/screen/ws.
+        Stream display frames via GET /api/screen/ws.
 
         Yields bytes for image frames and strings for server messages.
         """
@@ -381,13 +556,3 @@ class AsyncDisplayMixin(AsyncClientBase):
                 path="/api/screen/ws",
                 original=exc,
             ) from exc
-
-    def _ws_headers(self, headers: dict[str, str]) -> dict[str, str]:
-        """
-        Build a minimal header set for WebSocket upgrades.
-
-        This intentionally returns no extra headers to match the debug client.
-        """
-        allowed_headers: set[str] = set()
-
-        return {k: v for k, v in headers.items() if k.lower() in allowed_headers}

--- a/src/busylib/client/firmware.py
+++ b/src/busylib/client/firmware.py
@@ -13,8 +13,8 @@ class FirmwareMixin(SyncClientBase):
     Version and system status methods.
     """
 
-    def get_version(self) -> types.VersionInfo:
-        logger.info("get_version")
+    def version(self) -> types.VersionInfo:
+        logger.info("version")
         data = self._request("GET", "/api/version")
         version_info = types.VersionInfo.model_validate(data)
         if version_info.api_semver:
@@ -25,34 +25,34 @@ class FirmwareMixin(SyncClientBase):
             )
         return version_info
 
-    def get_status(self) -> types.Status:
-        logger.info("get_status")
+    def status(self) -> types.Status:
+        logger.info("status")
         data = self._request("GET", "/api/status")
         return types.Status.model_validate(data)
 
-    def get_system_status(self) -> types.StatusSystem:
-        logger.info("get_system_status")
+    def status_system(self) -> types.StatusSystem:
+        logger.info("status_system")
         data = self._request("GET", "/api/status/system")
         return types.StatusSystem.model_validate(data)
 
-    def get_power_status(self) -> types.StatusPower:
-        logger.info("get_power_status")
+    def status_power(self) -> types.StatusPower:
+        logger.info("status_power")
         data = self._request("GET", "/api/status/power")
         return types.StatusPower.model_validate(data)
 
-    def get_device_name(self) -> types.DeviceNameResponse:
+    def name(self) -> types.DeviceNameResponse:
         """
         Fetch device name via GET /api/name.
         """
-        logger.info("get_device_name")
+        logger.info("name")
         data = self._request("GET", "/api/name")
         return types.DeviceNameResponse.model_validate(data)
 
-    def set_device_name(self, name: str) -> types.SuccessResponse:
+    def name_set(self, name: str) -> types.SuccessResponse:
         """
         Set device name via POST /api/name.
         """
-        logger.info("set_device_name")
+        logger.info("name_set")
         payload = types.DeviceNameUpdate(name=name).model_dump()
         data = self._request(
             "POST",
@@ -61,11 +61,11 @@ class FirmwareMixin(SyncClientBase):
         )
         return types.SuccessResponse.model_validate(data)
 
-    def get_device_time(self) -> types.DeviceTimeResponse:
+    def time(self) -> types.DeviceTimeResponse:
         """
         Fetch device time via GET /api/time.
         """
-        logger.info("get_device_time")
+        logger.info("time")
         data = self._request("GET", "/api/time")
         return types.DeviceTimeResponse.model_validate(data)
 
@@ -75,8 +75,8 @@ class AsyncFirmwareMixin(AsyncClientBase):
     Async variant of version and system status methods.
     """
 
-    async def get_version(self) -> types.VersionInfo:
-        logger.info("async get_version")
+    async def version(self) -> types.VersionInfo:
+        logger.info("async version")
         data = await self._request("GET", "/api/version")
         version_info = types.VersionInfo.model_validate(data)
         if version_info.api_semver:
@@ -87,34 +87,34 @@ class AsyncFirmwareMixin(AsyncClientBase):
             )
         return version_info
 
-    async def get_status(self) -> types.Status:
-        logger.info("async get_status")
+    async def status(self) -> types.Status:
+        logger.info("async status")
         data = await self._request("GET", "/api/status")
         return types.Status.model_validate(data)
 
-    async def get_system_status(self) -> types.StatusSystem:
-        logger.info("async get_system_status")
+    async def status_system(self) -> types.StatusSystem:
+        logger.info("async status_system")
         data = await self._request("GET", "/api/status/system")
         return types.StatusSystem.model_validate(data)
 
-    async def get_power_status(self) -> types.StatusPower:
-        logger.info("async get_power_status")
+    async def status_power(self) -> types.StatusPower:
+        logger.info("async status_power")
         data = await self._request("GET", "/api/status/power")
         return types.StatusPower.model_validate(data)
 
-    async def get_device_name(self) -> types.DeviceNameResponse:
+    async def name(self) -> types.DeviceNameResponse:
         """
         Fetch device name via GET /api/name.
         """
-        logger.info("async get_device_name")
+        logger.info("async name")
         data = await self._request("GET", "/api/name")
         return types.DeviceNameResponse.model_validate(data)
 
-    async def set_device_name(self, name: str) -> types.SuccessResponse:
+    async def name_set(self, name: str) -> types.SuccessResponse:
         """
         Set device name via POST /api/name.
         """
-        logger.info("async set_device_name")
+        logger.info("async name_set")
         payload = types.DeviceNameUpdate(name=name).model_dump()
         data = await self._request(
             "POST",
@@ -123,10 +123,10 @@ class AsyncFirmwareMixin(AsyncClientBase):
         )
         return types.SuccessResponse.model_validate(data)
 
-    async def get_device_time(self) -> types.DeviceTimeResponse:
+    async def time(self) -> types.DeviceTimeResponse:
         """
         Fetch device time via GET /api/time.
         """
-        logger.info("async get_device_time")
+        logger.info("async time")
         data = await self._request("GET", "/api/time")
         return types.DeviceTimeResponse.model_validate(data)

--- a/src/busylib/client/input.py
+++ b/src/busylib/client/input.py
@@ -13,8 +13,8 @@ class InputMixin(SyncClientBase):
     Input key events.
     """
 
-    def send_input_key(self, key: types.InputKey) -> types.SuccessResponse:
-        logger.info("send_input_key key=%s", key.value)
+    def input(self, key: types.InputKey) -> types.SuccessResponse:
+        logger.info("input key=%s", key.value)
         data = self._request(
             "POST",
             "/api/input",
@@ -28,8 +28,8 @@ class AsyncInputMixin(AsyncClientBase):
     Async input key events.
     """
 
-    async def send_input_key(self, key: types.InputKey) -> types.SuccessResponse:
-        logger.info("async send_input_key key=%s", key.value)
+    async def input(self, key: types.InputKey) -> types.SuccessResponse:
+        logger.info("async input key=%s", key.value)
         data = await self._request(
             "POST",
             "/api/input",

--- a/src/busylib/client/state_stream.py
+++ b/src/busylib/client/state_stream.py
@@ -2,7 +2,8 @@ from __future__ import annotations
 
 import json
 import logging
-from typing import Any, AsyncIterator
+from collections.abc import Mapping
+from typing import Any, AsyncIterator, cast
 from urllib.parse import quote, urlparse, urlunparse
 
 from google.protobuf.json_format import MessageToDict
@@ -30,7 +31,7 @@ def _http_to_ws(addr: str) -> str:
     return urlunparse(parsed._replace(scheme=scheme))
 
 
-def _extract_token(headers: dict[str, str]) -> str | None:
+def _extract_token(headers: Mapping[str, str]) -> str | None:
     """
     Extract API token from configured HTTP headers.
 
@@ -114,7 +115,8 @@ class AsyncStateStreamMixin(AsyncClientBase):
                         continue
 
                     try:
-                        state_message = state_pb2.State()
+                        state_schema = cast(Any, state_pb2)
+                        state_message = state_schema.State()
                         state_message.ParseFromString(message)
                         yield MessageToDict(
                             state_message,

--- a/src/busylib/client/storage.py
+++ b/src/busylib/client/storage.py
@@ -16,7 +16,7 @@ class StorageMixin(SyncClientBase):
     File storage helpers for reading, writing, listing, and removing.
     """
 
-    def write_storage_file(
+    def storage_write(
         self,
         path: str,
         data: bytes,
@@ -27,7 +27,7 @@ class StorageMixin(SyncClientBase):
     ) -> types.SuccessResponse:
         new_path, payload = convert_for_storage(path, data)
         total = len(payload)
-        logger.info("write_storage_file path=%s size=%s", new_path, total)
+        logger.info("storage_write path=%s size=%s", new_path, total)
 
         def _iter_payload() -> Iterator[bytes]:
             sent = 0
@@ -48,8 +48,8 @@ class StorageMixin(SyncClientBase):
         )
         return types.SuccessResponse.model_validate(response)
 
-    def read_storage_file(self, path: str) -> bytes:
-        logger.info("read_storage_file path=%s", path)
+    def storage_read(self, path: str) -> bytes:
+        logger.info("storage_read path=%s", path)
         return self._request(
             "GET",
             "/api/storage/read",
@@ -57,8 +57,8 @@ class StorageMixin(SyncClientBase):
             expect_bytes=True,
         )  # type: ignore[return-value]
 
-    def list_storage_files(self, path: str) -> types.StorageList:
-        logger.info("list_storage_files path=%s", path)
+    def storage_list(self, path: str) -> types.StorageList:
+        logger.info("storage_list path=%s", path)
         data = self._request(
             "GET",
             "/api/storage/list",
@@ -66,8 +66,8 @@ class StorageMixin(SyncClientBase):
         )
         return types.StorageList.model_validate(data)
 
-    def remove_storage_file(self, path: str) -> types.SuccessResponse:
-        logger.info("remove_storage_file path=%s", path)
+    def storage_remove(self, path: str) -> types.SuccessResponse:
+        logger.info("storage_remove path=%s", path)
         data = self._request(
             "DELETE",
             "/api/storage/remove",
@@ -75,8 +75,8 @@ class StorageMixin(SyncClientBase):
         )
         return types.SuccessResponse.model_validate(data)
 
-    def create_storage_directory(self, path: str) -> types.SuccessResponse:
-        logger.info("create_storage_directory path=%s", path)
+    def storage_mkdir(self, path: str) -> types.SuccessResponse:
+        logger.info("storage_mkdir path=%s", path)
         data = self._request(
             "POST",
             "/api/storage/mkdir",
@@ -84,8 +84,8 @@ class StorageMixin(SyncClientBase):
         )
         return types.SuccessResponse.model_validate(data)
 
-    def get_storage_status(self) -> types.StorageStatus:
-        logger.info("get_storage_status")
+    def storage_status(self) -> types.StorageStatus:
+        logger.info("storage_status")
         data = self._request(
             "GET",
             "/api/storage/status",
@@ -98,7 +98,7 @@ class AsyncStorageMixin(AsyncClientBase):
     Async file storage helpers for reading, writing, listing, and removing.
     """
 
-    async def write_storage_file(
+    async def storage_write(
         self,
         path: str,
         data: bytes,
@@ -109,7 +109,7 @@ class AsyncStorageMixin(AsyncClientBase):
     ) -> types.SuccessResponse:
         new_path, payload = await asyncio.to_thread(convert_for_storage, path, data)
         total = len(payload)
-        logger.info("async write_storage_file path=%s size=%s", new_path, total)
+        logger.info("async storage_write path=%s size=%s", new_path, total)
 
         async def _aiter_payload() -> AsyncIterator[bytes]:
             sent = 0
@@ -130,8 +130,8 @@ class AsyncStorageMixin(AsyncClientBase):
         )
         return types.SuccessResponse.model_validate(response)
 
-    async def read_storage_file(self, path: str) -> bytes:
-        logger.info("async read_storage_file path=%s", path)
+    async def storage_read(self, path: str) -> bytes:
+        logger.info("async storage_read path=%s", path)
         return await self._request(
             "GET",
             "/api/storage/read",
@@ -139,8 +139,8 @@ class AsyncStorageMixin(AsyncClientBase):
             expect_bytes=True,
         )  # type: ignore[return-value]
 
-    async def list_storage_files(self, path: str) -> types.StorageList:
-        logger.info("async list_storage_files path=%s", path)
+    async def storage_list(self, path: str) -> types.StorageList:
+        logger.info("async storage_list path=%s", path)
         data = await self._request(
             "GET",
             "/api/storage/list",
@@ -148,8 +148,8 @@ class AsyncStorageMixin(AsyncClientBase):
         )
         return types.StorageList.model_validate(data)
 
-    async def remove_storage_file(self, path: str) -> types.SuccessResponse:
-        logger.info("async remove_storage_file path=%s", path)
+    async def storage_remove(self, path: str) -> types.SuccessResponse:
+        logger.info("async storage_remove path=%s", path)
         data = await self._request(
             "DELETE",
             "/api/storage/remove",
@@ -157,8 +157,8 @@ class AsyncStorageMixin(AsyncClientBase):
         )
         return types.SuccessResponse.model_validate(data)
 
-    async def create_storage_directory(self, path: str) -> types.SuccessResponse:
-        logger.info("async create_storage_directory path=%s", path)
+    async def storage_mkdir(self, path: str) -> types.SuccessResponse:
+        logger.info("async storage_mkdir path=%s", path)
         data = await self._request(
             "POST",
             "/api/storage/mkdir",
@@ -166,8 +166,8 @@ class AsyncStorageMixin(AsyncClientBase):
         )
         return types.SuccessResponse.model_validate(data)
 
-    async def get_storage_status(self) -> types.StorageStatus:
-        logger.info("async get_storage_status")
+    async def storage_status(self) -> types.StorageStatus:
+        logger.info("async storage_status")
         data = await self._request(
             "GET",
             "/api/storage/status",

--- a/src/busylib/client/time.py
+++ b/src/busylib/client/time.py
@@ -13,20 +13,20 @@ class TimeMixin(SyncClientBase):
     Device time helpers.
     """
 
-    def set_time_timestamp(self, timestamp: str) -> types.SuccessResponse:
+    def time_timestamp(self, timestamp: str) -> types.SuccessResponse:
         """
         Set device time via POST /api/time/timestamp.
         """
-        logger.info("set_time_timestamp")
+        logger.info("time_timestamp")
         params = {"timestamp": timestamp}
         data = self._request("POST", "/api/time/timestamp", params=params)
         return types.SuccessResponse.model_validate(data)
 
-    def set_time_timezone(self, timezone: str) -> types.SuccessResponse:
+    def time_timezone(self, timezone: str) -> types.SuccessResponse:
         """
         Set device timezone via POST /api/time/timezone.
         """
-        logger.info("set_time_timezone")
+        logger.info("time_timezone")
         params = {"timezone": timezone}
         data = self._request("POST", "/api/time/timezone", params=params)
         return types.SuccessResponse.model_validate(data)
@@ -37,20 +37,20 @@ class AsyncTimeMixin(AsyncClientBase):
     Async device time helpers.
     """
 
-    async def set_time_timestamp(self, timestamp: str) -> types.SuccessResponse:
+    async def time_timestamp(self, timestamp: str) -> types.SuccessResponse:
         """
         Set device time via POST /api/time/timestamp.
         """
-        logger.info("async set_time_timestamp")
+        logger.info("async time_timestamp")
         params = {"timestamp": timestamp}
         data = await self._request("POST", "/api/time/timestamp", params=params)
         return types.SuccessResponse.model_validate(data)
 
-    async def set_time_timezone(self, timezone: str) -> types.SuccessResponse:
+    async def time_timezone(self, timezone: str) -> types.SuccessResponse:
         """
         Set device timezone via POST /api/time/timezone.
         """
-        logger.info("async set_time_timezone")
+        logger.info("async time_timezone")
         params = {"timezone": timezone}
         data = await self._request("POST", "/api/time/timezone", params=params)
         return types.SuccessResponse.model_validate(data)

--- a/src/busylib/client/updater.py
+++ b/src/busylib/client/updater.py
@@ -13,14 +13,14 @@ class UpdaterMixin(SyncClientBase):
     Firmware update helpers for the updater API.
     """
 
-    def update_firmware(
+    def update(
         self,
         firmware_data: bytes,
     ) -> types.SuccessResponse:
         """
         Upload firmware update TAR and initiate update.
         """
-        logger.info("update_firmware size=%s", len(firmware_data))
+        logger.info("update size=%s", len(firmware_data))
         data = self._request(
             "POST",
             "/api/update",
@@ -28,27 +28,27 @@ class UpdaterMixin(SyncClientBase):
         )
         return types.SuccessResponse.model_validate(data)
 
-    def check_firmware_update(self) -> types.SuccessResponse:
+    def update_check(self) -> types.SuccessResponse:
         """
         Start asynchronous firmware update check.
         """
-        logger.info("check_firmware_update")
+        logger.info("update_check")
         data = self._request("POST", "/api/update/check")
         return types.SuccessResponse.model_validate(data)
 
-    def get_update_status(self) -> types.UpdateStatus:
+    def update_status(self) -> types.UpdateStatus:
         """
         Get firmware update status with progress information.
         """
-        logger.info("get_update_status")
+        logger.info("update_status")
         data = self._request("GET", "/api/update/status")
         return types.UpdateStatus.model_validate(data)
 
-    def get_update_changelog(self, version: str) -> types.UpdateChangelogResponse:
+    def update_changelog(self, version: str) -> types.UpdateChangelogResponse:
         """
         Fetch update changelog for a specific version.
         """
-        logger.info("get_update_changelog version=%s", version)
+        logger.info("update_changelog version=%s", version)
         data = self._request(
             "GET",
             "/api/update/changelog",
@@ -56,11 +56,11 @@ class UpdaterMixin(SyncClientBase):
         )
         return types.UpdateChangelogResponse.model_validate(data)
 
-    def install_firmware_update(self, version: str) -> types.SuccessResponse:
+    def update_install(self, version: str) -> types.SuccessResponse:
         """
         Start firmware update installation by version.
         """
-        logger.info("install_firmware_update version=%s", version)
+        logger.info("update_install version=%s", version)
         data = self._request(
             "POST",
             "/api/update/install",
@@ -68,11 +68,11 @@ class UpdaterMixin(SyncClientBase):
         )
         return types.SuccessResponse.model_validate(data)
 
-    def abort_firmware_download(self) -> types.SuccessResponse:
+    def update_abort_download(self) -> types.SuccessResponse:
         """
         Abort an ongoing firmware download.
         """
-        logger.info("abort_firmware_download")
+        logger.info("update_abort_download")
         data = self._request("POST", "/api/update/abort_download")
         return types.SuccessResponse.model_validate(data)
 
@@ -82,14 +82,14 @@ class AsyncUpdaterMixin(AsyncClientBase):
     Async firmware update helpers for the updater API.
     """
 
-    async def update_firmware(
+    async def update(
         self,
         firmware_data: bytes,
     ) -> types.SuccessResponse:
         """
         Upload firmware update TAR and initiate update.
         """
-        logger.info("async update_firmware size=%s", len(firmware_data))
+        logger.info("async update size=%s", len(firmware_data))
         data = await self._request(
             "POST",
             "/api/update",
@@ -97,27 +97,27 @@ class AsyncUpdaterMixin(AsyncClientBase):
         )
         return types.SuccessResponse.model_validate(data)
 
-    async def check_firmware_update(self) -> types.SuccessResponse:
+    async def update_check(self) -> types.SuccessResponse:
         """
         Start asynchronous firmware update check.
         """
-        logger.info("async check_firmware_update")
+        logger.info("async update_check")
         data = await self._request("POST", "/api/update/check")
         return types.SuccessResponse.model_validate(data)
 
-    async def get_update_status(self) -> types.UpdateStatus:
+    async def update_status(self) -> types.UpdateStatus:
         """
         Get firmware update status with progress information.
         """
-        logger.info("async get_update_status")
+        logger.info("async update_status")
         data = await self._request("GET", "/api/update/status")
         return types.UpdateStatus.model_validate(data)
 
-    async def get_update_changelog(self, version: str) -> types.UpdateChangelogResponse:
+    async def update_changelog(self, version: str) -> types.UpdateChangelogResponse:
         """
         Fetch update changelog for a specific version.
         """
-        logger.info("async get_update_changelog version=%s", version)
+        logger.info("async update_changelog version=%s", version)
         data = await self._request(
             "GET",
             "/api/update/changelog",
@@ -125,11 +125,11 @@ class AsyncUpdaterMixin(AsyncClientBase):
         )
         return types.UpdateChangelogResponse.model_validate(data)
 
-    async def install_firmware_update(self, version: str) -> types.SuccessResponse:
+    async def update_install(self, version: str) -> types.SuccessResponse:
         """
         Start firmware update installation by version.
         """
-        logger.info("async install_firmware_update version=%s", version)
+        logger.info("async update_install version=%s", version)
         data = await self._request(
             "POST",
             "/api/update/install",
@@ -137,10 +137,10 @@ class AsyncUpdaterMixin(AsyncClientBase):
         )
         return types.SuccessResponse.model_validate(data)
 
-    async def abort_firmware_download(self) -> types.SuccessResponse:
+    async def update_abort_download(self) -> types.SuccessResponse:
         """
         Abort an ongoing firmware download.
         """
-        logger.info("async abort_firmware_download")
+        logger.info("async update_abort_download")
         data = await self._request("POST", "/api/update/abort_download")
         return types.SuccessResponse.model_validate(data)

--- a/src/busylib/client/wifi.py
+++ b/src/busylib/client/wifi.py
@@ -14,22 +14,22 @@ class WifiMixin(SyncClientBase):
     Wi-Fi control helpers: enable, connect, scan, and status.
     """
 
-    def enable_wifi(self) -> types.SuccessResponse:
-        logger.info("enable_wifi")
+    def wifi_enable(self) -> types.SuccessResponse:
+        logger.info("wifi_enable")
         data = self._request("POST", "/api/wifi/enable")
         return types.SuccessResponse.model_validate(data)
 
-    def disable_wifi(self) -> types.SuccessResponse:
-        logger.info("disable_wifi")
+    def wifi_disable(self) -> types.SuccessResponse:
+        logger.info("wifi_disable")
         data = self._request("POST", "/api/wifi/disable")
         return types.SuccessResponse.model_validate(data)
 
-    def get_wifi_status(self) -> types.StatusResponse:
-        logger.info("get_wifi_status")
+    def wifi_status(self) -> types.StatusResponse:
+        logger.info("wifi_status")
         data = self._request("GET", "/api/wifi/status")
         return types.StatusResponse.model_validate(data)
 
-    def connect_wifi(
+    def wifi_connect(
         self, config: types.ConnectRequestConfig | dict[str, Any]
     ) -> types.SuccessResponse:
         ssid = (
@@ -37,7 +37,7 @@ class WifiMixin(SyncClientBase):
             if isinstance(config, types.ConnectRequestConfig)
             else config.get("ssid")
         )
-        logger.info("connect_wifi ssid=%s", ssid)
+        logger.info("wifi_connect ssid=%s", ssid)
         model = (
             config
             if isinstance(config, types.ConnectRequestConfig)
@@ -51,13 +51,13 @@ class WifiMixin(SyncClientBase):
         )
         return types.SuccessResponse.model_validate(data)
 
-    def disconnect_wifi(self) -> types.SuccessResponse:
-        logger.info("disconnect_wifi")
+    def wifi_disconnect(self) -> types.SuccessResponse:
+        logger.info("wifi_disconnect")
         data = self._request("POST", "/api/wifi/disconnect")
         return types.SuccessResponse.model_validate(data)
 
-    def scan_wifi_networks(self) -> types.NetworkResponse:
-        logger.info("scan_wifi_networks")
+    def wifi_networks(self) -> types.NetworkResponse:
+        logger.info("wifi_networks")
         data = self._request("GET", "/api/wifi/networks")
         return types.NetworkResponse.model_validate(data)
 
@@ -67,22 +67,22 @@ class AsyncWifiMixin(AsyncClientBase):
     Async Wi-Fi control helpers: enable, connect, scan, and status.
     """
 
-    async def enable_wifi(self) -> types.SuccessResponse:
-        logger.info("async enable_wifi")
+    async def wifi_enable(self) -> types.SuccessResponse:
+        logger.info("async wifi_enable")
         data = await self._request("POST", "/api/wifi/enable")
         return types.SuccessResponse.model_validate(data)
 
-    async def disable_wifi(self) -> types.SuccessResponse:
-        logger.info("async disable_wifi")
+    async def wifi_disable(self) -> types.SuccessResponse:
+        logger.info("async wifi_disable")
         data = await self._request("POST", "/api/wifi/disable")
         return types.SuccessResponse.model_validate(data)
 
-    async def get_wifi_status(self) -> types.StatusResponse:
-        logger.info("async get_wifi_status")
+    async def wifi_status(self) -> types.StatusResponse:
+        logger.info("async wifi_status")
         data = await self._request("GET", "/api/wifi/status")
         return types.StatusResponse.model_validate(data)
 
-    async def connect_wifi(
+    async def wifi_connect(
         self,
         config: types.ConnectRequestConfig | dict[str, Any],
     ) -> types.SuccessResponse:
@@ -91,7 +91,7 @@ class AsyncWifiMixin(AsyncClientBase):
             if isinstance(config, types.ConnectRequestConfig)
             else config.get("ssid")
         )
-        logger.info("async connect_wifi ssid=%s", ssid)
+        logger.info("async wifi_connect ssid=%s", ssid)
         model = (
             config
             if isinstance(config, types.ConnectRequestConfig)
@@ -105,12 +105,12 @@ class AsyncWifiMixin(AsyncClientBase):
         )
         return types.SuccessResponse.model_validate(data)
 
-    async def disconnect_wifi(self) -> types.SuccessResponse:
-        logger.info("async disconnect_wifi")
+    async def wifi_disconnect(self) -> types.SuccessResponse:
+        logger.info("async wifi_disconnect")
         data = await self._request("POST", "/api/wifi/disconnect")
         return types.SuccessResponse.model_validate(data)
 
-    async def scan_wifi_networks(self) -> types.NetworkResponse:
-        logger.info("async scan_wifi_networks")
+    async def wifi_networks(self) -> types.NetworkResponse:
+        logger.info("async wifi_networks")
         data = await self._request("GET", "/api/wifi/networks")
         return types.NetworkResponse.model_validate(data)

--- a/src/busylib/exceptions.py
+++ b/src/busylib/exceptions.py
@@ -64,14 +64,71 @@ class BusyBarRequestError(BusyBarError):
         *,
         method: str | None = None,
         path: str | None = None,
+        request_id: str | None = None,
         attempts: int | None = None,
         original: Exception | None = None,
     ) -> None:
+        self.message = message
         self.method = method
         self.path = path
+        self.request_id = request_id
         self.attempts = attempts
         self.original = original
-        super().__init__(message)
+        details = [message]
+        if method and path:
+            details.append(f"{method} {path}")
+        if request_id:
+            details.append(f"request_id={request_id}")
+        if attempts is not None:
+            details.append(f"attempts={attempts}")
+        super().__init__(" | ".join(details))
+
+
+def is_retryable_delivery_error(error: BusyBarError) -> bool:
+    """
+    Classify Busy Bar delivery failures for caller retry decisions.
+
+    Treats request/transport failures and explicitly transient HTTP statuses
+    as retryable. Other 4xx responses are caller or authorization problems and
+    should not be retried as-is.
+    """
+
+    if isinstance(error, BusyBarAPIError):
+        return error.status_code in {408, 429, 500, 502, 503, 504}
+    return isinstance(error, BusyBarRequestError)
+
+
+def format_delivery_error(error: BusyBarError) -> str:
+    """
+    Format Busy Bar delivery failure into a compact diagnostic string.
+
+    Keeps enough HTTP context and response body excerpt for service logs without
+    duplicating full response-formatting logic in each integration.
+    """
+
+    if isinstance(error, BusyBarAPIError):
+        details = [
+            f"HTTP {error.status_code}" if error.status_code else "API error",
+            f"{error.method} {error.path}" if error.method and error.path else "",
+            error.error,
+        ]
+        if error.request_id:
+            details.append(f"request_id={error.request_id}")
+        if error.response_excerpt:
+            details.append(f"body={error.response_excerpt}")
+        return " | ".join(detail for detail in details if detail)
+
+    if isinstance(error, BusyBarRequestError):
+        details = [
+            "request error",
+            f"{error.method} {error.path}" if error.method and error.path else "",
+            f"request_id={error.request_id}" if error.request_id else "",
+            f"attempts={error.attempts}" if error.attempts else "",
+            error.message,
+        ]
+        return " | ".join(detail for detail in details if detail)
+
+    return str(error)
 
 
 class BusyBarAPIVersionError(BusyBarError):

--- a/src/busylib/features/app_assets.py
+++ b/src/busylib/features/app_assets.py
@@ -12,13 +12,13 @@ class AssetsClient(Protocol):
     Protocol describing the async client surface used by asset sync.
     """
 
-    async def list_storage_files(self, path: str) -> types.StorageList:
+    async def storage_list(self, path: str) -> types.StorageList:
         """
         Return a listing of files in the given storage path.
         """
         ...
 
-    async def write_storage_file(self, path: str, data: bytes) -> types.SuccessResponse:
+    async def storage_write(self, path: str, data: bytes) -> types.SuccessResponse:
         """
         Upload a file to device storage.
         """
@@ -30,20 +30,20 @@ logger = logging.getLogger(__name__)
 
 async def sync_app_assets(
     client: AssetsClient,
-    app_id: str,
+    application_name: str,
     assets_dir: str | Path,
 ) -> list[str]:
     """
-    Sync local assets with device storage for the given app id.
+    Sync local assets with device storage for the given application name.
     Uploads files that are missing or have different sizes.
     """
     assets_path = Path(assets_dir)
     if not assets_path.is_dir():
         return []
 
-    remote_dir = f"/ext/assets/{app_id}"
+    remote_dir = f"/ext/assets/{application_name}"
     try:
-        listing = await client.list_storage_files(remote_dir)
+        listing = await client.storage_list(remote_dir)
     except Exception as exc:  # noqa: BLE001
         logger.debug("Failed to list remote assets: %s", exc)
         listing = types.StorageList(list=[])
@@ -62,7 +62,7 @@ async def sync_app_assets(
         if remote_sizes.get(local_path.name) == local_size:
             continue
         data = local_path.read_bytes()
-        await client.write_storage_file(f"{remote_dir}/{local_path.name}", data)
+        await client.storage_write(f"{remote_dir}/{local_path.name}", data)
         uploaded.append(local_path.name)
 
     return uploaded

--- a/src/busylib/features/dashboard.py
+++ b/src/busylib/features/dashboard.py
@@ -4,7 +4,7 @@ import asyncio
 import logging
 from collections.abc import Awaitable, Callable
 from datetime import datetime
-from typing import TypeAlias, TypeVar
+from typing import TypeAlias, TypeVar, cast
 
 from pydantic import BaseModel, Field
 
@@ -77,19 +77,19 @@ async def collect_device_snapshot(client: AsyncBusyBar) -> DeviceSnapshot:
     reported in `field_errors` without aborting the whole snapshot.
     """
     tasks = {
-        "name": asyncio.create_task(_safe("name", client.get_device_name())),
-        "version": asyncio.create_task(_safe("version", client.get_version())),
-        "status": asyncio.create_task(_safe("status", client.get_status())),
-        "system": asyncio.create_task(_safe("system", client.get_system_status())),
-        "power": asyncio.create_task(_safe("power", client.get_power_status())),
-        "time": asyncio.create_task(_safe("time", client.get_device_time())),
-        "wifi": asyncio.create_task(_safe("wifi", client.get_wifi_status())),
+        "name": asyncio.create_task(_safe("name", client.name())),
+        "version": asyncio.create_task(_safe("version", client.version())),
+        "status": asyncio.create_task(_safe("status", client.status())),
+        "system": asyncio.create_task(_safe("system", client.status_system())),
+        "power": asyncio.create_task(_safe("power", client.status_power())),
+        "time": asyncio.create_task(_safe("time", client.time())),
+        "wifi": asyncio.create_task(_safe("wifi", client.wifi_status())),
         "brightness": asyncio.create_task(
-            _safe("brightness", client.get_display_brightness())
+            _safe("brightness", client.display_brightness())
         ),
-        "volume": asyncio.create_task(_safe("volume", client.get_audio_volume())),
+        "volume": asyncio.create_task(_safe("volume", client.audio_volume())),
         "ble": asyncio.create_task(_safe("ble", client.ble_status())),
-        "storage": asyncio.create_task(_safe("storage", client.get_storage_status())),
+        "storage": asyncio.create_task(_safe("storage", client.storage_status())),
     }
 
     results: dict[str, object | None] = {}
@@ -342,6 +342,6 @@ class DeviceStateStore:
         Remove callback from subscription container if present.
         """
         try:
-            container.remove(callback)
+            cast(list[object], container).remove(callback)
         except ValueError:
             return

--- a/src/busylib/types.py
+++ b/src/busylib/types.py
@@ -528,7 +528,7 @@ DisplayElement = TextElement | ImageElement | AnimationElement | CountdownElemen
 
 
 class DisplayElements(BaseModel):
-    application_name: str = Field(min_length=1, alias="app_id")
+    application_name: str = Field(min_length=1)
     priority: int = Field(default=50, ge=1, le=100)
     elements: list[DisplayElement]
 
@@ -573,7 +573,6 @@ class AudioVolumeUpdate(BaseModel):
 
 
 class AudioPlayRequest(BaseModel):
-    application_name: str | None = Field(default=None, min_length=1)
     path: str | None = Field(default=None, min_length=1)
     stock_path: str | None = Field(default=None, min_length=1)
 
@@ -584,12 +583,9 @@ class AudioPlayRequest(BaseModel):
         """
         Ensure payload references exactly one audio source style.
 
-        Stock resources use `stock_path`; uploaded resources use
-        `application_name + path`.
+        Stock resources use `stock_path`; uploaded resources use `path`.
+        Application context is supplied by request kwargs in client methods.
         """
-        if not self.application_name:
-            raise ValueError("application_name is required")
-
         if bool(self.path) == bool(self.stock_path):
             raise ValueError("exactly one of path or stock_path must be provided")
 

--- a/tests/busylib/client/test_audio.py
+++ b/tests/busylib/client/test_audio.py
@@ -4,9 +4,8 @@ import json
 
 import httpx
 import pytest
-from pydantic import ValidationError
-
-from busylib import AsyncBusyBar, BusyBar, exceptions, types
+from busylib import AsyncBusyBar, BusyBar, types
+from busylib import exceptions
 
 
 def _make_sync_client(responder) -> BusyBar:
@@ -27,18 +26,17 @@ def _make_async_client(responder) -> AsyncBusyBar:
 
 def test_audio_play_stop_volume_sync() -> None:
     """
-    Validate audio playback and volume endpoints for sync client.
+    Validate audio play, stop, and volume endpoints for sync client.
     """
     seen: list[dict[str, object]] = []
 
     def responder(request: httpx.Request) -> httpx.Response:
-        body = request.content.decode("utf-8") if request.content else ""
         seen.append(
             {
                 "path": request.url.path,
                 "method": request.method,
                 "params": dict(request.url.params),
-                "json": json.loads(body) if body else None,
+                "body": json.loads(request.content) if request.content else None,
             }
         )
         if request.url.path == "/api/audio/volume" and request.method == "GET":
@@ -46,16 +44,16 @@ def test_audio_play_stop_volume_sync() -> None:
         return httpx.Response(200, json={"result": "OK"})
 
     client = _make_sync_client(responder)
-    resp = client.play_audio("app", "sounds/event.snd")
+    resp = client.audio_play(application_name="app", path="/ext/app.wav")
     assert resp.result == "OK"
-    resp = client.stop_audio()
+    resp = client.audio_stop()
     assert resp.result == "OK"
-    resp = client.stop_sound()
+    resp = client.audio_stop()
     assert resp.result == "OK"
-    info = client.get_audio_volume()
+    info = client.audio_volume()
     assert isinstance(info, types.AudioVolumeInfo)
     assert info.volume == 42.0
-    resp = client.set_audio_volume(55.5)
+    resp = client.audio_volume_set(55.5)
     assert resp.result == "OK"
 
     assert seen == [
@@ -63,35 +61,106 @@ def test_audio_play_stop_volume_sync() -> None:
             "path": "/api/audio/play",
             "method": "POST",
             "params": {},
-            "json": {"application_name": "app", "path": "sounds/event.snd"},
+            "body": {"application_name": "app", "path": "/ext/app.wav"},
         },
-        {"path": "/api/audio/play", "method": "DELETE", "params": {}, "json": None},
-        {"path": "/api/audio/play", "method": "DELETE", "params": {}, "json": None},
-        {"path": "/api/audio/volume", "method": "GET", "params": {}, "json": None},
+        {"path": "/api/audio/play", "method": "DELETE", "params": {}, "body": None},
+        {"path": "/api/audio/play", "method": "DELETE", "params": {}, "body": None},
+        {"path": "/api/audio/volume", "method": "GET", "params": {}, "body": None},
         {
             "path": "/api/audio/volume",
             "method": "POST",
             "params": {"volume": "55.5"},
-            "json": None,
+            "body": None,
         },
     ]
+
+
+def test_audio_play_sync_supports_session_header() -> None:
+    """
+    Ensure audio_play forwards x-session-id through request kwargs.
+    """
+    seen: dict[str, str] = {}
+
+    def responder(request: httpx.Request) -> httpx.Response:
+        seen["session"] = request.headers.get("x-session-id", "")
+        return httpx.Response(200, json={"result": "OK"})
+
+    client = _make_sync_client(responder)
+    resp = client.audio_play(
+        application_name="app",
+        path="/ext/app.wav",
+        session_id="bar-1",
+    )
+    assert resp.result == "OK"
+    assert seen["session"] == "bar-1"
+
+
+def test_audio_play_sync_supports_stock_path_payload() -> None:
+    """
+    Send stock-path playback payload without application context in payload.
+    """
+    seen: dict[str, object] = {}
+
+    def responder(request: httpx.Request) -> httpx.Response:
+        seen.update(json.loads(request.content))
+        return httpx.Response(200, json={"result": "OK"})
+
+    client = _make_sync_client(responder)
+    resp = client.audio_play(payload={"stock_path": "shared/sfx.snd"})
+    assert resp.result == "OK"
+    assert seen == {"stock_path": "shared/sfx.snd"}
+
+
+def test_audio_play_sync_rejects_payload_application_name() -> None:
+    """
+    Reject application_name inside audio payload; request context owns it.
+    """
+    client = _make_sync_client(
+        lambda _request: httpx.Response(200, json={"result": "OK"})
+    )
+    with pytest.raises(exceptions.BusyBarResponseValidationError):
+        client.audio_play(
+            application_name="app",
+            payload={
+                "application_name": "legacy",
+                "stock_path": "shared/sfx.snd",
+            },
+        )
+
+
+def test_audio_play_sync_keyword_arguments_override_payload() -> None:
+    """
+    Let explicit path and stock_path keyword arguments override payload keys.
+    """
+    seen: dict[str, object] = {}
+
+    def responder(request: httpx.Request) -> httpx.Response:
+        seen.update(json.loads(request.content))
+        return httpx.Response(200, json={"result": "OK"})
+
+    client = _make_sync_client(responder)
+    resp = client.audio_play(
+        payload={"path": "old.wav"},
+        stock_path="shared/sfx.snd",
+    )
+    assert resp.result == "OK"
+    assert seen == {"stock_path": "shared/sfx.snd"}
 
 
 @pytest.mark.asyncio
 async def test_audio_play_stop_volume_async() -> None:
     """
-    Validate audio playback and volume endpoints for async client.
+    Validate audio play, stop, and volume endpoints for async client.
     """
     seen: list[dict[str, object]] = []
 
     async def responder(request: httpx.Request) -> httpx.Response:
-        body = request.content.decode("utf-8") if request.content else ""
         seen.append(
             {
                 "path": request.url.path,
                 "method": request.method,
                 "params": dict(request.url.params),
-                "json": json.loads(body) if body else None,
+                "body": json.loads(request.content) if request.content else None,
             }
         )
         if request.url.path == "/api/audio/volume" and request.method == "GET":
@@ -99,16 +168,16 @@ async def test_audio_play_stop_volume_async() -> None:
         return httpx.Response(200, json={"result": "OK"})
 
     client = _make_async_client(responder)
-    resp = await client.play_audio("app", "sounds/event.snd")
+    resp = await client.audio_play(application_name="app", path="/ext/app.wav")
     assert resp.result == "OK"
-    resp = await client.stop_audio()
+    resp = await client.audio_stop()
     assert resp.result == "OK"
-    resp = await client.stop_sound()
+    resp = await client.audio_stop()
     assert resp.result == "OK"
-    info = await client.get_audio_volume()
+    info = await client.audio_volume()
     assert isinstance(info, types.AudioVolumeInfo)
     assert info.volume == 17.0
-    resp = await client.set_audio_volume(12.5)
+    resp = await client.audio_volume_set(12.5)
     assert resp.result == "OK"
     await client.aclose()
 
@@ -117,212 +186,55 @@ async def test_audio_play_stop_volume_async() -> None:
             "path": "/api/audio/play",
             "method": "POST",
             "params": {},
-            "json": {"application_name": "app", "path": "sounds/event.snd"},
+            "body": {"application_name": "app", "path": "/ext/app.wav"},
         },
-        {"path": "/api/audio/play", "method": "DELETE", "params": {}, "json": None},
-        {"path": "/api/audio/play", "method": "DELETE", "params": {}, "json": None},
-        {"path": "/api/audio/volume", "method": "GET", "params": {}, "json": None},
+        {"path": "/api/audio/play", "method": "DELETE", "params": {}, "body": None},
+        {"path": "/api/audio/play", "method": "DELETE", "params": {}, "body": None},
+        {"path": "/api/audio/volume", "method": "GET", "params": {}, "body": None},
         {
             "path": "/api/audio/volume",
             "method": "POST",
             "params": {"volume": "12.5"},
-            "json": None,
+            "body": None,
         },
     ]
 
 
-def test_audio_play_stock_path_sync() -> None:
+@pytest.mark.asyncio
+async def test_audio_play_async_supports_session_header() -> None:
     """
-    Send stock sound playback payload using shared resource reference.
+    Ensure async audio_play forwards x-session-id through request kwargs.
     """
-    seen: list[dict[str, object]] = []
+    seen: dict[str, str] = {}
 
-    def responder(request: httpx.Request) -> httpx.Response:
-        seen.append(
-            {
-                "path": request.url.path,
-                "method": request.method,
-                "params": dict(request.url.params),
-                "json": json.loads(request.content.decode("utf-8")),
-            }
-        )
+    async def responder(request: httpx.Request) -> httpx.Response:
+        seen["session"] = request.headers.get("x-session-id", "")
         return httpx.Response(200, json={"result": "OK"})
 
-    client = _make_sync_client(responder)
-    resp = client.play_audio(
-        application_name="calendar",
-        stock_path="shared/Calendar_event_starts.snd",
+    client = _make_async_client(responder)
+    resp = await client.audio_play(
+        application_name="app",
+        path="/ext/app.wav",
+        session_id="bar-2",
     )
     assert resp.result == "OK"
-    assert seen == [
-        {
-            "path": "/api/audio/play",
-            "method": "POST",
-            "params": {},
-            "json": {
-                "application_name": "calendar",
-                "stock_path": "shared/Calendar_event_starts.snd",
-            },
-        }
-    ]
-
-
-def test_audio_play_stock_path_requires_application_name() -> None:
-    """
-    Reject stock-path playback payloads without application_name.
-    """
-    client = _make_sync_client(lambda _request: httpx.Response(200, json={"result": "OK"}))
-    with pytest.raises(ValidationError):
-        client.play_audio(stock_path="shared/Calendar_event_starts.snd")
-
-
-def test_audio_play_legacy_fallback_sync() -> None:
-    """
-    Fallback to legacy query params when JSON audio play is not supported.
-    """
-    seen: list[dict[str, object]] = []
-
-    def responder(request: httpx.Request) -> httpx.Response:
-        item = {
-            "path": request.url.path,
-            "method": request.method,
-            "params": dict(request.url.params),
-            "json": (
-                None
-                if not request.content
-                else json.loads(request.content.decode("utf-8"))
-            ),
-        }
-        seen.append(item)
-        if request.method == "POST" and request.url.path == "/api/audio/play":
-            if item["params"]:
-                return httpx.Response(200, json={"result": "OK"})
-            return httpx.Response(400, json={"error": "bad request", "code": 400})
-        return httpx.Response(200, json={"result": "OK"})
-
-    client = _make_sync_client(responder)
-    resp = client.play_audio("calendar", "sounds/reminder.snd")
-    assert resp.result == "OK"
-    assert seen == [
-        {
-            "path": "/api/audio/play",
-            "method": "POST",
-            "params": {},
-            "json": {"application_name": "calendar", "path": "sounds/reminder.snd"},
-        },
-        {
-            "path": "/api/audio/play",
-            "method": "POST",
-            "params": {
-                "application_name": "calendar",
-                "path": "sounds/reminder.snd",
-            },
-            "json": None,
-        },
-    ]
-
-
-def test_audio_play_no_fallback_for_non_400_sync() -> None:
-    """
-    Do not fallback to legacy params when JSON play fails with non-400 status.
-    """
-    seen: list[dict[str, object]] = []
-
-    def responder(request: httpx.Request) -> httpx.Response:
-        item = {
-            "path": request.url.path,
-            "method": request.method,
-            "params": dict(request.url.params),
-            "json": (
-                None
-                if not request.content
-                else json.loads(request.content.decode("utf-8"))
-            ),
-        }
-        seen.append(item)
-        return httpx.Response(401, json={"error": "unauthorized", "code": 401})
-
-    client = _make_sync_client(responder)
-    with pytest.raises(exceptions.BusyBarAPIError):
-        client.play_audio("calendar", "sounds/reminder.snd")
-
-    assert len(seen) == 1
-    assert seen[0]["params"] == {}
+    assert seen["session"] == "bar-2"
+    await client.aclose()
 
 
 @pytest.mark.asyncio
-async def test_audio_play_legacy_fallback_async() -> None:
+async def test_audio_play_async_supports_stock_path_payload() -> None:
     """
-    Fallback to legacy query params in async mode when JSON is rejected.
+    Send stock-path playback payload in async mode.
     """
-    seen: list[dict[str, object]] = []
+    seen: dict[str, object] = {}
 
     async def responder(request: httpx.Request) -> httpx.Response:
-        item = {
-            "path": request.url.path,
-            "method": request.method,
-            "params": dict(request.url.params),
-            "json": (
-                None
-                if not request.content
-                else json.loads(request.content.decode("utf-8"))
-            ),
-        }
-        seen.append(item)
-        if request.method == "POST" and request.url.path == "/api/audio/play":
-            if item["params"]:
-                return httpx.Response(200, json={"result": "OK"})
-            return httpx.Response(400, json={"error": "bad request", "code": 400})
+        seen.update(json.loads(request.content))
         return httpx.Response(200, json={"result": "OK"})
 
     client = _make_async_client(responder)
-    resp = await client.play_audio("calendar", "sounds/reminder.snd")
+    resp = await client.audio_play(payload={"stock_path": "shared/sfx.snd"})
     assert resp.result == "OK"
+    assert seen == {"stock_path": "shared/sfx.snd"}
     await client.aclose()
-    assert seen == [
-        {
-            "path": "/api/audio/play",
-            "method": "POST",
-            "params": {},
-            "json": {"application_name": "calendar", "path": "sounds/reminder.snd"},
-        },
-        {
-            "path": "/api/audio/play",
-            "method": "POST",
-            "params": {
-                "application_name": "calendar",
-                "path": "sounds/reminder.snd",
-            },
-            "json": None,
-        },
-    ]
-
-
-@pytest.mark.asyncio
-async def test_audio_play_no_fallback_for_non_400_async() -> None:
-    """
-    Do not fallback to legacy params in async mode for non-400 failures.
-    """
-    seen: list[dict[str, object]] = []
-
-    async def responder(request: httpx.Request) -> httpx.Response:
-        item = {
-            "path": request.url.path,
-            "method": request.method,
-            "params": dict(request.url.params),
-            "json": (
-                None
-                if not request.content
-                else json.loads(request.content.decode("utf-8"))
-            ),
-        }
-        seen.append(item)
-        return httpx.Response(503, json={"error": "service unavailable", "code": 503})
-
-    client = _make_async_client(responder)
-    with pytest.raises(exceptions.BusyBarAPIError):
-        await client.play_audio("calendar", "sounds/reminder.snd")
-    await client.aclose()
-
-    assert len(seen) == 1
-    assert seen[0]["params"] == {}

--- a/tests/busylib/client/test_base.py
+++ b/tests/busylib/client/test_base.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+import json
+import uuid
+
 import httpx
 import pytest
 
@@ -128,6 +131,165 @@ def test_request_json_payload_allow_text_sync() -> None:
     client = _SyncBaseClient(httpx.MockTransport(responder))
     result = client._request("GET", "/api/test", allow_text=True)
     assert result == "ok"
+
+
+def test_api_request_uses_client_session_sync() -> None:
+    """
+    Exposes raw API requests through the same client session.
+    """
+
+    def responder(request: httpx.Request) -> httpx.Response:
+        assert request.url.path == "/api/custom"
+        assert request.headers["x-session-id"] == "bar-1"
+        assert json.loads(request.content) == {
+            "value": 1,
+            "application_name": "app",
+        }
+        return httpx.Response(200, json={"result": "OK"})
+
+    client = _SyncBaseClient(httpx.MockTransport(responder))
+    result = client.api_request(
+        "POST",
+        "/api/custom",
+        session_id="bar-1",
+        application_name="app",
+        json_payload={"value": 1},
+    )
+    assert result == {"result": "OK"}
+
+
+def test_request_applies_common_session_and_application_name_sync() -> None:
+    """
+    Adds shared request context as session header and application query param.
+    """
+
+    def responder(request: httpx.Request) -> httpx.Response:
+        assert request.headers["x-session-id"] == "bar-1"
+        assert dict(request.url.params) == {"application_name": "app"}
+        return httpx.Response(200, json={"result": "OK"})
+
+    client = _SyncBaseClient(httpx.MockTransport(responder))
+    result = client._request(
+        "GET",
+        "/api/test",
+        session_id="bar-1",
+        application_name="app",
+    )
+    assert result == {"result": "OK"}
+
+
+def test_request_generates_request_id_sync(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    Adds X-Request-ID when caller did not provide one.
+    """
+
+    monkeypatch.setattr(uuid, "uuid4", lambda: uuid.UUID(int=1))
+
+    def responder(request: httpx.Request) -> httpx.Response:
+        assert request.headers["x-request-id"] == uuid.UUID(int=1).hex
+        return httpx.Response(200, json={"result": "OK"})
+
+    client = _SyncBaseClient(httpx.MockTransport(responder))
+    result = client._request("GET", "/api/test")
+    assert result == {"result": "OK"}
+
+
+def test_request_preserves_caller_request_id_sync() -> None:
+    """
+    Keeps caller-provided X-Request-ID instead of generating a new value.
+    """
+
+    def responder(request: httpx.Request) -> httpx.Response:
+        assert request.headers["x-request-id"] == "caller-rid"
+        return httpx.Response(200, json={"result": "OK"})
+
+    client = _SyncBaseClient(httpx.MockTransport(responder))
+    result = client._request(
+        "GET",
+        "/api/test",
+        headers={"X-Request-ID": "caller-rid"},
+    )
+    assert result == {"result": "OK"}
+
+
+def test_request_uses_generated_request_id_in_api_error_sync(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    Stores generated request id in API error when response has no own id.
+    """
+
+    monkeypatch.setattr(uuid, "uuid4", lambda: uuid.UUID(int=2))
+
+    def responder(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(400, json={"error": "bad request"})
+
+    client = _SyncBaseClient(httpx.MockTransport(responder))
+    with pytest.raises(exceptions.BusyBarAPIError) as exc:
+        client._request("POST", "/api/test", json_payload={"x": 1})
+    assert exc.value.request_id == uuid.UUID(int=2).hex
+
+
+def test_request_uses_generated_request_id_in_transport_error_sync(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    Stores generated request id in transport errors without a response.
+    """
+
+    monkeypatch.setattr(uuid, "uuid4", lambda: uuid.UUID(int=3))
+
+    def responder(request: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError("boom", request=request)
+
+    client = _SyncBaseClient(httpx.MockTransport(responder))
+    with pytest.raises(exceptions.BusyBarRequestError) as exc:
+        client._request("GET", "/api/fail")
+    assert exc.value.request_id == uuid.UUID(int=3).hex
+
+
+def test_request_applies_application_name_to_json_sync() -> None:
+    """
+    Adds application_name to JSON payload for mutating object requests.
+    """
+
+    def responder(request: httpx.Request) -> httpx.Response:
+        assert json.loads(request.content) == {
+            "path": "/ext/app.wav",
+            "application_name": "app",
+        }
+        return httpx.Response(200, json={"result": "OK"})
+
+    client = _SyncBaseClient(httpx.MockTransport(responder))
+    result = client._request(
+        "POST",
+        "/api/test",
+        json_payload={"path": "/ext/app.wav"},
+        application_name="app",
+    )
+    assert result == {"result": "OK"}
+
+
+def test_request_keeps_application_name_in_params_for_binary_post_sync() -> None:
+    """
+    Adds application_name to query params when POST has no object JSON body.
+    """
+
+    def responder(request: httpx.Request) -> httpx.Response:
+        assert dict(request.url.params) == {"application_name": "app"}
+        assert request.content == b"payload"
+        return httpx.Response(200, json={"result": "OK"})
+
+    client = _SyncBaseClient(httpx.MockTransport(responder))
+    result = client._request(
+        "POST",
+        "/api/test",
+        data=b"payload",
+        application_name="app",
+    )
+    assert result == {"result": "OK"}
 
 
 def test_request_expect_bytes_sync() -> None:
@@ -294,6 +456,33 @@ async def test_request_allow_text_async() -> None:
     client = _AsyncBaseClient(httpx.MockTransport(responder))
     result = await client._request("GET", "/api/test", allow_text=True)
     assert result == "ok"
+    await client.aclose()
+
+
+@pytest.mark.asyncio
+async def test_api_request_uses_client_session_async() -> None:
+    """
+    Exposes raw async API requests through the same client session.
+    """
+
+    async def responder(request: httpx.Request) -> httpx.Response:
+        assert request.url.path == "/api/custom"
+        assert request.headers["x-session-id"] == "bar-2"
+        assert json.loads(request.content) == {
+            "value": 2,
+            "application_name": "app",
+        }
+        return httpx.Response(200, json={"result": "OK"})
+
+    client = _AsyncBaseClient(httpx.MockTransport(responder))
+    result = await client.api_request(
+        "POST",
+        "/api/custom",
+        session_id="bar-2",
+        application_name="app",
+        json_payload={"value": 2},
+    )
+    assert result == {"result": "OK"}
     await client.aclose()
 
 

--- a/tests/busylib/client/test_client.py
+++ b/tests/busylib/client/test_client.py
@@ -41,7 +41,7 @@ def test_init_token_sets_cloud_base_and_header():
     assert client.client.headers["authorization"] == "Bearer secret"
 
 
-def test_get_version_success():
+def test_version_success():
     """
     Validate successful parsing of version information.
 
@@ -60,13 +60,13 @@ def test_get_version_success():
         )
 
     client = make_client(responder, api_version="1.2.0")
-    result = client.get_version()
+    result = client.version()
     assert isinstance(result, types.VersionInfo)
     assert result.api_semver == "1.2.0"
     assert result.branch == "main"
 
 
-def test_get_device_name_and_time():
+def test_name_and_time():
     """
     Fetch device name and time from their respective endpoints.
 
@@ -81,13 +81,13 @@ def test_get_device_name_and_time():
         return httpx.Response(404, json={"error": "missing", "code": 404})
 
     client = make_client(responder)
-    name = client.get_device_name()
+    name = client.name()
     assert name.name == "BusyBar"
-    time_info = client.get_device_time()
+    time_info = client.time()
     assert time_info.timestamp == "2024-01-01T10:00:00"
 
 
-def test_set_device_name() -> None:
+def test_name_set() -> None:
     """
     Send device name update payload via POST /api/name.
     """
@@ -100,23 +100,23 @@ def test_set_device_name() -> None:
         return httpx.Response(200, json={"result": "OK"})
 
     client = make_client(responder)
-    resp = client.set_device_name("Busy Desk")
+    resp = client.name_set("Busy Desk")
     assert resp.result == "OK"
     assert seen["path"] == "/api/name"
     assert seen["method"] == "POST"
     assert seen["body"] == {"name": "Busy Desk"}
 
 
-def test_set_device_name_rejects_empty() -> None:
+def test_name_set_rejects_empty() -> None:
     """
     Reject empty device names before sending request.
     """
     client = make_client(lambda _request: httpx.Response(200, json={"result": "OK"}))
     with pytest.raises(ValueError):
-        client.set_device_name("")
+        client.name_set("")
 
 
-def test_get_account_info():
+def test_account_info():
     """
     Parse linked account info from the client.
     """
@@ -126,12 +126,12 @@ def test_get_account_info():
         return httpx.Response(200, json={"linked": True, "email": "name@example.com"})
 
     client = make_client(responder)
-    result = client.get_account_info()
+    result = client.account_info()
     assert result.linked is True
     assert result.email == "name@example.com"
 
 
-def test_set_account_profile() -> None:
+def test_account_profile_set() -> None:
     """
     Ensure account profile updates are sent as query params.
     """
@@ -142,7 +142,7 @@ def test_set_account_profile() -> None:
         return httpx.Response(200, json={"result": "OK"})
 
     client = make_client(responder)
-    resp = client.set_account_profile("custom", custom_url="mqtts://mqtt.example.com")
+    resp = client.account_profile_set("custom", custom_url="mqtts://mqtt.example.com")
     assert resp.result == "OK"
     assert seen["params"] == {
         "profile": "custom",
@@ -150,7 +150,7 @@ def test_set_account_profile() -> None:
     }
 
 
-def test_link_account():
+def test_account_link():
     """
     Parse account link response from the client.
     """
@@ -160,7 +160,7 @@ def test_link_account():
         return httpx.Response(200, json={"code": "ABCD", "expires_at": 1700000000})
 
     client = make_client(responder)
-    result = client.link_account()
+    result = client.account_link()
     assert result.code == "ABCD"
     assert result.expires_at == 1700000000
 
@@ -181,7 +181,7 @@ def test_error_response_raises_api_error():
 
     client = make_client(responder)
     with pytest.raises(exceptions.BusyBarAPIError) as exc:
-        client.get_version()
+        client.version()
     assert exc.value.code == 500
     assert exc.value.status_code == 500
     assert exc.value.method == "GET"
@@ -202,7 +202,7 @@ def test_api_error_has_truncated_excerpt() -> None:
 
     client = make_client(responder)
     with pytest.raises(exceptions.BusyBarAPIError) as exc:
-        client.get_version()
+        client.version()
     assert exc.value.response_excerpt is not None
     assert exc.value.response_excerpt.endswith("...")
     assert len(exc.value.response_excerpt) <= 259
@@ -220,12 +220,12 @@ def test_plain_text_error_response():
 
     client = make_client(responder)
     with pytest.raises(exceptions.BusyBarAPIError) as exc:
-        client.get_version()
+        client.version()
     assert exc.value.code == 404
     assert "HTTP 404" in str(exc.value)
 
 
-def test_get_version_incompatible_requires_device_update():
+def test_version_incompatible_requires_device_update():
     """
     Reject incompatible firmware API versions.
 
@@ -237,7 +237,7 @@ def test_get_version_incompatible_requires_device_update():
 
     client = make_client(responder, api_version="1.0.0")
     with pytest.raises(exceptions.BusyBarAPIVersionError) as exc:
-        client.get_version()
+        client.version()
     assert "update firmware" in str(exc.value)
 
 
@@ -254,7 +254,7 @@ def test_request_carries_api_version_header():
         return httpx.Response(200, json={"result": "OK"})
 
     client = make_client(responder, api_version="1.1.0")
-    resp = client.enable_wifi()
+    resp = client.wifi_enable()
     assert resp.result == "OK"
     assert seen["header"] == "1.1.0"
 
@@ -274,7 +274,7 @@ def test_retry_on_transport_error():
         return httpx.Response(200, json={"result": "OK"})
 
     client = make_client(responder, max_retries=1, backoff=0.0)
-    resp = client.enable_wifi()
+    resp = client.wifi_enable()
     assert resp.result == "OK"
     assert calls["count"] == 2
 
@@ -293,7 +293,7 @@ def test_response_validation_error_is_wrapped() -> None:
 
     client = make_client(responder, api_version="1.2.0")
     with pytest.raises(exceptions.BusyBarResponseValidationError) as exc:
-        client.get_version()
+        client.version()
     assert exc.value.model == "VersionInfo"
 
 
@@ -314,7 +314,47 @@ def test_all_library_errors_inherit_base_error() -> None:
     assert issubclass(exceptions.BusyBarWebSocketError, exceptions.BusyBarError)
 
 
-def test_draw_on_display_sends_utf8_body():
+def test_delivery_error_helpers_format_and_classify_errors() -> None:
+    """
+    Validate delivery error diagnostics and retryability helpers.
+    """
+
+    bad_request = exceptions.BusyBarAPIError(
+        "invalid payload",
+        status_code=400,
+        method="POST",
+        path="/api/display/draw",
+        request_id="req-1",
+        response_excerpt='{"error":"invalid payload"}',
+    )
+    server_error = exceptions.BusyBarAPIError(
+        "proxy unavailable",
+        status_code=503,
+        method="POST",
+        path="/api/display/draw",
+    )
+    request_error = exceptions.BusyBarRequestError(
+        "connection failed",
+        method="POST",
+        path="/api/audio/play",
+        attempts=2,
+    )
+
+    assert not exceptions.is_retryable_delivery_error(bad_request)
+    assert exceptions.is_retryable_delivery_error(server_error)
+    assert exceptions.is_retryable_delivery_error(request_error)
+    assert (
+        exceptions.format_delivery_error(bad_request)
+        == "HTTP 400 | POST /api/display/draw | invalid payload | "
+        'request_id=req-1 | body={"error":"invalid payload"}'
+    )
+    assert (
+        exceptions.format_delivery_error(request_error)
+        == "request error | POST /api/audio/play | attempts=2 | connection failed"
+    )
+
+
+def test_display_draw_sends_utf8_body():
     """
     Ensure JSON payloads are encoded as UTF-8 without ASCII escaping.
 
@@ -342,11 +382,191 @@ def test_draw_on_display_sends_utf8_body():
         return httpx.Response(200, json={"result": "OK"})
 
     client = make_client(responder)
-    resp = client.draw_on_display(payload)
+    resp = client.display_draw(payload)
     assert resp.result == "OK"
 
 
-def test_get_screen_frame_returns_bytes():
+def test_display_draw_and_clear_params() -> None:
+    """
+    Validate display_draw and display_clear request params and session header.
+    """
+
+    seen: list[dict[str, object]] = []
+
+    def responder(request: httpx.Request) -> httpx.Response:
+        seen.append(
+            {
+                "path": request.url.path,
+                "method": request.method,
+                "params": dict(request.url.params),
+                "session": request.headers.get("x-session-id"),
+            }
+        )
+        return httpx.Response(200, json={"result": "OK"})
+
+    client = make_client(responder)
+    payload = {
+        "application_name": "demo",
+        "elements": [
+            {"id": "1", "type": "text", "x": 0, "y": 0, "text": "A", "font": "small"}
+        ],
+    }
+    draw_resp = client.display_draw(payload, session_id="bar-1")
+    clear_resp = client.display_clear(
+        application_name="demo",
+        session_id="bar-1",
+    )
+    assert draw_resp.result == "OK"
+    assert clear_resp.result == "OK"
+    assert seen[0]["path"] == "/api/display/draw"
+    assert seen[0]["method"] == "POST"
+    assert seen[0]["session"] == "bar-1"
+    assert seen[1]["path"] == "/api/display/draw"
+    assert seen[1]["method"] == "DELETE"
+    assert seen[1]["params"] == {"application_name": "demo"}
+    assert seen[1]["session"] == "bar-1"
+
+
+def test_display_draw_can_clear_before_draw() -> None:
+    """
+    Validate clear_before_draw in display_draw.
+    """
+
+    seen: list[tuple[str, str, dict[str, str]]] = []
+
+    def responder(request: httpx.Request) -> httpx.Response:
+        seen.append((request.method, request.url.path, dict(request.url.params)))
+        return httpx.Response(200, json={"result": "OK"})
+
+    client = make_client(responder)
+    payload = {
+        "application_name": "demo",
+        "elements": [
+            {"id": "1", "type": "text", "x": 0, "y": 0, "text": "A", "font": "small"}
+        ],
+    }
+    resp = client.display_draw(payload, clear_before_draw=True)
+    assert resp.result == "OK"
+    assert seen[0] == (
+        "DELETE",
+        "/api/display/draw",
+        {"application_name": "demo"},
+    )
+    assert seen[1][0] == "POST"
+
+
+def test_display_can_clear_draw_and_audio_play() -> None:
+    """
+    Validate high-level display flow: clear, draw, and audio_play.
+    """
+
+    seen: list[dict[str, object]] = []
+
+    def responder(request: httpx.Request) -> httpx.Response:
+        seen.append(
+            {
+                "method": request.method,
+                "path": request.url.path,
+                "params": dict(request.url.params),
+                "body": json.loads(request.content) if request.content else None,
+                "session": request.headers.get("x-session-id"),
+            }
+        )
+        return httpx.Response(200, json={"result": "OK"})
+
+    client = make_client(responder)
+    payload = {
+        "application_name": "demo",
+        "elements": [
+            {"id": "1", "type": "text", "x": 0, "y": 0, "text": "A", "font": "small"}
+        ],
+    }
+    normalized_payload = {
+        "application_name": "demo",
+        "priority": 50,
+        "elements": [
+            {
+                "id": "1",
+                "display": "front",
+                "type": "text",
+                "x": 0,
+                "y": 0,
+                "text": "A",
+                "font": "small",
+            }
+        ],
+    }
+    resp = client.display(
+        payload,
+        session_id="bar-1",
+        clear_before_draw=True,
+        audio_payload={"stock_path": "shared/sfx.snd"},
+    )
+    assert resp.result == "OK"
+    assert seen == [
+        {
+            "method": "DELETE",
+            "path": "/api/display/draw",
+            "params": {"application_name": "demo"},
+            "body": None,
+            "session": "bar-1",
+        },
+        {
+            "method": "POST",
+            "path": "/api/display/draw",
+            "params": {},
+            "body": normalized_payload,
+            "session": "bar-1",
+        },
+        {
+            "method": "POST",
+            "path": "/api/audio/play",
+            "params": {},
+            "body": {"stock_path": "shared/sfx.snd"},
+            "session": "bar-1",
+        },
+    ]
+
+
+def test_display_draw_can_sanitize_text_payload(caplog) -> None:
+    """
+    Validate sanitize_text for sync display_draw.
+    """
+
+    seen: dict[str, str] = {}
+
+    def responder(request: httpx.Request) -> httpx.Response:
+        body = request.content.decode("utf-8")
+        seen["body"] = body
+        return httpx.Response(200, json={"result": "OK"})
+
+    client = make_client(responder)
+    caplog.set_level("WARNING", logger="busylib.client.display")
+    payload = {
+        "application_name": "demo",
+        "elements": [
+            {
+                "id": "1",
+                "type": "text",
+                "x": 0,
+                "y": 0,
+                "text": "Demo 🚀\nmeeting",
+                "display": "front",
+                "font": "small",
+            }
+        ],
+    }
+    resp = client.display_draw(payload, sanitize_text=True)
+    assert resp.result == "OK"
+    assert "Demo meeting" in seen["body"]
+    assert "🚀" not in seen["body"]
+    assert (
+        "Sanitized display text element_id=1 display=front "
+        "text_before='Demo 🚀\\nmeeting' text_after='Demo meeting'"
+    ) in caplog.text
+
+
+def test_screen_returns_bytes():
     """
     Return raw bytes for screen frame requests.
 
@@ -360,25 +580,25 @@ def test_get_screen_frame_returns_bytes():
         return httpx.Response(200, content=expected)
 
     client = make_client(responder)
-    data = client.get_screen_frame(1)
+    data = client.screen(1)
     assert data == expected
 
 
 @pytest.mark.parametrize(
     "method,path",
     [
-        ("play_audio", "/api/audio/play"),
-        ("stop_audio", "/api/audio/play"),
-        ("clear_display", "/api/display/draw"),
-        ("remove_storage_file", "/api/storage/remove"),
-        ("create_storage_directory", "/api/storage/mkdir"),
-        ("delete_app_assets", "/api/assets/upload"),
-        ("enable_wifi", "/api/wifi/enable"),
-        ("disable_wifi", "/api/wifi/disable"),
-        ("disconnect_wifi", "/api/wifi/disconnect"),
+        ("audio_play", "/api/audio/play"),
+        ("audio_stop", "/api/audio/play"),
+        ("display_clear", "/api/display/draw"),
+        ("storage_remove", "/api/storage/remove"),
+        ("storage_mkdir", "/api/storage/mkdir"),
+        ("assets_delete", "/api/assets/upload"),
+        ("wifi_enable", "/api/wifi/enable"),
+        ("wifi_disable", "/api/wifi/disable"),
+        ("wifi_disconnect", "/api/wifi/disconnect"),
         ("ble_enable", "/api/ble/enable"),
         ("ble_disable", "/api/ble/disable"),
-        ("ble_forget_pairing", "/api/ble/pairing"),
+        ("ble_pairing_forget", "/api/ble/pairing"),
     ],
 )
 def test_simple_success_methods(method: str, path: str):
@@ -395,20 +615,20 @@ def test_simple_success_methods(method: str, path: str):
     client = make_client(responder)
     func = getattr(client, method)
     # supply required args when needed
-    if method == "play_audio":
-        resp = func("app", "file")
-    elif method in {"remove_storage_file", "create_storage_directory"}:
+    if method == "audio_play":
+        resp = func(path="file")
+    elif method in {"storage_remove", "storage_mkdir"}:
         resp = func("/tmp")
-    elif method == "delete_app_assets":
+    elif method == "assets_delete":
         resp = func("app")
-    elif method == "disconnect_wifi":
+    elif method == "wifi_disconnect":
         resp = func()
     else:
         resp = func()
     assert resp.result == "OK"
 
 
-def test_connect_wifi_serialization():
+def test_wifi_connect_serialization():
     """
     Serialize Wi-Fi configuration into JSON payload.
 
@@ -422,7 +642,7 @@ def test_connect_wifi_serialization():
 
     cfg = {"ssid": "TestNetwork", "password": "secret", "security": "WPA2"}
     client = make_client(responder)
-    resp = client.connect_wifi(cfg)
+    resp = client.wifi_connect(cfg)
     assert resp.result == "OK"
     assert seen["body"]["ssid"] == "TestNetwork"
     assert seen["body"]["security"] == "WPA2"
@@ -442,16 +662,16 @@ def test_display_brightness_validation_and_payload():
         return httpx.Response(200, json={"result": "OK"})
 
     client = make_client(responder)
-    resp = client.set_display_brightness("auto")
+    resp = client.display_brightness_set("auto")
     assert resp.result == "OK"
     assert seen["params"] == {"value": "auto"}
     assert seen["content"] == b""
 
     with pytest.raises(ValueError):
-        client.set_display_brightness("invalid")  # type: ignore[arg-type]
+        client.display_brightness_set("invalid")  # type: ignore[arg-type]
 
 
-def test_set_audio_volume_params():
+def test_audio_volume_set_params():
     """
     Validate audio volume query parameters.
 
@@ -465,13 +685,13 @@ def test_set_audio_volume_params():
         return httpx.Response(200, json={"result": "OK"})
 
     client = make_client(responder)
-    resp = client.set_audio_volume(42.5)
+    resp = client.audio_volume_set(42.5)
     assert resp.result == "OK"
     assert seen["params"] == {"volume": "42.5"}
     assert seen["content"] == b""
 
 
-def test_draw_on_display_color_serialization():
+def test_display_draw_color_serialization():
     """
     Serialize color strings into hex RGBA values.
 
@@ -500,13 +720,13 @@ def test_draw_on_display_color_serialization():
         application_name="app",
         elements=elements,
     )
-    resp = client.draw_on_display(display)
+    resp = client.display_draw(display)
     assert resp.result == "OK"
     color = seen["body"]["elements"][0]["color"]
     assert color == "#FF000080"
 
 
-def test_draw_on_display_color_tuple_alpha():
+def test_display_draw_color_tuple_alpha():
     """
     Serialize color tuples with alpha into hex RGBA values.
 
@@ -535,7 +755,7 @@ def test_draw_on_display_color_tuple_alpha():
         application_name="app",
         elements=elements,
     )
-    resp = client.draw_on_display(display)
+    resp = client.display_draw(display)
     assert resp.result == "OK"
     color = seen["body"]["elements"][0]["color"]
     assert color == "#FFFFFF64"

--- a/tests/busylib/client/test_client_async.py
+++ b/tests/busylib/client/test_client_async.py
@@ -17,7 +17,7 @@ def make_client(async_responder, **kwargs) -> AsyncBusyBar:
 
 
 @pytest.mark.asyncio
-async def test_get_version_success_async():
+async def test_version_success_async():
     """
     Parse version information from the async client.
 
@@ -29,14 +29,14 @@ async def test_get_version_success_async():
         return httpx.Response(200, json={"api_semver": "2.0.0", "branch": "dev"})
 
     client = make_client(responder, api_version="2.0.0")
-    result = await client.get_version()
+    result = await client.version()
     assert isinstance(result, types.VersionInfo)
     assert result.api_semver == "2.0.0"
     await client.aclose()
 
 
 @pytest.mark.asyncio
-async def test_get_device_name_and_time_async():
+async def test_name_and_time_async():
     """
     Fetch name and time via async client calls.
 
@@ -51,15 +51,15 @@ async def test_get_device_name_and_time_async():
         return httpx.Response(404, json={"error": "missing", "code": 404})
 
     client = make_client(responder)
-    name = await client.get_device_name()
+    name = await client.name()
     assert name.name == "BusyBar"
-    time_info = await client.get_device_time()
+    time_info = await client.time()
     assert time_info.timestamp == "2024-01-01T10:00:00"
     await client.aclose()
 
 
 @pytest.mark.asyncio
-async def test_set_device_name_async() -> None:
+async def test_name_set_async() -> None:
     """
     Send device name update payload via async POST /api/name.
     """
@@ -72,7 +72,7 @@ async def test_set_device_name_async() -> None:
         return httpx.Response(200, json={"result": "OK"})
 
     client = make_client(responder)
-    resp = await client.set_device_name("Busy Desk")
+    resp = await client.name_set("Busy Desk")
     assert resp.result == "OK"
     assert seen["path"] == "/api/name"
     assert seen["method"] == "POST"
@@ -81,18 +81,18 @@ async def test_set_device_name_async() -> None:
 
 
 @pytest.mark.asyncio
-async def test_set_device_name_async_rejects_empty() -> None:
+async def test_name_set_async_rejects_empty() -> None:
     """
     Reject empty device names before async request send.
     """
     client = make_client(lambda _request: httpx.Response(200, json={"result": "OK"}))
     with pytest.raises(ValueError):
-        await client.set_device_name("")
+        await client.name_set("")
     await client.aclose()
 
 
 @pytest.mark.asyncio
-async def test_get_account_info_async():
+async def test_account_info_async():
     """
     Parse linked account info from the async client.
     """
@@ -102,14 +102,14 @@ async def test_get_account_info_async():
         return httpx.Response(200, json={"linked": False, "email": "name@example.com"})
 
     client = make_client(responder)
-    result = await client.get_account_info()
+    result = await client.account_info()
     assert result.linked is False
     assert result.email == "name@example.com"
     await client.aclose()
 
 
 @pytest.mark.asyncio
-async def test_get_account_status_async():
+async def test_account_status_async():
     """
     Parse MQTT account state from the async client.
     """
@@ -119,13 +119,13 @@ async def test_get_account_status_async():
         return httpx.Response(200, json={"state": "connected"})
 
     client = make_client(responder)
-    result = await client.get_account_status()
+    result = await client.account_status()
     assert result.state == "connected"
     await client.aclose()
 
 
 @pytest.mark.asyncio
-async def test_link_account_async():
+async def test_account_link_async():
     """
     Parse account link response from the async client.
     """
@@ -135,7 +135,7 @@ async def test_link_account_async():
         return httpx.Response(200, json={"code": "EFGH", "expires_at": 1700000001})
 
     client = make_client(responder)
-    result = await client.link_account()
+    result = await client.account_link()
     assert result.code == "EFGH"
     assert result.expires_at == 1700000001
     await client.aclose()
@@ -157,14 +157,14 @@ async def test_async_retry_on_transport_error():
         return httpx.Response(200, json={"result": "OK"})
 
     client = make_client(responder, max_retries=1, backoff=0.0)
-    resp = await client.enable_wifi()
+    resp = await client.wifi_enable()
     assert resp.result == "OK"
     assert calls["count"] == 2
     await client.aclose()
 
 
 @pytest.mark.asyncio
-async def test_draw_on_display_utf8_async():
+async def test_display_draw_utf8_async():
     """
     Ensure async display payloads preserve UTF-8 content.
 
@@ -192,8 +192,195 @@ async def test_draw_on_display_utf8_async():
         return httpx.Response(200, json={"result": "OK"})
 
     client = make_client(responder)
-    resp = await client.draw_on_display(payload)
+    resp = await client.display_draw(payload)
     assert resp.result == "OK"
+    await client.aclose()
+
+
+@pytest.mark.asyncio
+async def test_display_draw_and_clear_params_async() -> None:
+    """
+    Validate async display_draw and display_clear session header.
+    """
+
+    seen: list[dict[str, object]] = []
+
+    async def responder(request: httpx.Request) -> httpx.Response:
+        seen.append(
+            {
+                "path": request.url.path,
+                "method": request.method,
+                "params": dict(request.url.params),
+                "session": request.headers.get("x-session-id"),
+            }
+        )
+        return httpx.Response(200, json={"result": "OK"})
+
+    client = make_client(responder)
+    payload = {
+        "application_name": "demo",
+        "elements": [
+            {"id": "1", "type": "text", "x": 0, "y": 0, "text": "A", "font": "small"}
+        ],
+    }
+    draw_resp = await client.display_draw(payload, session_id="bar-2")
+    clear_resp = await client.display_clear(
+        application_name="demo",
+        session_id="bar-2",
+    )
+    assert draw_resp.result == "OK"
+    assert clear_resp.result == "OK"
+    assert seen[0]["path"] == "/api/display/draw"
+    assert seen[0]["method"] == "POST"
+    assert seen[0]["session"] == "bar-2"
+    assert seen[1]["path"] == "/api/display/draw"
+    assert seen[1]["method"] == "DELETE"
+    assert seen[1]["params"] == {"application_name": "demo"}
+    assert seen[1]["session"] == "bar-2"
+    await client.aclose()
+
+
+@pytest.mark.asyncio
+async def test_display_draw_can_clear_before_draw_async() -> None:
+    """
+    Validate async clear_before_draw in display_draw.
+    """
+
+    seen: list[tuple[str, str, dict[str, str]]] = []
+
+    async def responder(request: httpx.Request) -> httpx.Response:
+        seen.append((request.method, request.url.path, dict(request.url.params)))
+        return httpx.Response(200, json={"result": "OK"})
+
+    client = make_client(responder)
+    payload = {
+        "application_name": "demo",
+        "elements": [
+            {"id": "1", "type": "text", "x": 0, "y": 0, "text": "A", "font": "small"}
+        ],
+    }
+    resp = await client.display_draw(payload, clear_before_draw=True)
+    assert resp.result == "OK"
+    assert seen[0] == (
+        "DELETE",
+        "/api/display/draw",
+        {"application_name": "demo"},
+    )
+    assert seen[1][0] == "POST"
+    await client.aclose()
+
+
+@pytest.mark.asyncio
+async def test_display_can_clear_draw_and_audio_play_async() -> None:
+    """
+    Validate async high-level display flow: clear, draw, and audio_play.
+    """
+
+    seen: list[dict[str, object]] = []
+
+    async def responder(request: httpx.Request) -> httpx.Response:
+        seen.append(
+            {
+                "method": request.method,
+                "path": request.url.path,
+                "params": dict(request.url.params),
+                "body": json.loads(request.content) if request.content else None,
+                "session": request.headers.get("x-session-id"),
+            }
+        )
+        return httpx.Response(200, json={"result": "OK"})
+
+    client = make_client(responder)
+    payload = {
+        "application_name": "demo",
+        "elements": [
+            {"id": "1", "type": "text", "x": 0, "y": 0, "text": "A", "font": "small"}
+        ],
+    }
+    normalized_payload = {
+        "application_name": "demo",
+        "priority": 50,
+        "elements": [
+            {
+                "id": "1",
+                "display": "front",
+                "type": "text",
+                "x": 0,
+                "y": 0,
+                "text": "A",
+                "font": "small",
+            }
+        ],
+    }
+    resp = await client.display(
+        payload,
+        session_id="bar-2",
+        clear_before_draw=True,
+        audio_payload={"stock_path": "shared/sfx.snd"},
+    )
+    assert resp.result == "OK"
+    assert seen == [
+        {
+            "method": "DELETE",
+            "path": "/api/display/draw",
+            "params": {"application_name": "demo"},
+            "body": None,
+            "session": "bar-2",
+        },
+        {
+            "method": "POST",
+            "path": "/api/display/draw",
+            "params": {},
+            "body": normalized_payload,
+            "session": "bar-2",
+        },
+        {
+            "method": "POST",
+            "path": "/api/audio/play",
+            "params": {},
+            "body": {"stock_path": "shared/sfx.snd"},
+            "session": "bar-2",
+        },
+    ]
+    await client.aclose()
+
+
+@pytest.mark.asyncio
+async def test_display_draw_can_sanitize_text_payload_async(caplog) -> None:
+    """
+    Validate sanitize_text for async display_draw.
+    """
+
+    seen: dict[str, str] = {}
+
+    async def responder(request: httpx.Request) -> httpx.Response:
+        seen["body"] = request.content.decode("utf-8")
+        return httpx.Response(200, json={"result": "OK"})
+
+    client = make_client(responder)
+    caplog.set_level("WARNING", logger="busylib.client.display")
+    payload = {
+        "application_name": "demo",
+        "elements": [
+            {
+                "id": "1",
+                "type": "text",
+                "x": 0,
+                "y": 0,
+                "text": "Demo 🚀\nmeeting",
+                "display": "front",
+                "font": "small",
+            }
+        ],
+    }
+    resp = await client.display_draw(payload, sanitize_text=True)
+    assert resp.result == "OK"
+    assert "Demo meeting" in seen["body"]
+    assert "🚀" not in seen["body"]
+    assert (
+        "Sanitized display text element_id=1 display=front "
+        "text_before='Demo 🚀\\nmeeting' text_after='Demo meeting'"
+    ) in caplog.text
     await client.aclose()
 
 
@@ -210,12 +397,12 @@ async def test_error_response_raises_api_error_async():
 
     client = make_client(responder)
     with pytest.raises(exceptions.BusyBarAPIError):
-        await client.get_status()
+        await client.status()
     await client.aclose()
 
 
 @pytest.mark.asyncio
-async def test_async_set_display_brightness_params():
+async def test_async_display_brightness_set_params():
     """
     Validate async display brightness params and empty body.
 
@@ -229,7 +416,7 @@ async def test_async_set_display_brightness_params():
         return httpx.Response(200, json={"result": "OK"})
 
     client = make_client(responder)
-    resp = await client.set_display_brightness("auto")
+    resp = await client.display_brightness_set("auto")
     assert resp.result == "OK"
     assert seen["params"] == {"value": "auto"}
     assert seen["content"] == b""

--- a/tests/busylib/client/test_client_mixins.py
+++ b/tests/busylib/client/test_client_mixins.py
@@ -37,13 +37,13 @@ def test_assets_upload_and_delete_sync() -> None:
         return httpx.Response(200, json={"result": "OK"})
 
     client = _make_sync_client(responder)
-    resp = client.upload_asset("app", "file.bin", b"data")
+    resp = client.assets_upload("app", "file.bin", b"data")
     assert resp.result == "OK"
     assert seen["path"] == "/api/assets/upload"
     assert seen["params"] == {"application_name": "app", "file": "file.bin"}
     assert seen["body"] == b"data"
 
-    resp = client.delete_app_assets("app")
+    resp = client.assets_delete("app")
     assert resp.result == "OK"
 
 
@@ -66,7 +66,7 @@ def test_assets_upload_sync_uses_extended_timeout_by_default(
         return {"result": "OK"}
 
     monkeypatch.setattr(client, "_request", fake_request)
-    resp = client.upload_asset("app", "file.bin", b"data")
+    resp = client.assets_upload("app", "file.bin", b"data")
     assert resp.result == "OK"
     assert captured["timeout"] == assets_client.ASSET_UPLOAD_TIMEOUT
 
@@ -90,7 +90,7 @@ def test_assets_upload_sync_allows_timeout_override(
         return {"result": "OK"}
 
     monkeypatch.setattr(client, "_request", fake_request)
-    resp = client.upload_asset("app", "file.bin", b"data", timeout=7.5)
+    resp = client.assets_upload("app", "file.bin", b"data", timeout=7.5)
     assert resp.result == "OK"
     assert captured["timeout"] == 7.5
 
@@ -113,13 +113,13 @@ async def test_assets_upload_and_delete_async() -> None:
         return httpx.Response(200, json={"result": "OK"})
 
     client = _make_async_client(responder)
-    resp = await client.upload_asset("app", "file.bin", b"data")
+    resp = await client.assets_upload("app", "file.bin", b"data")
     assert resp.result == "OK"
     assert seen[0]["path"] == "/api/assets/upload"
     assert seen[0]["params"] == {"application_name": "app", "file": "file.bin"}
     assert seen[0]["body"] == b"data"
 
-    resp = await client.delete_app_assets("app")
+    resp = await client.assets_delete("app")
     assert resp.result == "OK"
     await client.aclose()
 
@@ -144,7 +144,7 @@ async def test_assets_upload_async_uses_extended_timeout_by_default(
         return {"result": "OK"}
 
     monkeypatch.setattr(client, "_request", fake_request)
-    resp = await client.upload_asset("app", "file.bin", b"data")
+    resp = await client.assets_upload("app", "file.bin", b"data")
     assert resp.result == "OK"
     assert captured["timeout"] == assets_client.ASSET_UPLOAD_TIMEOUT
     await client.aclose()
@@ -170,7 +170,7 @@ async def test_assets_upload_async_allows_timeout_override(
         return {"result": "OK"}
 
     monkeypatch.setattr(client, "_request", fake_request)
-    resp = await client.upload_asset("app", "file.bin", b"data", timeout=9.5)
+    resp = await client.assets_upload("app", "file.bin", b"data", timeout=9.5)
     assert resp.result == "OK"
     assert captured["timeout"] == 9.5
     await client.aclose()
@@ -195,9 +195,9 @@ def test_ble_and_wifi_status_sync() -> None:
     client = _make_sync_client(responder)
     ble = client.ble_status()
     assert ble.state == "on"
-    status = client.get_wifi_status()
+    status = client.wifi_status()
     assert status.ssid == "Test"
-    networks = client.scan_wifi_networks()
+    networks = client.wifi_networks()
     assert networks.count == 0
     assert seen == ["/api/ble/status", "/api/wifi/status", "/api/wifi/networks"]
 
@@ -217,10 +217,10 @@ def test_access_mode_sync() -> None:
         return httpx.Response(200, json={"result": "OK"})
 
     client = _make_sync_client(responder)
-    info = client.get_http_access()
+    info = client.access()
     assert info.mode == "key"
     assert info.key_valid is True
-    resp = client.set_http_access("enabled", "1234")
+    resp = client.access_set("enabled", "1234")
     assert resp.result == "OK"
     assert seen == [
         {"path": "/api/access", "params": {}},
@@ -254,12 +254,12 @@ def test_busy_snapshot_sync() -> None:
         return httpx.Response(200, json={"result": "OK"})
 
     client = _make_sync_client(responder)
-    snapshot = client.get_busy_snapshot()
+    snapshot = client.busy_snapshot()
     assert snapshot.snapshot.type == "SIMPLE"
     assert snapshot.snapshot.card_id == "card"
     assert snapshot.snapshot.time_left_ms == 9000
     assert snapshot.snapshot.is_paused is False
-    resp = client.set_busy_snapshot(snapshot)
+    resp = client.busy_snapshot_set(snapshot)
     assert resp.result == "OK"
     assert len(seen) == 2
     assert seen[0]["path"] == "/api/busy/snapshot"
@@ -286,9 +286,9 @@ async def test_ble_and_wifi_status_async() -> None:
     client = _make_async_client(responder)
     ble = await client.ble_status()
     assert ble.state == "on"
-    status = await client.get_wifi_status()
+    status = await client.wifi_status()
     assert status.ssid == "Test"
-    networks = await client.scan_wifi_networks()
+    networks = await client.wifi_networks()
     assert networks.count == 0
     assert seen == ["/api/ble/status", "/api/wifi/status", "/api/wifi/networks"]
     await client.aclose()
@@ -310,10 +310,10 @@ async def test_access_mode_async() -> None:
         return httpx.Response(200, json={"result": "OK"})
 
     client = _make_async_client(responder)
-    info = await client.get_http_access()
+    info = await client.access()
     assert info.mode == "key"
     assert info.key_valid is True
-    resp = await client.set_http_access("enabled", "1234")
+    resp = await client.access_set("enabled", "1234")
     assert resp.result == "OK"
     assert seen == [
         {"path": "/api/access", "params": {}},
@@ -349,12 +349,12 @@ async def test_busy_snapshot_async() -> None:
         return httpx.Response(200, json={"result": "OK"})
 
     client = _make_async_client(responder)
-    snapshot = await client.get_busy_snapshot()
+    snapshot = await client.busy_snapshot()
     assert snapshot.snapshot.type == "SIMPLE"
     assert snapshot.snapshot.card_id == "card"
     assert snapshot.snapshot.time_left_ms == 9000
     assert snapshot.snapshot.is_paused is False
-    resp = await client.set_busy_snapshot(snapshot)
+    resp = await client.busy_snapshot_set(snapshot)
     assert resp.result == "OK"
     assert len(seen) == 2
     assert seen[0]["path"] == "/api/busy/snapshot"
@@ -362,7 +362,7 @@ async def test_busy_snapshot_async() -> None:
     await client.aclose()
 
 
-def test_updater_update_firmware_sync() -> None:
+def test_updater_update_sync() -> None:
     """
     Ensure firmware update sends raw body without params.
     """
@@ -374,7 +374,7 @@ def test_updater_update_firmware_sync() -> None:
         return httpx.Response(200, json={"result": "OK"})
 
     client = _make_sync_client(responder)
-    resp = client.update_firmware(b"fw")
+    resp = client.update(b"fw")
     assert resp.result == "OK"
     assert seen["params"] == {}
     assert seen["body"] == b"fw"
@@ -391,9 +391,9 @@ def test_time_endpoints_sync() -> None:
         return httpx.Response(200, json={"result": "OK"})
 
     client = _make_sync_client(responder)
-    resp = client.set_time_timestamp("2025-10-02T14:30:45+04:00")
+    resp = client.time_timestamp("2025-10-02T14:30:45+04:00")
     assert resp.result == "OK"
-    resp = client.set_time_timezone("Europe/Moscow")
+    resp = client.time_timezone("Europe/Moscow")
     assert resp.result == "OK"
     assert seen == [
         {
@@ -405,7 +405,7 @@ def test_time_endpoints_sync() -> None:
 
 
 @pytest.mark.asyncio
-async def test_updater_update_firmware_async() -> None:
+async def test_updater_update_async() -> None:
     """
     Ensure async firmware update omits params.
     """
@@ -416,7 +416,7 @@ async def test_updater_update_firmware_async() -> None:
         return httpx.Response(200, json={"result": "OK"})
 
     client = _make_async_client(responder)
-    resp = await client.update_firmware(b"fw")
+    resp = await client.update(b"fw")
     assert resp.result == "OK"
     await client.aclose()
 
@@ -433,9 +433,9 @@ async def test_time_endpoints_async() -> None:
         return httpx.Response(200, json={"result": "OK"})
 
     client = _make_async_client(responder)
-    resp = await client.set_time_timestamp("2025-10-02T14:30:45+04:00")
+    resp = await client.time_timestamp("2025-10-02T14:30:45+04:00")
     assert resp.result == "OK"
-    resp = await client.set_time_timezone("Europe/Moscow")
+    resp = await client.time_timezone("Europe/Moscow")
     assert resp.result == "OK"
     assert seen == [
         {
@@ -463,15 +463,15 @@ def test_updater_check_status_and_changelog_sync() -> None:
         return httpx.Response(200, json={"result": "OK"})
 
     client = _make_sync_client(responder)
-    resp = client.check_firmware_update()
+    resp = client.update_check()
     assert resp.result == "OK"
-    status = client.get_update_status()
+    status = client.update_status()
     assert status.install is not None
-    changelog = client.get_update_changelog("1.2.3")
+    changelog = client.update_changelog("1.2.3")
     assert changelog.changelog == "Fixes"
-    resp = client.install_firmware_update("1.2.3")
+    resp = client.update_install("1.2.3")
     assert resp.result == "OK"
-    resp = client.abort_firmware_download()
+    resp = client.update_abort_download()
     assert resp.result == "OK"
     assert seen == [
         "/api/update/check",
@@ -499,15 +499,15 @@ async def test_updater_check_status_and_changelog_async() -> None:
         return httpx.Response(200, json={"result": "OK"})
 
     client = _make_async_client(responder)
-    resp = await client.check_firmware_update()
+    resp = await client.update_check()
     assert resp.result == "OK"
-    status = await client.get_update_status()
+    status = await client.update_status()
     assert status.check is not None
-    changelog = await client.get_update_changelog("2.0.0")
+    changelog = await client.update_changelog("2.0.0")
     assert changelog.changelog == "New"
-    resp = await client.install_firmware_update("2.0.0")
+    resp = await client.update_install("2.0.0")
     assert resp.result == "OK"
-    resp = await client.abort_firmware_download()
+    resp = await client.update_abort_download()
     assert resp.result == "OK"
     assert seen == [
         "/api/update/check",

--- a/tests/busylib/client/test_display_ws.py
+++ b/tests/busylib/client/test_display_ws.py
@@ -61,7 +61,7 @@ class DummyWebSocket:
 
 
 @pytest.mark.asyncio
-async def test_stream_screen_ws_uses_query_token(
+async def test_screen_ws_uses_query_token(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """
@@ -86,7 +86,7 @@ async def test_stream_screen_ws_uses_query_token(
 
     client = AsyncBusyBar(addr="http://device.local", token="secret")
     client.client.headers["Connection"] = "keep-alive"
-    async for _frame in client.stream_screen_ws(0):
+    async for _frame in client.screen_ws(0):
         pass
     await client.aclose()
 
@@ -105,7 +105,7 @@ async def test_stream_screen_ws_uses_query_token(
 
 
 @pytest.mark.asyncio
-async def test_stream_screen_ws_wraps_connection_errors(
+async def test_screen_ws_wraps_connection_errors(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """
@@ -119,7 +119,7 @@ async def test_stream_screen_ws_wraps_connection_errors(
 
     client = AsyncBusyBar(addr="http://device.local", token="secret")
     with pytest.raises(exceptions.BusyBarWebSocketError) as exc:
-        async for _frame in client.stream_screen_ws(0):
+        async for _frame in client.screen_ws(0):
             pass
     await client.aclose()
 

--- a/tests/busylib/client/test_input.py
+++ b/tests/busylib/client/test_input.py
@@ -22,7 +22,7 @@ def _make_async_client(responder) -> AsyncBusyBar:
     return AsyncBusyBar(addr="http://device.local", transport=transport)
 
 
-def test_send_input_key_sync() -> None:
+def test_input_sync() -> None:
     """
     Ensure sync input key events send the correct key parameter.
     """
@@ -39,13 +39,13 @@ def test_send_input_key_sync() -> None:
         return httpx.Response(200, json={"result": "OK"})
 
     client = _make_sync_client(responder)
-    resp = client.send_input_key(types.InputKey.OK)
+    resp = client.input(types.InputKey.OK)
     assert resp.result == "OK"
     assert seen == [{"path": "/api/input", "params": {"key": "ok"}, "method": "POST"}]
 
 
 @pytest.mark.asyncio
-async def test_send_input_key_async() -> None:
+async def test_input_async() -> None:
     """
     Ensure async input key events send the correct key parameter.
     """
@@ -62,7 +62,7 @@ async def test_send_input_key_async() -> None:
         return httpx.Response(200, json={"result": "OK"})
 
     client = _make_async_client(responder)
-    resp = await client.send_input_key(types.InputKey.OK)
+    resp = await client.input(types.InputKey.OK)
     assert resp.result == "OK"
     await client.aclose()
     assert seen == [{"path": "/api/input", "params": {"key": "ok"}, "method": "POST"}]

--- a/tests/busylib/client/test_status_ws.py
+++ b/tests/busylib/client/test_status_ws.py
@@ -1,4 +1,5 @@
 import json
+from typing import Any, cast
 
 import pytest
 
@@ -60,7 +61,8 @@ async def test_stream_status_ws_decodes_protobuf(
     """
     Decode binary protobuf payloads from /api/status/ws into dictionaries.
     """
-    message = state_pb2.State(timestamp=123)
+    state_schema = cast(Any, state_pb2)
+    message = state_schema.State(timestamp=123)
     update = message.updates.add()
     update.device_name.name = "BUSY"
     payload = message.SerializeToString()
@@ -86,8 +88,9 @@ async def test_stream_status_ws_decodes_protobuf(
 
     assert ws.sent == [json.dumps({"enable": True})]
     assert isinstance(items[0], dict)
-    assert items[0]["timestamp"] == "123"
-    assert items[0]["updates"][0]["device_name"]["name"] == "BUSY"
+    decoded = cast(dict[str, Any], items[0])
+    assert decoded["timestamp"] == "123"
+    assert decoded["updates"][0]["device_name"]["name"] == "BUSY"
     assert "x-api-token=secret" in str(captured["url"])
     assert isinstance(captured["kwargs"], dict)
     assert captured["kwargs"]["max_size"] == 4 * 1024 * 1024

--- a/tests/busylib/client/test_storage.py
+++ b/tests/busylib/client/test_storage.py
@@ -28,6 +28,8 @@ class _DummyStorage(StorageMixin):
         *,
         params: dict[str, object] | None = None,
         headers: dict[str, str] | None = None,
+        session_id: str | None = None,
+        application_name: str | None = None,
         json_payload: JsonType | None = None,
         data: bytes | Iterable[bytes] | None = None,
         expect_bytes: bool = False,
@@ -46,6 +48,8 @@ class _DummyStorage(StorageMixin):
                 "path": path,
                 "params": params,
                 "headers": headers,
+                "session_id": session_id,
+                "application_name": application_name,
                 "json_payload": json_payload,
                 "data": payload,
                 "expect_bytes": expect_bytes,
@@ -78,6 +82,8 @@ class _DummyAsyncStorage(AsyncStorageMixin):
         *,
         params: dict[str, object] | None = None,
         headers: dict[str, str] | None = None,
+        session_id: str | None = None,
+        application_name: str | None = None,
         json_payload: JsonType | None = None,
         data: bytes | AsyncIterable[bytes] | None = None,
         expect_bytes: bool = False,
@@ -99,6 +105,8 @@ class _DummyAsyncStorage(AsyncStorageMixin):
                 "path": path,
                 "params": params,
                 "headers": headers,
+                "session_id": session_id,
+                "application_name": application_name,
                 "json_payload": json_payload,
                 "data": payload,
                 "expect_bytes": expect_bytes,
@@ -113,7 +121,7 @@ class _DummyAsyncStorage(AsyncStorageMixin):
         return {"result": "ok"}
 
 
-def test_write_storage_file_sync_progress(monkeypatch) -> None:
+def test_storage_write_sync_progress(monkeypatch) -> None:
     """
     Verify sync write uses converted path and reports progress.
     """
@@ -134,7 +142,7 @@ def test_write_storage_file_sync_progress(monkeypatch) -> None:
     monkeypatch.setattr("busylib.client.storage.convert_for_storage", _fake_convert)
     client = _DummyStorage()
 
-    resp = client.write_storage_file(
+    resp = client.storage_write(
         "/ext/test.txt",
         b"abc",
         progress_callback=_on_progress,
@@ -152,7 +160,7 @@ def test_write_storage_file_sync_progress(monkeypatch) -> None:
 
 
 @pytest.mark.asyncio
-async def test_write_storage_file_async_progress(monkeypatch) -> None:
+async def test_storage_write_async_progress(monkeypatch) -> None:
     """
     Verify async write uses converted path and reports progress.
     """
@@ -173,7 +181,7 @@ async def test_write_storage_file_async_progress(monkeypatch) -> None:
     monkeypatch.setattr("busylib.client.storage.convert_for_storage", _fake_convert)
     client = _DummyAsyncStorage()
 
-    resp = await client.write_storage_file(
+    resp = await client.storage_write(
         "/ext/test.txt",
         b"abc",
         progress_callback=_on_progress,
@@ -195,9 +203,9 @@ def test_read_list_remove_sync() -> None:
     Ensure sync storage read/list/remove wire the right requests.
     """
     client = _DummyStorage()
-    client.read_storage_file("/ext/a.txt")
-    client.list_storage_files("/ext")
-    client.remove_storage_file("/ext/a.txt")
+    client.storage_read("/ext/a.txt")
+    client.storage_list("/ext")
+    client.storage_remove("/ext/a.txt")
 
     assert client.calls[0]["path"] == "/api/storage/read"
     assert client.calls[0]["params"] == {"path": "/ext/a.txt"}
@@ -214,9 +222,9 @@ async def test_read_list_remove_async() -> None:
     Ensure async storage read/list/remove wire the right requests.
     """
     client = _DummyAsyncStorage()
-    await client.read_storage_file("/ext/a.txt")
-    await client.list_storage_files("/ext")
-    await client.remove_storage_file("/ext/a.txt")
+    await client.storage_read("/ext/a.txt")
+    await client.storage_list("/ext")
+    await client.storage_remove("/ext/a.txt")
 
     assert client.calls[0]["path"] == "/api/storage/read"
     assert client.calls[0]["params"] == {"path": "/ext/a.txt"}
@@ -227,7 +235,7 @@ async def test_read_list_remove_async() -> None:
     assert client.calls[2]["params"] == {"path": "/ext/a.txt"}
 
 
-def test_write_storage_file_sync_raises_conversion_error(
+def test_storage_write_sync_raises_conversion_error(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """
@@ -247,11 +255,11 @@ def test_write_storage_file_sync_raises_conversion_error(
     client = _DummyStorage()
 
     with pytest.raises(exceptions.BusyBarConversionError):
-        client.write_storage_file("/ext/test.mp3", b"abc")
+        client.storage_write("/ext/test.mp3", b"abc")
 
 
 @pytest.mark.asyncio
-async def test_write_storage_file_async_raises_conversion_error(
+async def test_storage_write_async_raises_conversion_error(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """
@@ -271,4 +279,4 @@ async def test_write_storage_file_async_raises_conversion_error(
     client = _DummyAsyncStorage()
 
     with pytest.raises(exceptions.BusyBarConversionError):
-        await client.write_storage_file("/ext/test.mp3", b"abc")
+        await client.storage_write("/ext/test.mp3", b"abc")

--- a/tests/busylib/features/test_dashboard.py
+++ b/tests/busylib/features/test_dashboard.py
@@ -21,55 +21,55 @@ class _OkClient:
     The stub returns minimal payloads compatible with target response models.
     """
 
-    async def get_device_name(self) -> types.DeviceNameResponse:
+    async def name(self) -> types.DeviceNameResponse:
         """
         Return a valid device name payload.
         """
         return types.DeviceNameResponse(name="Busy")
 
-    async def get_version(self) -> types.VersionInfo:
+    async def version(self) -> types.VersionInfo:
         """
         Return a valid version payload.
         """
         return types.VersionInfo(api_semver="1.0.0")
 
-    async def get_status(self) -> types.Status:
+    async def status(self) -> types.Status:
         """
         Return a valid status payload.
         """
         return types.Status()
 
-    async def get_system_status(self) -> types.StatusSystem:
+    async def status_system(self) -> types.StatusSystem:
         """
         Return a valid system status payload.
         """
         return types.StatusSystem()
 
-    async def get_power_status(self) -> types.StatusPower:
+    async def status_power(self) -> types.StatusPower:
         """
         Return a valid power status payload.
         """
         return types.StatusPower()
 
-    async def get_device_time(self) -> types.DeviceTimeResponse:
+    async def time(self) -> types.DeviceTimeResponse:
         """
         Return a valid ISO timestamp payload.
         """
         return types.DeviceTimeResponse(timestamp="2024-01-01T10:00:00")
 
-    async def get_wifi_status(self) -> types.StatusResponse:
+    async def wifi_status(self) -> types.StatusResponse:
         """
         Return a valid Wi-Fi status payload.
         """
         return types.StatusResponse(state=types.WifiState.CONNECTED)
 
-    async def get_display_brightness(self) -> types.DisplayBrightnessInfo:
+    async def display_brightness(self) -> types.DisplayBrightnessInfo:
         """
         Return a valid display brightness payload.
         """
         return types.DisplayBrightnessInfo(front="10", back="10")
 
-    async def get_audio_volume(self) -> types.AudioVolumeInfo:
+    async def audio_volume(self) -> types.AudioVolumeInfo:
         """
         Return a valid audio volume payload.
         """
@@ -81,7 +81,7 @@ class _OkClient:
         """
         return types.BleStatus(state="on")
 
-    async def get_storage_status(self) -> types.StorageStatus:
+    async def storage_status(self) -> types.StorageStatus:
         """
         Return a valid storage payload.
         """
@@ -92,10 +92,10 @@ class _VolumeFailClient(_OkClient):
     """
     Async client stub with a single failing field for diagnostics coverage.
 
-    All fields succeed except `get_audio_volume`.
+    All fields succeed except `audio_volume`.
     """
 
-    async def get_audio_volume(self) -> types.AudioVolumeInfo:
+    async def audio_volume(self) -> types.AudioVolumeInfo:
         """
         Raise a deterministic error for field-level failure checks.
         """
@@ -145,7 +145,7 @@ def test_apply_state_stream_update_updates_known_fields() -> None:
         name="Old",
         brightness=types.DisplayBrightnessInfo(front="10", back="15"),
     )
-    payload = {
+    payload: dict[str, object] = {
         "updates": [
             {"device_name": {"name": "BUSY"}},
             {
@@ -210,7 +210,7 @@ def test_apply_state_stream_update_sets_update_available_version() -> None:
     This keeps diagnostic field_errors reserved for collection failures.
     """
     start = DeviceSnapshot(name="Stable", field_errors={"volume": "x"})
-    payload = {
+    payload: dict[str, object] = {
         "updates": [
             {"update_check": {"available": {"version": "1.2.3"}}},
         ]


### PR DESCRIPTION
Renamed client endpoint helpers to firmware-aligned API names and removed unsupported legacy aliases.
Moved `application_name`, `session_id`, params, headers, timeout, and request IDs into the shared request layer so endpoint methods keep business arguments small.
Added redacted request diagnostics and compact API error formatting so delivery failures expose method, path, status, body excerpt, and request ID without logging tokens.
Added display orchestration with optional clear-before-draw, optional audio playback, text sanitization warnings, and websocket token quoting.
Updated README, examples, and tests to use `application_name`, `display_draw`, `display_clear`, `audio_play`, `audio_stop`, `audio_volume`, and `audio_volume_set`.
Kept Python 3.10 compatibility by using `typing_extensions` for endpoint kwargs typing.
Excluded generated protobuf files from formatter hooks and documented English-only repository text plus local preflight commands in `AGENTS.md`.
