### PR TITLE
fix: update display font names

### DIFF
--- a/examples/bc/preview.py
+++ b/examples/bc/preview.py
@@ -287,7 +287,7 @@ def start_text_preview_thread(
                             x=0,
                             y=center_y,
                             text=line,
-                            font="medium",
+                            font="normal",
                             width=width,
                             scroll_rate=1000,
                             display=types.DisplayName.FRONT,

--- a/examples/remote/commands/text.py
+++ b/examples/remote/commands/text.py
@@ -55,8 +55,17 @@ class TextCommand(CommandBase):
         )
         parser.add_argument(
             "--font",
-            choices=["small", "medium", "medium_condensed", "big"],
-            default="big",
+            choices=[
+                "tiny",
+                "small",
+                "normal",
+                "condensed",
+                "bold",
+                "large",
+                "extra_large",
+                "global",
+            ],
+            default="extra_large",
             help="Font name",
         )
         parser.add_argument(

--- a/src/busylib/types.py
+++ b/src/busylib/types.py
@@ -407,6 +407,16 @@ class StorageDirElement(BaseModel):
 
 
 StorageListElement = StorageFileElement | StorageDirElement
+DisplayFontName = Literal[
+    "tiny",
+    "small",
+    "normal",
+    "condensed",
+    "bold",
+    "large",
+    "extra_large",
+    "global",
+]
 
 
 class StorageList(BaseModel):
@@ -437,7 +447,7 @@ class TextElement(DisplayElementBase):
     x: int
     y: int
     text: str
-    font: Literal["small", "medium", "medium_condensed", "big"]
+    font: DisplayFontName
     align: (
         Literal[
             "top_left",

--- a/tests/busylib/client/test_client.py
+++ b/tests/busylib/client/test_client.py
@@ -3,6 +3,7 @@ from typing import Callable
 
 import httpx
 import pytest
+from pydantic import ValidationError
 
 from busylib import BusyBar, exceptions, types
 
@@ -724,6 +725,51 @@ def test_display_draw_color_serialization():
     assert resp.result == "OK"
     color = seen["body"]["elements"][0]["color"]
     assert color == "#FF000080"
+
+
+def test_text_element_accepts_current_font_names() -> None:
+    """
+    Validate font names supported by the current display API.
+
+    Firmware API 22 rejects the old medium/medium_condensed/big names.
+    """
+    for font in (
+        "tiny",
+        "small",
+        "normal",
+        "condensed",
+        "bold",
+        "large",
+        "extra_large",
+        "global",
+    ):
+        element = types.TextElement(
+            id=f"text-{font}",
+            type="text",
+            x=0,
+            y=0,
+            text="hi",
+            font=font,
+        )
+        assert element.font == font
+
+
+@pytest.mark.parametrize("font", ["medium", "medium_condensed", "big"])
+def test_text_element_rejects_legacy_font_names(font: str) -> None:
+    """
+    Reject font names removed from the current display API.
+
+    This catches payload regressions that firmware returns as HTTP 400.
+    """
+    with pytest.raises(ValidationError):
+        types.TextElement(
+            id=f"text-{font}",
+            type="text",
+            x=0,
+            y=0,
+            text="hi",
+            font=font,  # type: ignore[reportArgumentType]
+        )
 
 
 def test_display_draw_color_tuple_alpha():


### PR DESCRIPTION
Updates TextElement font typing to match the current firmware display API names so invalid legacy fonts are rejected before sending requests.

Updates display examples and CLI choices to use the current font names so copied payloads work with API 22 firmware.

Adds regression tests for accepted current font names and rejected legacy font names to catch payloads that would produce firmware HTTP 400 responses.