### PR TITLE
fix: clear full display before draw

### DIFF
--- a/src/busylib/client/display.py
+++ b/src/busylib/client/display.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import json
 import logging
 import re
-from typing import Any, AsyncIterator
+from typing import Any, AsyncIterator, cast
 from urllib.parse import quote, urlparse, urlunparse
 
 import websockets
@@ -169,10 +169,8 @@ class DisplayMixin(SyncClientBase):
                 override_name,
             )
         if clear_before_draw:
-            clear_request_kwargs = {
-                "application_name": model.application_name,
-                **request_kwargs,
-            }
+            clear_request_kwargs = cast(RequestKwargs, dict(request_kwargs))
+            clear_request_kwargs.pop("application_name", None)
             self.display_clear(**clear_request_kwargs)
         payload = model.model_dump(exclude_none=True)
         if sanitize_text:
@@ -361,10 +359,8 @@ class AsyncDisplayMixin(AsyncClientBase):
                 override_name,
             )
         if clear_before_draw:
-            clear_request_kwargs = {
-                "application_name": model.application_name,
-                **request_kwargs,
-            }
+            clear_request_kwargs = cast(RequestKwargs, dict(request_kwargs))
+            clear_request_kwargs.pop("application_name", None)
             await self.display_clear(**clear_request_kwargs)
         payload = model.model_dump(exclude_none=True)
         if sanitize_text:

--- a/tests/busylib/client/test_client.py
+++ b/tests/busylib/client/test_client.py
@@ -450,7 +450,7 @@ def test_display_draw_can_clear_before_draw() -> None:
     assert seen[0] == (
         "DELETE",
         "/api/display/draw",
-        {"application_name": "demo"},
+        {},
     )
     assert seen[1][0] == "POST"
 
@@ -507,7 +507,7 @@ def test_display_can_clear_draw_and_audio_play() -> None:
         {
             "method": "DELETE",
             "path": "/api/display/draw",
-            "params": {"application_name": "demo"},
+            "params": {},
             "body": None,
             "session": "bar-1",
         },

--- a/tests/busylib/client/test_client_async.py
+++ b/tests/busylib/client/test_client_async.py
@@ -264,7 +264,7 @@ async def test_display_draw_can_clear_before_draw_async() -> None:
     assert seen[0] == (
         "DELETE",
         "/api/display/draw",
-        {"application_name": "demo"},
+        {},
     )
     assert seen[1][0] == "POST"
     await client.aclose()
@@ -323,7 +323,7 @@ async def test_display_can_clear_draw_and_audio_play_async() -> None:
         {
             "method": "DELETE",
             "path": "/api/display/draw",
-            "params": {"application_name": "demo"},
+            "params": {},
             "body": None,
             "session": "bar-2",
         },


### PR DESCRIPTION
Display draw with `clear_before_draw=True` now performs a full display clear so a new payload replaces all existing canvas elements.

Explicit `display_clear(application_name=...)` remains available for scoped clears.

Tests now verify that sync and async display clear-before-draw requests do not include `application_name` query params.

Local verification:
- `uv run python -m pre_commit run --all-files`
- `uv run python -m pytest -q`
