### PR TITLE
feat: sync client with firmware openapi

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -211,3 +211,6 @@ cython_debug/
 marimo/_static/
 marimo/_lsp/
 __marimo__/
+
+# Local agent instructions
+AGENTS.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,0 @@
-# Repository Instructions
-
-- Keep repository-facing text in English: code comments, docstrings, README updates, PR titles, PR descriptions, commit messages, review notes intended for GitHub, and user-visible library messages.
-- Do not introduce Russian text or references to internal conversation language in this repository.
-- Preserve Python 3.10+ runtime compatibility unless `pyproject.toml` is intentionally updated to raise the minimum supported version.
-- Run `python -m pre_commit run --all-files` and `python -m pytest -q` before pushing PR updates.

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # busylib
 
-[![PyPI](https://img.shields.io/pypi/v/busylib.svg)](https://pypi.org/project/busylib/)
-[![Python Versions](https://img.shields.io/pypi/pyversions/busylib.svg)](https://pypi.org/project/busylib/)
-[![License](https://img.shields.io/pypi/l/busylib.svg)](https://github.com/busy-app/busylib-py/blob/main/LICENSE)
+[![PyPI version](https://img.shields.io/pypi/v/busylib.svg?label=PyPI)](https://pypi.org/project/busylib/)
+[![Python versions](https://img.shields.io/badge/python-3.10%20%7C%203.11%20%7C%203.12%20%7C%203.13%20%7C%203.14-blue)](https://pypi.org/project/busylib/)
+[![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](https://github.com/busy-app/busylib-py/blob/main/LICENSE)
 
 A simple and intuitive Python client for interacting with the Busy Bar API. This library allows you to programmatically control the device's display, audio, and assets.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,7 @@ requires = [ "setuptools>=61", "setuptools-scm", "wheel" ]
 name = "busylib"
 description = "Python library for Busy Bar API"
 readme = "README.md"
+license = "MIT"
 authors = [
   { name = "flipperdevices", email = "pypi@flipperdevices.com" },
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 build-backend = "setuptools.build_meta"
-requires = [ "setuptools>=61", "setuptools-scm", "wheel" ]
+requires = [ "setuptools>=77", "setuptools-scm", "wheel" ]
 
 [project]
 name = "busylib"

--- a/src/busylib/client/__init__.py
+++ b/src/busylib/client/__init__.py
@@ -12,6 +12,7 @@ from .ble import AsyncBleMixin, BleMixin
 from .display import AsyncDisplayMixin, DisplayMixin
 from .firmware import AsyncFirmwareMixin, FirmwareMixin
 from .input import AsyncInputMixin, InputMixin
+from .smart_home import AsyncSmartHomeMixin, SmartHomeMixin
 from .state_stream import AsyncStateStreamMixin, StateStreamMixin
 from .storage import AsyncStorageMixin, StorageMixin
 from .time import AsyncTimeMixin, TimeMixin
@@ -35,6 +36,7 @@ class BusyBar(
     AudioMixin,
     WifiMixin,
     InputMixin,
+    SmartHomeMixin,
     StateStreamMixin,
     BleMixin,
     SyncClientBase,
@@ -94,6 +96,7 @@ class AsyncBusyBar(
     AsyncAudioMixin,
     AsyncWifiMixin,
     AsyncInputMixin,
+    AsyncSmartHomeMixin,
     AsyncStateStreamMixin,
     AsyncBleMixin,
     AsyncClientBase,

--- a/src/busylib/client/account.py
+++ b/src/busylib/client/account.py
@@ -13,7 +13,7 @@ AccountProfileName = Literal["dev", "prod", "local", "custom"]
 
 class AccountMixin(SyncClientBase):
     """
-    Account linking and MQTT profile helpers.
+    Account linking and MQTT backend helpers.
     """
 
     def account_unlink(self) -> types.SuccessResponse:
@@ -48,9 +48,37 @@ class AccountMixin(SyncClientBase):
         data = self._request("GET", "/api/account/status")
         return types.AccountState.model_validate(data)
 
+    def account_backend(self) -> types.AccountBackend:
+        """
+        Fetch MQTT backend settings via GET /api/account/backend.
+        """
+        logger.info("account_backend")
+        data = self._request("GET", "/api/account/backend")
+        return types.AccountBackend.model_validate(data)
+
+    def account_backend_set(
+        self,
+        backend: types.AccountBackend | dict[str, object],
+    ) -> types.SuccessResponse:
+        """
+        Set MQTT backend settings via PUT /api/account/backend.
+        """
+        logger.info("account_backend_set")
+        model = (
+            backend
+            if isinstance(backend, types.AccountBackend)
+            else types.AccountBackend.model_validate(backend)
+        )
+        data = self._request(
+            "PUT",
+            "/api/account/backend",
+            json_payload=model.model_dump(mode="json"),
+        )
+        return types.SuccessResponse.model_validate(data)
+
     def account_profile(self) -> types.AccountProfile:
         """
-        Fetch MQTT profile via GET /api/account/profile.
+        Fetch legacy MQTT profile via GET /api/account/profile.
         """
         logger.info("account_profile")
         data = self._request("GET", "/api/account/profile")
@@ -62,7 +90,7 @@ class AccountMixin(SyncClientBase):
         custom_url: str | None = None,
     ) -> types.SuccessResponse:
         """
-        Set MQTT profile via POST /api/account/profile.
+        Set legacy MQTT profile via POST /api/account/profile.
         """
         logger.info("account_profile_set profile=%s", profile)
         params: dict[str, str] = {"profile": profile}
@@ -78,7 +106,7 @@ class AccountMixin(SyncClientBase):
 
 class AsyncAccountMixin(AsyncClientBase):
     """
-    Async account linking and MQTT profile helpers.
+    Async account linking and MQTT backend helpers.
     """
 
     async def account_unlink(self) -> types.SuccessResponse:
@@ -113,9 +141,37 @@ class AsyncAccountMixin(AsyncClientBase):
         data = await self._request("GET", "/api/account/status")
         return types.AccountState.model_validate(data)
 
+    async def account_backend(self) -> types.AccountBackend:
+        """
+        Fetch MQTT backend settings via GET /api/account/backend.
+        """
+        logger.info("async account_backend")
+        data = await self._request("GET", "/api/account/backend")
+        return types.AccountBackend.model_validate(data)
+
+    async def account_backend_set(
+        self,
+        backend: types.AccountBackend | dict[str, object],
+    ) -> types.SuccessResponse:
+        """
+        Set MQTT backend settings via PUT /api/account/backend.
+        """
+        logger.info("async account_backend_set")
+        model = (
+            backend
+            if isinstance(backend, types.AccountBackend)
+            else types.AccountBackend.model_validate(backend)
+        )
+        data = await self._request(
+            "PUT",
+            "/api/account/backend",
+            json_payload=model.model_dump(mode="json"),
+        )
+        return types.SuccessResponse.model_validate(data)
+
     async def account_profile(self) -> types.AccountProfile:
         """
-        Fetch MQTT profile via GET /api/account/profile.
+        Fetch legacy MQTT profile via GET /api/account/profile.
         """
         logger.info("async account_profile")
         data = await self._request("GET", "/api/account/profile")
@@ -127,7 +183,7 @@ class AsyncAccountMixin(AsyncClientBase):
         custom_url: str | None = None,
     ) -> types.SuccessResponse:
         """
-        Set MQTT profile via POST /api/account/profile.
+        Set legacy MQTT profile via POST /api/account/profile.
         """
         logger.info("async account_profile_set profile=%s", profile)
         params: dict[str, str] = {"profile": profile}

--- a/src/busylib/client/busy.py
+++ b/src/busylib/client/busy.py
@@ -10,7 +10,7 @@ logger = logging.getLogger(__name__)
 
 class BusyMixin(SyncClientBase):
     """
-    Busy snapshot helpers.
+    Busy snapshot and profile helpers.
     """
 
     def busy_snapshot(self) -> types.BusySnapshot:
@@ -34,10 +34,39 @@ class BusyMixin(SyncClientBase):
         )
         return types.SuccessResponse.model_validate(data)
 
+    def busy_profile(self, slot: types.BusyProfileSlot) -> types.BusyProfile:
+        """
+        Fetch a busy profile slot via GET /api/busy/profiles/{slot}.
+        """
+        logger.info("busy_profile slot=%s", slot)
+        data = self._request("GET", f"/api/busy/profiles/{slot}")
+        return types.BusyProfile.model_validate(data)
+
+    def busy_profile_set(
+        self,
+        slot: types.BusyProfileSlot,
+        profile: types.BusyProfile | dict[str, object],
+    ) -> types.SuccessResponse:
+        """
+        Set a busy profile slot via PUT /api/busy/profiles/{slot}.
+        """
+        logger.info("busy_profile_set slot=%s", slot)
+        model = (
+            profile
+            if isinstance(profile, types.BusyProfile)
+            else types.BusyProfile.model_validate(profile)
+        )
+        data = self._request(
+            "PUT",
+            f"/api/busy/profiles/{slot}",
+            json_payload=model.model_dump(mode="json"),
+        )
+        return types.SuccessResponse.model_validate(data)
+
 
 class AsyncBusyMixin(AsyncClientBase):
     """
-    Async busy snapshot helpers.
+    Async busy snapshot and profile helpers.
     """
 
     async def busy_snapshot(self) -> types.BusySnapshot:
@@ -60,5 +89,34 @@ class AsyncBusyMixin(AsyncClientBase):
             "PUT",
             "/api/busy/snapshot",
             json_payload=payload,
+        )
+        return types.SuccessResponse.model_validate(data)
+
+    async def busy_profile(self, slot: types.BusyProfileSlot) -> types.BusyProfile:
+        """
+        Fetch a busy profile slot via GET /api/busy/profiles/{slot}.
+        """
+        logger.info("async busy_profile slot=%s", slot)
+        data = await self._request("GET", f"/api/busy/profiles/{slot}")
+        return types.BusyProfile.model_validate(data)
+
+    async def busy_profile_set(
+        self,
+        slot: types.BusyProfileSlot,
+        profile: types.BusyProfile | dict[str, object],
+    ) -> types.SuccessResponse:
+        """
+        Set a busy profile slot via PUT /api/busy/profiles/{slot}.
+        """
+        logger.info("async busy_profile_set slot=%s", slot)
+        model = (
+            profile
+            if isinstance(profile, types.BusyProfile)
+            else types.BusyProfile.model_validate(profile)
+        )
+        data = await self._request(
+            "PUT",
+            f"/api/busy/profiles/{slot}",
+            json_payload=model.model_dump(mode="json"),
         )
         return types.SuccessResponse.model_validate(data)

--- a/src/busylib/client/firmware.py
+++ b/src/busylib/client/firmware.py
@@ -10,10 +10,13 @@ logger = logging.getLogger(__name__)
 
 class FirmwareMixin(SyncClientBase):
     """
-    Version and system status methods.
+    Version, transport, and system status methods.
     """
 
     def version(self) -> types.VersionInfo:
+        """
+        Fetch API version info and validate compatibility.
+        """
         logger.info("version")
         data = self._request("GET", "/api/version")
         version_info = types.VersionInfo.model_validate(data)
@@ -25,17 +28,50 @@ class FirmwareMixin(SyncClientBase):
             )
         return version_info
 
+    def transport(self) -> types.NetworkInterfaceInfo:
+        """
+        Fetch active network transport via GET /api/transport.
+        """
+        logger.info("transport")
+        data = self._request("GET", "/api/transport")
+        return types.NetworkInterfaceInfo.model_validate(data)
+
     def status(self) -> types.Status:
+        """
+        Fetch full device status via GET /api/status.
+        """
         logger.info("status")
         data = self._request("GET", "/api/status")
         return types.Status.model_validate(data)
 
+    def status_device(self) -> types.StatusDevice:
+        """
+        Fetch device manufacturing status via GET /api/status/device.
+        """
+        logger.info("status_device")
+        data = self._request("GET", "/api/status/device")
+        return types.StatusDevice.model_validate(data)
+
+    def status_firmware(self) -> types.StatusFirmware:
+        """
+        Fetch firmware status via GET /api/status/firmware.
+        """
+        logger.info("status_firmware")
+        data = self._request("GET", "/api/status/firmware")
+        return types.StatusFirmware.model_validate(data)
+
     def status_system(self) -> types.StatusSystem:
+        """
+        Fetch runtime status via GET /api/status/system.
+        """
         logger.info("status_system")
         data = self._request("GET", "/api/status/system")
         return types.StatusSystem.model_validate(data)
 
     def status_power(self) -> types.StatusPower:
+        """
+        Fetch power status via GET /api/status/power.
+        """
         logger.info("status_power")
         data = self._request("GET", "/api/status/power")
         return types.StatusPower.model_validate(data)
@@ -72,10 +108,13 @@ class FirmwareMixin(SyncClientBase):
 
 class AsyncFirmwareMixin(AsyncClientBase):
     """
-    Async variant of version and system status methods.
+    Async variant of version, transport, and system status methods.
     """
 
     async def version(self) -> types.VersionInfo:
+        """
+        Fetch API version info and validate compatibility.
+        """
         logger.info("async version")
         data = await self._request("GET", "/api/version")
         version_info = types.VersionInfo.model_validate(data)
@@ -87,17 +126,50 @@ class AsyncFirmwareMixin(AsyncClientBase):
             )
         return version_info
 
+    async def transport(self) -> types.NetworkInterfaceInfo:
+        """
+        Fetch active network transport via GET /api/transport.
+        """
+        logger.info("async transport")
+        data = await self._request("GET", "/api/transport")
+        return types.NetworkInterfaceInfo.model_validate(data)
+
     async def status(self) -> types.Status:
+        """
+        Fetch full device status via GET /api/status.
+        """
         logger.info("async status")
         data = await self._request("GET", "/api/status")
         return types.Status.model_validate(data)
 
+    async def status_device(self) -> types.StatusDevice:
+        """
+        Fetch device manufacturing status via GET /api/status/device.
+        """
+        logger.info("async status_device")
+        data = await self._request("GET", "/api/status/device")
+        return types.StatusDevice.model_validate(data)
+
+    async def status_firmware(self) -> types.StatusFirmware:
+        """
+        Fetch firmware status via GET /api/status/firmware.
+        """
+        logger.info("async status_firmware")
+        data = await self._request("GET", "/api/status/firmware")
+        return types.StatusFirmware.model_validate(data)
+
     async def status_system(self) -> types.StatusSystem:
+        """
+        Fetch runtime status via GET /api/status/system.
+        """
         logger.info("async status_system")
         data = await self._request("GET", "/api/status/system")
         return types.StatusSystem.model_validate(data)
 
     async def status_power(self) -> types.StatusPower:
+        """
+        Fetch power status via GET /api/status/power.
+        """
         logger.info("async status_power")
         data = await self._request("GET", "/api/status/power")
         return types.StatusPower.model_validate(data)

--- a/src/busylib/client/smart_home.py
+++ b/src/busylib/client/smart_home.py
@@ -1,0 +1,127 @@
+from __future__ import annotations
+
+import logging
+from typing import Literal
+
+from .. import types
+from .base import AsyncClientBase, SyncClientBase
+
+logger = logging.getLogger(__name__)
+
+
+class SmartHomeMixin(SyncClientBase):
+    """
+    Smart home pairing and switch helpers.
+    """
+
+    def smart_home_pairing(self) -> types.SmartHomePairingInfo:
+        """
+        Fetch smart home pairing status via GET /api/smart_home/pairing.
+        """
+        logger.info("smart_home_pairing")
+        data = self._request("GET", "/api/smart_home/pairing")
+        return types.SmartHomePairingInfo.model_validate(data)
+
+    def smart_home_pairing_start(self) -> types.SmartHomePairingPayload:
+        """
+        Start smart home pairing via POST /api/smart_home/pairing.
+        """
+        logger.info("smart_home_pairing_start")
+        data = self._request("POST", "/api/smart_home/pairing")
+        return types.SmartHomePairingPayload.model_validate(data)
+
+    def smart_home_pairing_stop(self) -> types.SuccessResponse:
+        """
+        Stop smart home pairing via DELETE /api/smart_home/pairing.
+        """
+        logger.info("smart_home_pairing_stop")
+        data = self._request("DELETE", "/api/smart_home/pairing")
+        return types.SuccessResponse.model_validate(data)
+
+    def smart_home_switch(self) -> types.SmartHomeSwitchState:
+        """
+        Fetch smart home switch state via GET /api/smart_home/switch.
+        """
+        logger.info("smart_home_switch")
+        data = self._request("GET", "/api/smart_home/switch")
+        return types.SmartHomeSwitchState.model_validate(data)
+
+    def smart_home_switch_set(
+        self,
+        state: bool,
+        *,
+        startup: Literal["off", "on", "toggle", "last"] | None = None,
+    ) -> types.SuccessResponse:
+        """
+        Set smart home switch state via POST /api/smart_home/switch.
+        """
+        logger.info("smart_home_switch_set state=%s startup=%s", state, startup)
+        payload = types.SmartHomeSwitchState(
+            state=state,
+            startup=startup,
+        ).model_dump(exclude_none=True)
+        data = self._request(
+            "POST",
+            "/api/smart_home/switch",
+            json_payload=payload,
+        )
+        return types.SuccessResponse.model_validate(data)
+
+
+class AsyncSmartHomeMixin(AsyncClientBase):
+    """
+    Async smart home pairing and switch helpers.
+    """
+
+    async def smart_home_pairing(self) -> types.SmartHomePairingInfo:
+        """
+        Fetch smart home pairing status via GET /api/smart_home/pairing.
+        """
+        logger.info("async smart_home_pairing")
+        data = await self._request("GET", "/api/smart_home/pairing")
+        return types.SmartHomePairingInfo.model_validate(data)
+
+    async def smart_home_pairing_start(self) -> types.SmartHomePairingPayload:
+        """
+        Start smart home pairing via POST /api/smart_home/pairing.
+        """
+        logger.info("async smart_home_pairing_start")
+        data = await self._request("POST", "/api/smart_home/pairing")
+        return types.SmartHomePairingPayload.model_validate(data)
+
+    async def smart_home_pairing_stop(self) -> types.SuccessResponse:
+        """
+        Stop smart home pairing via DELETE /api/smart_home/pairing.
+        """
+        logger.info("async smart_home_pairing_stop")
+        data = await self._request("DELETE", "/api/smart_home/pairing")
+        return types.SuccessResponse.model_validate(data)
+
+    async def smart_home_switch(self) -> types.SmartHomeSwitchState:
+        """
+        Fetch smart home switch state via GET /api/smart_home/switch.
+        """
+        logger.info("async smart_home_switch")
+        data = await self._request("GET", "/api/smart_home/switch")
+        return types.SmartHomeSwitchState.model_validate(data)
+
+    async def smart_home_switch_set(
+        self,
+        state: bool,
+        *,
+        startup: Literal["off", "on", "toggle", "last"] | None = None,
+    ) -> types.SuccessResponse:
+        """
+        Set smart home switch state via POST /api/smart_home/switch.
+        """
+        logger.info("async smart_home_switch_set state=%s startup=%s", state, startup)
+        payload = types.SmartHomeSwitchState(
+            state=state,
+            startup=startup,
+        ).model_dump(exclude_none=True)
+        data = await self._request(
+            "POST",
+            "/api/smart_home/switch",
+            json_payload=payload,
+        )
+        return types.SuccessResponse.model_validate(data)

--- a/src/busylib/client/storage.py
+++ b/src/busylib/client/storage.py
@@ -76,11 +76,26 @@ class StorageMixin(SyncClientBase):
         return types.SuccessResponse.model_validate(data)
 
     def storage_mkdir(self, path: str) -> types.SuccessResponse:
+        """
+        Create a storage directory via POST /api/storage/mkdir.
+        """
         logger.info("storage_mkdir path=%s", path)
         data = self._request(
             "POST",
             "/api/storage/mkdir",
             params={"path": path},
+        )
+        return types.SuccessResponse.model_validate(data)
+
+    def storage_rename(self, old_path: str, new_path: str) -> types.SuccessResponse:
+        """
+        Rename a storage entry via POST /api/storage/rename.
+        """
+        logger.info("storage_rename old_path=%s new_path=%s", old_path, new_path)
+        data = self._request(
+            "POST",
+            "/api/storage/rename",
+            params={"old_path": old_path, "new_path": new_path},
         )
         return types.SuccessResponse.model_validate(data)
 
@@ -158,11 +173,28 @@ class AsyncStorageMixin(AsyncClientBase):
         return types.SuccessResponse.model_validate(data)
 
     async def storage_mkdir(self, path: str) -> types.SuccessResponse:
+        """
+        Create a storage directory via POST /api/storage/mkdir.
+        """
         logger.info("async storage_mkdir path=%s", path)
         data = await self._request(
             "POST",
             "/api/storage/mkdir",
             params={"path": path},
+        )
+        return types.SuccessResponse.model_validate(data)
+
+    async def storage_rename(
+        self, old_path: str, new_path: str
+    ) -> types.SuccessResponse:
+        """
+        Rename a storage entry via POST /api/storage/rename.
+        """
+        logger.info("async storage_rename old_path=%s new_path=%s", old_path, new_path)
+        data = await self._request(
+            "POST",
+            "/api/storage/rename",
+            params={"old_path": old_path, "new_path": new_path},
         )
         return types.SuccessResponse.model_validate(data)
 

--- a/src/busylib/client/time.py
+++ b/src/busylib/client/time.py
@@ -10,8 +10,24 @@ logger = logging.getLogger(__name__)
 
 class TimeMixin(SyncClientBase):
     """
-    Device time helpers.
+    Device time and timezone helpers.
     """
+
+    def time_timezone_info(self) -> types.TimezoneInfo:
+        """
+        Fetch current device timezone via GET /api/time/timezone.
+        """
+        logger.info("time_timezone_info")
+        data = self._request("GET", "/api/time/timezone")
+        return types.TimezoneInfo.model_validate(data)
+
+    def time_timezone_list(self) -> types.TimezoneListResponse:
+        """
+        Fetch supported device timezones via GET /api/time/tzlist.
+        """
+        logger.info("time_timezone_list")
+        data = self._request("GET", "/api/time/tzlist")
+        return types.TimezoneListResponse.model_validate(data)
 
     def time_timestamp(self, timestamp: str) -> types.SuccessResponse:
         """
@@ -34,8 +50,24 @@ class TimeMixin(SyncClientBase):
 
 class AsyncTimeMixin(AsyncClientBase):
     """
-    Async device time helpers.
+    Async device time and timezone helpers.
     """
+
+    async def time_timezone_info(self) -> types.TimezoneInfo:
+        """
+        Fetch current device timezone via GET /api/time/timezone.
+        """
+        logger.info("async time_timezone_info")
+        data = await self._request("GET", "/api/time/timezone")
+        return types.TimezoneInfo.model_validate(data)
+
+    async def time_timezone_list(self) -> types.TimezoneListResponse:
+        """
+        Fetch supported device timezones via GET /api/time/tzlist.
+        """
+        logger.info("async time_timezone_list")
+        data = await self._request("GET", "/api/time/tzlist")
+        return types.TimezoneListResponse.model_validate(data)
 
     async def time_timestamp(self, timestamp: str) -> types.SuccessResponse:
         """

--- a/src/busylib/client/updater.py
+++ b/src/busylib/client/updater.py
@@ -13,10 +13,7 @@ class UpdaterMixin(SyncClientBase):
     Firmware update helpers for the updater API.
     """
 
-    def update(
-        self,
-        firmware_data: bytes,
-    ) -> types.SuccessResponse:
+    def update(self, firmware_data: bytes) -> types.SuccessResponse:
         """
         Upload firmware update TAR and initiate update.
         """
@@ -76,16 +73,41 @@ class UpdaterMixin(SyncClientBase):
         data = self._request("POST", "/api/update/abort_download")
         return types.SuccessResponse.model_validate(data)
 
+    def update_autoupdate(self) -> types.AutoupdateSettings:
+        """
+        Fetch autoupdate settings via GET /api/update/autoupdate.
+        """
+        logger.info("update_autoupdate")
+        data = self._request("GET", "/api/update/autoupdate")
+        return types.AutoupdateSettings.model_validate(data)
+
+    def update_autoupdate_set(
+        self,
+        settings: types.AutoupdateSettings | dict[str, object],
+    ) -> types.SuccessResponse:
+        """
+        Set autoupdate settings via POST /api/update/autoupdate.
+        """
+        logger.info("update_autoupdate_set")
+        model = (
+            settings
+            if isinstance(settings, types.AutoupdateSettings)
+            else types.AutoupdateSettings.model_validate(settings)
+        )
+        data = self._request(
+            "POST",
+            "/api/update/autoupdate",
+            json_payload=model.model_dump(mode="json", exclude_none=True),
+        )
+        return types.SuccessResponse.model_validate(data)
+
 
 class AsyncUpdaterMixin(AsyncClientBase):
     """
     Async firmware update helpers for the updater API.
     """
 
-    async def update(
-        self,
-        firmware_data: bytes,
-    ) -> types.SuccessResponse:
+    async def update(self, firmware_data: bytes) -> types.SuccessResponse:
         """
         Upload firmware update TAR and initiate update.
         """
@@ -143,4 +165,32 @@ class AsyncUpdaterMixin(AsyncClientBase):
         """
         logger.info("async update_abort_download")
         data = await self._request("POST", "/api/update/abort_download")
+        return types.SuccessResponse.model_validate(data)
+
+    async def update_autoupdate(self) -> types.AutoupdateSettings:
+        """
+        Fetch autoupdate settings via GET /api/update/autoupdate.
+        """
+        logger.info("async update_autoupdate")
+        data = await self._request("GET", "/api/update/autoupdate")
+        return types.AutoupdateSettings.model_validate(data)
+
+    async def update_autoupdate_set(
+        self,
+        settings: types.AutoupdateSettings | dict[str, object],
+    ) -> types.SuccessResponse:
+        """
+        Set autoupdate settings via POST /api/update/autoupdate.
+        """
+        logger.info("async update_autoupdate_set")
+        model = (
+            settings
+            if isinstance(settings, types.AutoupdateSettings)
+            else types.AutoupdateSettings.model_validate(settings)
+        )
+        data = await self._request(
+            "POST",
+            "/api/update/autoupdate",
+            json_payload=model.model_dump(mode="json", exclude_none=True),
+        )
         return types.SuccessResponse.model_validate(data)

--- a/src/busylib/types.py
+++ b/src/busylib/types.py
@@ -180,7 +180,7 @@ class StatusFirmware(BaseModel):
     version: str | None = None
     target: int | None = None
     branch: str | None = None
-    build_date: datetime | str | None = None
+    build_date: str | None = None
     commit_hash: str | None = None
     nwp_version: str | None = None
     matter_version: str | None = None
@@ -202,7 +202,7 @@ class StatusSystem(BaseModel):
 
 
 class NetworkInterfaceInfo(BaseModel):
-    type: Literal["usb", "wifi"] | None = None
+    type: str | None = None
 
     model_config = ConfigDict(extra="ignore")
 
@@ -388,20 +388,19 @@ class AccountInfo(BaseModel):
 
 
 class AccountState(BaseModel):
-    status: Literal["error", "disconnected", "connected"] | None = None
-    state: Literal["error", "disconnected", "connected"] | None = None
+    status: str | None = None
+    state: str | None = Field(default=None, exclude=True)
 
     model_config = ConfigDict(extra="ignore")
 
     @model_validator(mode="after")
     def _sync_state_aliases(self) -> "AccountState":
         """
-        Keep the old state attribute and OpenAPI status field in sync.
+        Keep OpenAPI status authoritative while accepting legacy state input.
         """
-        if self.state is None:
-            self.state = self.status
         if self.status is None:
             self.status = self.state
+        self.state = self.status
         return self
 
 
@@ -414,7 +413,7 @@ class AccountProfile(BaseModel):
 
 class AccountBackend(BaseModel):
     server_url: str
-    client_cert_type: Literal["default", "custom", "none"]
+    client_cert_type: str
     ignore_server_cert: bool
 
     model_config = ConfigDict(extra="ignore")
@@ -437,48 +436,9 @@ class UpdateInstallDownload(BaseModel):
 
 class UpdateInstallStatus(BaseModel):
     is_allowed: bool | None = None
-    event: (
-        Literal[
-            "session_start",
-            "session_stop",
-            "action_begin",
-            "action_done",
-            "detail_change",
-            "action_progress",
-            "none",
-        ]
-        | None
-    ) = None
-    action: (
-        Literal[
-            "download",
-            "sha_verification",
-            "unpack",
-            "prepare",
-            "apply",
-            "none",
-        ]
-        | None
-    ) = None
-    status: (
-        Literal[
-            "ok",
-            "battery_low",
-            "busy",
-            "download_failure",
-            "download_abort",
-            "sha_mismatch",
-            "unpack_staging_dir_failure",
-            "unpack_archive_open_failure",
-            "unpack_archive_unpack_failure",
-            "install_manifest_not_found",
-            "install_manifest_invalid",
-            "install_session_config_failure",
-            "install_pointer_setup_failure",
-            "unknown_failure",
-        ]
-        | None
-    ) = None
+    event: str | None = None
+    action: str | None = None
+    status: str | None = None
     detail: str | None = None
     download: UpdateInstallDownload | None = None
 
@@ -487,21 +447,20 @@ class UpdateInstallStatus(BaseModel):
 
 class UpdateCheckStatus(BaseModel):
     available_version: str | None = None
-    event: Literal["start", "stop", "none"] | None = None
-    status: Literal["available", "not_available", "failure", "none"] | None = None
-    result: Literal["available", "not_available", "failure", "none"] | None = None
+    event: str | None = None
+    status: str | None = None
+    result: str | None = Field(default=None, exclude=True)
 
     model_config = ConfigDict(extra="ignore")
 
     @model_validator(mode="after")
     def _sync_result_aliases(self) -> "UpdateCheckStatus":
         """
-        Keep the old result attribute and OpenAPI status field in sync.
+        Keep OpenAPI status authoritative while accepting legacy result input.
         """
-        if self.result is None:
-            self.result = self.status
         if self.status is None:
             self.status = self.result
+        self.result = self.status
         return self
 
 
@@ -792,7 +751,7 @@ class ScreenResponse(BaseModel):
 
 class BleStatus(BaseModel):
     status: str | None = None
-    state: str | None = None
+    state: str | None = Field(default=None, exclude=True)
     address: str | None = None
 
     model_config = ConfigDict(extra="ignore")
@@ -800,25 +759,16 @@ class BleStatus(BaseModel):
     @model_validator(mode="after")
     def _sync_state_aliases(self) -> "BleStatus":
         """
-        Keep the old state attribute and OpenAPI status field in sync.
+        Keep OpenAPI status authoritative while accepting legacy state input.
         """
-        if self.state is None:
-            self.state = self.status
         if self.status is None:
             self.status = self.state
+        self.state = self.status
         return self
 
 
 class SmartHomePairingStatus(BaseModel):
-    value: (
-        Literal[
-            "never_started",
-            "started",
-            "completed_successfully",
-            "failed",
-        ]
-        | None
-    ) = None
+    value: str | None = None
     timestamp: int | None = None
 
     model_config = ConfigDict(extra="ignore")
@@ -841,6 +791,6 @@ class SmartHomePairingPayload(BaseModel):
 
 class SmartHomeSwitchState(BaseModel):
     state: bool | None = None
-    startup: Literal["off", "on", "toggle", "last"] | None = None
+    startup: str | None = None
 
     model_config = ConfigDict(extra="ignore")

--- a/src/busylib/types.py
+++ b/src/busylib/types.py
@@ -70,8 +70,12 @@ class StrEnum(str, Enum):
 
 
 class WifiState(StrEnum):
+    UNKNOWN = "unknown"
     DISCONNECTED = "disconnected"
     CONNECTED = "connected"
+    CONNECTING = "connecting"
+    DISCONNECTING = "disconnecting"
+    RECONNECTING = "reconnecting"
 
 
 class WifiSecurityMethod(StrEnum):
@@ -82,6 +86,7 @@ class WifiSecurityMethod(StrEnum):
     WPA_WPA2 = "WPA/WPA2"
     WPA3 = "WPA3"
     WPA2_WPA3 = "WPA2/WPA3"
+    UNSUPPORTED = "Unsupported"
 
 
 class WifiIpMethod(StrEnum):
@@ -159,12 +164,45 @@ class VersionInfo(BaseModel):
     model_config = ConfigDict(extra="ignore")
 
 
+class StatusDevice(BaseModel):
+    serial_number: str | None = None
+    usb_mac: str | None = None
+    wifi_mac: str | None = None
+    ble_mac: str | None = None
+    otp_valid: bool | None = None
+    otp_model: str | None = None
+    otp_timestamp: int | None = None
+
+    model_config = ConfigDict(extra="ignore")
+
+
+class StatusFirmware(BaseModel):
+    version: str | None = None
+    target: int | None = None
+    branch: str | None = None
+    build_date: datetime | str | None = None
+    commit_hash: str | None = None
+    nwp_version: str | None = None
+    matter_version: str | None = None
+
+    model_config = ConfigDict(extra="ignore")
+
+
 class StatusSystem(BaseModel):
+    api_semver: str | None = None
     version: str | None = None
     uptime: str | None = None
     branch: str | None = None
     build_date: datetime | None = None
     commit_hash: str | None = None
+    boot_time: int | None = None
+    auto_update_enabled: bool | None = None
+
+    model_config = ConfigDict(extra="ignore")
+
+
+class NetworkInterfaceInfo(BaseModel):
+    type: Literal["usb", "wifi"] | None = None
 
     model_config = ConfigDict(extra="ignore")
 
@@ -180,6 +218,8 @@ class StatusPower(BaseModel):
 
 
 class Status(BaseModel):
+    device: StatusDevice | None = None
+    firmware: StatusFirmware | None = None
     system: StatusSystem | None = None
     power: StatusPower | None = None
 
@@ -202,6 +242,20 @@ class DeviceNameUpdate(BaseModel):
 
 class DeviceTimeResponse(BaseModel):
     timestamp: str | None = None
+
+    model_config = ConfigDict(extra="ignore")
+
+
+class TimezoneInfo(BaseModel):
+    name: str
+    offset: str
+    abbr: str
+
+    model_config = ConfigDict(extra="ignore")
+
+
+class TimezoneListResponse(BaseModel):
+    list: list[TimezoneInfo]
 
     model_config = ConfigDict(extra="ignore")
 
@@ -283,6 +337,47 @@ class BusySnapshot(BaseModel):
     model_config = ConfigDict(extra="ignore")
 
 
+class BusyTimerInfiniteSettings(BaseModel):
+    type: Literal["INFINITE"]
+
+    model_config = ConfigDict(extra="ignore")
+
+
+class BusyTimerSimpleSettings(BaseModel):
+    type: Literal["SIMPLE"]
+    total_time_ms: int
+
+    model_config = ConfigDict(extra="ignore")
+
+
+BusyTimerSettings = Annotated[
+    BusyTimerInfiniteSettings | BusyTimerSimpleSettings | BusySnapshotIntervalSettings,
+    Field(discriminator="type"),
+]
+
+
+class BusyBarSettings(BaseModel):
+    theme: str
+    show_work_phase_only: bool
+    trigger_smart_home: bool
+
+    model_config = ConfigDict(extra="ignore")
+
+
+class BusyProfile(BaseModel):
+    sort_order: int
+    title: str
+    id: str
+    timer_settings: BusyTimerSettings
+    busy_bar_settings: BusyBarSettings
+    profile_timestamp_ms: int
+
+    model_config = ConfigDict(extra="ignore")
+
+
+BusyProfileSlot = Literal["busy", "custom"]
+
+
 class AccountInfo(BaseModel):
     linked: bool | None = None
     id: str | None = None
@@ -293,14 +388,34 @@ class AccountInfo(BaseModel):
 
 
 class AccountState(BaseModel):
+    status: Literal["error", "disconnected", "connected"] | None = None
     state: Literal["error", "disconnected", "connected"] | None = None
 
     model_config = ConfigDict(extra="ignore")
+
+    @model_validator(mode="after")
+    def _sync_state_aliases(self) -> "AccountState":
+        """
+        Keep the old state attribute and OpenAPI status field in sync.
+        """
+        if self.state is None:
+            self.state = self.status
+        if self.status is None:
+            self.status = self.state
+        return self
 
 
 class AccountProfile(BaseModel):
     state: Literal["dev", "prod", "local", "custom"] | None = None
     custom_url: str | None = None
+
+    model_config = ConfigDict(extra="ignore")
+
+
+class AccountBackend(BaseModel):
+    server_url: str
+    client_cert_type: Literal["default", "custom", "none"]
+    ignore_server_cert: bool
 
     model_config = ConfigDict(extra="ignore")
 
@@ -373,9 +488,21 @@ class UpdateInstallStatus(BaseModel):
 class UpdateCheckStatus(BaseModel):
     available_version: str | None = None
     event: Literal["start", "stop", "none"] | None = None
+    status: Literal["available", "not_available", "failure", "none"] | None = None
     result: Literal["available", "not_available", "failure", "none"] | None = None
 
     model_config = ConfigDict(extra="ignore")
+
+    @model_validator(mode="after")
+    def _sync_result_aliases(self) -> "UpdateCheckStatus":
+        """
+        Keep the old result attribute and OpenAPI status field in sync.
+        """
+        if self.result is None:
+            self.result = self.status
+        if self.status is None:
+            self.status = self.result
+        return self
 
 
 class UpdateStatus(BaseModel):
@@ -387,6 +514,14 @@ class UpdateStatus(BaseModel):
 
 class UpdateChangelogResponse(BaseModel):
     changelog: str | None = None
+
+    model_config = ConfigDict(extra="ignore")
+
+
+class AutoupdateSettings(BaseModel):
+    is_enabled: bool | None = None
+    interval_start: str | None = None
+    interval_end: str | None = None
 
     model_config = ConfigDict(extra="ignore")
 
@@ -546,6 +681,7 @@ class DisplayElements(BaseModel):
 
 
 class DisplayBrightnessInfo(BaseModel):
+    value: str | None = None
     front: str | None = None
     back: str | None = None
 
@@ -655,6 +791,56 @@ class ScreenResponse(BaseModel):
 
 
 class BleStatus(BaseModel):
-    state: str
+    status: str | None = None
+    state: str | None = None
+    address: str | None = None
+
+    model_config = ConfigDict(extra="ignore")
+
+    @model_validator(mode="after")
+    def _sync_state_aliases(self) -> "BleStatus":
+        """
+        Keep the old state attribute and OpenAPI status field in sync.
+        """
+        if self.state is None:
+            self.state = self.status
+        if self.status is None:
+            self.status = self.state
+        return self
+
+
+class SmartHomePairingStatus(BaseModel):
+    value: (
+        Literal[
+            "never_started",
+            "started",
+            "completed_successfully",
+            "failed",
+        ]
+        | None
+    ) = None
+    timestamp: int | None = None
+
+    model_config = ConfigDict(extra="ignore")
+
+
+class SmartHomePairingInfo(BaseModel):
+    fabric_count: int | None = None
+    latest_pairing_status: SmartHomePairingStatus | None = None
+
+    model_config = ConfigDict(extra="ignore")
+
+
+class SmartHomePairingPayload(BaseModel):
+    available_until: str | None = None
+    qr_code: str | None = None
+    manual_code: str | None = None
+
+    model_config = ConfigDict(extra="ignore")
+
+
+class SmartHomeSwitchState(BaseModel):
+    state: bool | None = None
+    startup: Literal["off", "on", "toggle", "last"] | None = None
 
     model_config = ConfigDict(extra="ignore")

--- a/tests/busylib/client/test_openapi_sync.py
+++ b/tests/busylib/client/test_openapi_sync.py
@@ -1,0 +1,323 @@
+from __future__ import annotations
+
+import json
+
+import httpx
+import pytest
+
+from busylib import AsyncBusyBar, BusyBar, types
+
+
+def _make_sync_client(responder) -> BusyBar:
+    """
+    Build a sync client with a mock transport responder.
+    """
+    transport = httpx.MockTransport(responder)
+    return BusyBar(addr="http://device.local", transport=transport)
+
+
+def _make_async_client(responder) -> AsyncBusyBar:
+    """
+    Build an async client with a mock transport responder.
+    """
+    transport = httpx.MockTransport(responder)
+    return AsyncBusyBar(addr="http://device.local", transport=transport)
+
+
+def _busy_profile_payload() -> dict[str, object]:
+    """
+    Return a complete BusyProfile payload matching the firmware OpenAPI schema.
+    """
+    return {
+        "sort_order": 1,
+        "title": "Focus",
+        "id": "00000000-0000-0000-0000-000000000000",
+        "timer_settings": {"type": "SIMPLE", "total_time_ms": 300000},
+        "busy_bar_settings": {
+            "theme": "on_air",
+            "show_work_phase_only": False,
+            "trigger_smart_home": True,
+        },
+        "profile_timestamp_ms": 123,
+    }
+
+
+def test_account_backend_sync_requests_match_openapi() -> None:
+    """
+    Ensure account backend helpers use the documented path and JSON payload.
+    """
+    seen: list[dict[str, object]] = []
+
+    def responder(request: httpx.Request) -> httpx.Response:
+        seen.append(
+            {
+                "method": request.method,
+                "path": request.url.path,
+                "body": request.content,
+            }
+        )
+        if request.method == "GET":
+            return httpx.Response(
+                200,
+                json={
+                    "server_url": "default",
+                    "client_cert_type": "default",
+                    "ignore_server_cert": False,
+                },
+            )
+        return httpx.Response(200, json={"result": "OK"})
+
+    client = _make_sync_client(responder)
+    backend = client.account_backend()
+    response = client.account_backend_set(
+        {
+            "server_url": "mqtts://mqtt.example.com:8883",
+            "client_cert_type": "custom",
+            "ignore_server_cert": True,
+        }
+    )
+
+    assert backend.server_url == "default"
+    assert response.result == "OK"
+    assert seen[0] == {"method": "GET", "path": "/api/account/backend", "body": b""}
+    assert seen[1]["method"] == "PUT"
+    assert seen[1]["path"] == "/api/account/backend"
+    account_body = seen[1]["body"]
+    assert isinstance(account_body, bytes)
+    assert json.loads(account_body) == {
+        "server_url": "mqtts://mqtt.example.com:8883",
+        "client_cert_type": "custom",
+        "ignore_server_cert": True,
+    }
+
+
+def test_busy_profile_sync_requests_match_openapi() -> None:
+    """
+    Ensure busy profile helpers use slot paths and serialize profile bodies.
+    """
+    seen: list[dict[str, object]] = []
+
+    def responder(request: httpx.Request) -> httpx.Response:
+        seen.append(
+            {
+                "method": request.method,
+                "path": request.url.path,
+                "body": request.content,
+            }
+        )
+        if request.method == "GET":
+            return httpx.Response(200, json=_busy_profile_payload())
+        return httpx.Response(200, json={"result": "OK"})
+
+    client = _make_sync_client(responder)
+    profile = client.busy_profile("busy")
+    response = client.busy_profile_set("custom", profile)
+
+    assert profile.timer_settings.type == "SIMPLE"
+    assert response.result == "OK"
+    assert seen[0]["path"] == "/api/busy/profiles/busy"
+    assert seen[1]["method"] == "PUT"
+    assert seen[1]["path"] == "/api/busy/profiles/custom"
+    busy_body = seen[1]["body"]
+    assert isinstance(busy_body, bytes)
+    assert json.loads(busy_body)["busy_bar_settings"] == {
+        "theme": "on_air",
+        "show_work_phase_only": False,
+        "trigger_smart_home": True,
+    }
+
+
+def test_system_time_update_and_storage_endpoints_match_openapi() -> None:
+    """
+    Cover newly documented system, time, autoupdate, and storage endpoints.
+    """
+    seen: list[dict[str, object]] = []
+
+    def responder(request: httpx.Request) -> httpx.Response:
+        seen.append(
+            {
+                "method": request.method,
+                "path": request.url.path,
+                "params": dict(request.url.params),
+                "body": request.content,
+            }
+        )
+        if request.url.path == "/api/transport":
+            return httpx.Response(200, json={"type": "wifi"})
+        if request.url.path == "/api/status/device":
+            return httpx.Response(
+                200,
+                json={
+                    "serial_number": "203638485431500400123456",
+                    "usb_mac": "0c:fa:22:21:2a:31",
+                    "otp_valid": True,
+                },
+            )
+        if request.url.path == "/api/status/firmware":
+            return httpx.Response(
+                200,
+                json={
+                    "version": "1.0.0",
+                    "target": 22,
+                    "branch": "dev",
+                    "build_date": "2026-06-19",
+                    "commit_hash": "abc123",
+                },
+            )
+        if request.url.path == "/api/time/timezone" and request.method == "GET":
+            return httpx.Response(
+                200,
+                json={"name": "Bangalore", "offset": "+05:30", "abbr": "IST"},
+            )
+        if request.url.path == "/api/time/tzlist":
+            return httpx.Response(
+                200,
+                json={"list": [{"name": "UTC", "offset": "+00:00", "abbr": "UTC"}]},
+            )
+        if request.url.path == "/api/update/autoupdate" and request.method == "GET":
+            return httpx.Response(
+                200,
+                json={
+                    "is_enabled": True,
+                    "interval_start": "00:00",
+                    "interval_end": "08:00",
+                },
+            )
+        return httpx.Response(200, json={"result": "OK"})
+
+    client = _make_sync_client(responder)
+    assert client.transport().type == "wifi"
+    assert client.status_device().serial_number == "203638485431500400123456"
+    assert client.status_firmware().target == 22
+    assert client.time_timezone_info().abbr == "IST"
+    assert client.time_timezone_list().list[0].name == "UTC"
+    assert client.storage_rename("/ext/a.txt", "/ext/b.txt").result == "OK"
+    autoupdate = client.update_autoupdate()
+    assert autoupdate.is_enabled is True
+    assert client.update_autoupdate_set({"is_enabled": False}).result == "OK"
+
+    assert seen[5] == {
+        "method": "POST",
+        "path": "/api/storage/rename",
+        "params": {"old_path": "/ext/a.txt", "new_path": "/ext/b.txt"},
+        "body": b"",
+    }
+    assert seen[7]["path"] == "/api/update/autoupdate"
+    autoupdate_body = seen[7]["body"]
+    assert isinstance(autoupdate_body, bytes)
+    assert json.loads(autoupdate_body) == {"is_enabled": False}
+
+
+def test_smart_home_sync_requests_match_openapi() -> None:
+    """
+    Ensure smart home helpers use documented pairing and switch endpoints.
+    """
+    seen: list[dict[str, object]] = []
+
+    def responder(request: httpx.Request) -> httpx.Response:
+        seen.append(
+            {
+                "method": request.method,
+                "path": request.url.path,
+                "body": request.content,
+            }
+        )
+        if request.url.path == "/api/smart_home/pairing" and request.method == "GET":
+            return httpx.Response(
+                200,
+                json={
+                    "fabric_count": 1,
+                    "latest_pairing_status": {
+                        "value": "completed_successfully",
+                        "timestamp": 1769436711,
+                    },
+                },
+            )
+        if request.url.path == "/api/smart_home/pairing" and request.method == "POST":
+            return httpx.Response(
+                200,
+                json={
+                    "available_until": "1769437579000",
+                    "qr_code": "MT:YNDA0-O913..VV7I000",
+                    "manual_code": "1155-360-0377",
+                },
+            )
+        if request.url.path == "/api/smart_home/switch" and request.method == "GET":
+            return httpx.Response(200, json={"state": False})
+        return httpx.Response(200, json={"result": "OK"})
+
+    client = _make_sync_client(responder)
+    assert client.smart_home_pairing().fabric_count == 1
+    assert client.smart_home_pairing_start().manual_code == "1155-360-0377"
+    assert client.smart_home_pairing_stop().result == "OK"
+    assert client.smart_home_switch().state is False
+    assert client.smart_home_switch_set(True, startup="last").result == "OK"
+
+    assert [item["path"] for item in seen] == [
+        "/api/smart_home/pairing",
+        "/api/smart_home/pairing",
+        "/api/smart_home/pairing",
+        "/api/smart_home/switch",
+        "/api/smart_home/switch",
+    ]
+    switch_body = seen[-1]["body"]
+    assert isinstance(switch_body, bytes)
+    assert json.loads(switch_body) == {"state": True, "startup": "last"}
+
+
+@pytest.mark.asyncio
+async def test_async_new_openapi_helpers() -> None:
+    """
+    Ensure async wrappers expose representative newly documented endpoints.
+    """
+    seen: list[str] = []
+
+    async def responder(request: httpx.Request) -> httpx.Response:
+        seen.append(f"{request.method} {request.url.path}")
+        if request.url.path == "/api/account/backend":
+            return httpx.Response(
+                200,
+                json={
+                    "server_url": "default",
+                    "client_cert_type": "default",
+                    "ignore_server_cert": False,
+                },
+            )
+        if request.url.path == "/api/busy/profiles/busy":
+            return httpx.Response(200, json=_busy_profile_payload())
+        if request.url.path == "/api/smart_home/switch":
+            return httpx.Response(200, json={"state": True})
+        return httpx.Response(200, json={"result": "OK"})
+
+    client = _make_async_client(responder)
+    assert (await client.account_backend()).server_url == "default"
+    assert (await client.busy_profile("busy")).title == "Focus"
+    assert (await client.smart_home_switch()).state is True
+    assert (await client.storage_rename("/a", "/b")).result == "OK"
+    await client.aclose()
+
+    assert seen == [
+        "GET /api/account/backend",
+        "GET /api/busy/profiles/busy",
+        "GET /api/smart_home/switch",
+        "POST /api/storage/rename",
+    ]
+
+
+def test_response_alias_models_accept_openapi_and_legacy_fields() -> None:
+    """
+    Validate response aliases introduced by the firmware OpenAPI refresh.
+    """
+    account = types.AccountState.model_validate({"status": "connected"})
+    ble = types.BleStatus.model_validate({"status": "connected", "address": "AA"})
+    update = types.UpdateStatus.model_validate(
+        {"check": {"available_version": "1.2.3", "status": "available"}}
+    )
+
+    assert account.status == "connected"
+    assert account.state == "connected"
+    assert ble.status == "connected"
+    assert ble.state == "connected"
+    assert update.check is not None
+    assert update.check.status == "available"
+    assert update.check.result == "available"

--- a/tests/busylib/client/test_openapi_sync.py
+++ b/tests/busylib/client/test_openapi_sync.py
@@ -309,15 +309,70 @@ def test_response_alias_models_accept_openapi_and_legacy_fields() -> None:
     Validate response aliases introduced by the firmware OpenAPI refresh.
     """
     account = types.AccountState.model_validate({"status": "connected"})
+    legacy_account = types.AccountState.model_validate({"state": "disconnected"})
+    conflict_account = types.AccountState.model_validate(
+        {"status": "connected", "state": "error"}
+    )
     ble = types.BleStatus.model_validate({"status": "connected", "address": "AA"})
+    legacy_ble = types.BleStatus.model_validate({"state": "connectable"})
     update = types.UpdateStatus.model_validate(
         {"check": {"available_version": "1.2.3", "status": "available"}}
     )
+    legacy_update = types.UpdateCheckStatus.model_validate({"result": "failure"})
 
     assert account.status == "connected"
     assert account.state == "connected"
+    assert account.model_dump(exclude_none=True) == {"status": "connected"}
+    assert legacy_account.status == "disconnected"
+    assert conflict_account.status == "connected"
+    assert conflict_account.state == "connected"
     assert ble.status == "connected"
     assert ble.state == "connected"
+    assert ble.model_dump(exclude_none=True) == {"status": "connected", "address": "AA"}
+    assert legacy_ble.status == "connectable"
     assert update.check is not None
     assert update.check.status == "available"
     assert update.check.result == "available"
+    assert update.check.model_dump(exclude_none=True) == {
+        "available_version": "1.2.3",
+        "status": "available",
+    }
+    assert legacy_update.status == "failure"
+
+
+def test_response_models_keep_firmware_strings_forward_compatible() -> None:
+    """
+    Ensure firmware response strings stay opaque for forward compatibility.
+    """
+    firmware = types.StatusFirmware.model_validate(
+        {"build_date": "2026-06-19T12:00:00", "target": 22}
+    )
+    transport = types.NetworkInterfaceInfo.model_validate({"type": "ethernet"})
+    backend = types.AccountBackend.model_validate(
+        {
+            "server_url": "default",
+            "client_cert_type": "future-cert",
+            "ignore_server_cert": False,
+        }
+    )
+    pairing = types.SmartHomePairingStatus.model_validate({"value": "in_progress"})
+    switch = types.SmartHomeSwitchState.model_validate(
+        {"state": True, "startup": "schedule"}
+    )
+    update = types.UpdateStatus.model_validate(
+        {
+            "install": {"event": "future_event", "action": "future_action"},
+            "check": {"status": "future_status"},
+        }
+    )
+
+    assert firmware.build_date == "2026-06-19T12:00:00"
+    assert transport.type == "ethernet"
+    assert backend.client_cert_type == "future-cert"
+    assert pairing.value == "in_progress"
+    assert switch.startup == "schedule"
+    assert update.install is not None
+    assert update.install.event == "future_event"
+    assert update.install.action == "future_action"
+    assert update.check is not None
+    assert update.check.status == "future_status"


### PR DESCRIPTION
## Summary

- Added client models for firmware OpenAPI additions so Python callers can validate backend settings, busy profiles, smart home state, transport details, status sections, timezone lists, storage rename, and autoupdate settings.
- Added sync and async helpers for the newly documented firmware endpoints so applications can call them without dropping to raw requests.
- Preserved compatibility aliases for response fields that changed from legacy client names to OpenAPI names while keeping model dumps canonical.
- Relaxed firmware-owned response string fields so future enum values do not break response validation.
- Added focused client tests so request paths, query params, JSON payloads, response aliases, build_date typing, and forward-compatible response strings stay aligned with the refreshed firmware OpenAPI.
- Updated README badges and project metadata so the package explicitly advertises Python 3.10-3.14 support and the existing MIT license.
- Removed AGENTS.md from repository tracking and ignored it so local agent instructions do not ship as package source.

## Review fixes

- Raised the build backend floor to `setuptools>=77` so SPDX `license = "MIT"` is valid across the declared build range.
- Made `StatusFirmware.build_date` an opaque string because the firmware OpenAPI declares it as a string without a datetime format.
- Prevented `AccountState`, `BleStatus`, and `UpdateCheckStatus` from duplicating legacy and OpenAPI alias keys in `model_dump()`.
- Added regression coverage for legacy alias input, OpenAPI-key priority on conflicts, and unknown future response enum values.

## License check

- Runtime dependency metadata is permissive: BSD-3-Clause, MIT-CMU, MIT, PSF-2.0, and BSD-style licenses.
- Development dependency metadata is permissive: MIT, BSD, Apache-2.0, and ISC licenses.
- No dependency metadata found in this check blocks publishing this project under the existing MIT license, assuming dependencies are consumed normally rather than vendored.

## Cleanup candidates

- Local logs such as bc.log, remote.log, hltv.log, snake.log, speed_racer.log, and remote_history.log look accidental and should stay untracked or be removed from local worktrees.
- Local cache and generated directories such as .history, root busylib/, dist/, src/busylib.egg-info/, __pycache__ trees, and test caches look removable from developer worktrees.
- Untracked old_examples/ and packages/busylib-mcp/ look stale or out-of-scope and should be reviewed before deleting because they are not currently tracked by git.
- Example folders under examples/ that are not tracked, such as snake, speed_racer, ws_debug, rasp, now_playing, hltv_live, schedules, and bar_events, should be reviewed before deciding whether they belong in the repository.

## Validation

- `uv run python -m pre_commit run --all-files`
- `uv run pytest -q`
