### PR TITLE
feat: sync client with firmware openapi 24.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,25 @@ if __name__ == "__main__":
     asyncio.run(main())
 ```
 
+## API Compatibility
+
+By default, `version()` records the device `api_semver` and logs a warning when
+it does not match the library compatibility header. Use strict mode when your
+application should fail fast on incompatible firmware.
+
+```python
+bb = BusyBar("10.0.4.20", compatibility_mode="strict")
+bb.version()
+```
+
+For migrations and diagnostics, methods can expose the OpenAPI version where
+they were introduced.
+
+```python
+metadata = bb.method_compatibility("log_dump")
+# {"version": "24.3.0", "path": "/api/log_dump", "method": "POST"}
+```
+
 ## API Examples
 
 Here are some examples of how to use the library to control your Busy Bar device.

--- a/src/busylib/_utils.py
+++ b/src/busylib/_utils.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from pydantic_extra_types.color import Color
+
+
+ColorInput = str | Sequence[int | float]
+
+
+def normalize_rgba_color(value: ColorInput | None) -> str | None:
+    """
+    Normalize supported CSS-like and RGB/RGBA inputs to OpenAPI #RRGGBBAA.
+
+    Integer channels are interpreted as 0-255 values, while float channels in
+    the 0-1 range are scaled to 0-255 for common normalized RGBA inputs.
+    """
+    if value is None:
+        return None
+
+    if isinstance(value, (list, tuple)):
+        if len(value) not in (3, 4):
+            raise ValueError("Color tuple/list must have 3 (RGB) or 4 (RGBA) elements")
+
+        def to_channel(component: int | float) -> int:
+            if isinstance(component, float):
+                scaled = component * 255 if component <= 1 else component
+                return int(round(scaled))
+            return int(component)
+
+        r, g, b = [max(0, min(255, to_channel(c))) for c in value[:3]]
+        alpha_component = value[3] if len(value) == 4 else 255
+        alpha = max(0, min(255, to_channel(alpha_component)))
+        return f"#{r:02X}{g:02X}{b:02X}{alpha:02X}"
+
+    if not isinstance(value, str):
+        raise ValueError("Color must be a string or RGB/RGBA tuple")
+
+    col = Color(value)
+    hex_value = col.as_hex().upper()
+    if len(hex_value) == 9:
+        return hex_value
+    if len(hex_value) == 7:
+        return f"{hex_value}FF"
+
+    rgb = col.as_rgb_tuple()
+    r, g, b = rgb[0], rgb[1], rgb[2]
+    return f"#{r:02X}{g:02X}{b:02X}FF"

--- a/src/busylib/client/base.py
+++ b/src/busylib/client/base.py
@@ -364,6 +364,7 @@ class SyncClientBase:
         backoff: float = DEFAULT_BACKOFF,
         transport: httpx.BaseTransport | None = None,
         api_version: str | None = None,
+        compatibility_mode: versioning.CompatibilityMode = "warn",
     ) -> None:
         if addr is None and token is None:
             self.base_url = settings.base_url
@@ -379,6 +380,9 @@ class SyncClientBase:
         self.max_retries = max(0, int(max_retries))
         self.backoff = backoff
         self.api_version = api_version or versioning.API_VERSION
+        if compatibility_mode not in ("warn", "strict", "none"):
+            raise ValueError("compatibility_mode must be 'warn', 'strict', or 'none'")
+        self.compatibility_mode: versioning.CompatibilityMode = compatibility_mode
         self._device_api_version: str | None = None
 
         headers: dict[str, str] = {versioning.API_VERSION_HEADER: self.api_version}
@@ -413,6 +417,18 @@ class SyncClientBase:
         Returns True for local connection_type.
         """
         return self.connection_type == "local"
+
+    def method_compatibility(
+        self,
+        method_name: str,
+    ) -> versioning.MethodCompatibility | None:
+        """
+        Return declarative OpenAPI compatibility metadata for a client method.
+        """
+        method = getattr(self, method_name, None)
+        if not callable(method):
+            return None
+        return versioning.get_method_compatibility(method)
 
     def is_local_available(self) -> bool:
         """
@@ -629,6 +645,7 @@ class AsyncClientBase:
         backoff: float = DEFAULT_BACKOFF,
         transport: httpx.AsyncBaseTransport | None = None,
         api_version: str | None = None,
+        compatibility_mode: versioning.CompatibilityMode = "warn",
     ) -> None:
         if addr is None and token is None:
             self.base_url = settings.base_url
@@ -644,6 +661,9 @@ class AsyncClientBase:
         self.max_retries = max(0, int(max_retries))
         self.backoff = backoff
         self.api_version = api_version or versioning.API_VERSION
+        if compatibility_mode not in ("warn", "strict", "none"):
+            raise ValueError("compatibility_mode must be 'warn', 'strict', or 'none'")
+        self.compatibility_mode: versioning.CompatibilityMode = compatibility_mode
         self._device_api_version: str | None = None
 
         headers: dict[str, str] = {versioning.API_VERSION_HEADER: self.api_version}
@@ -678,6 +698,18 @@ class AsyncClientBase:
         Returns True for local connection_type.
         """
         return self.connection_type == "local"
+
+    def method_compatibility(
+        self,
+        method_name: str,
+    ) -> versioning.MethodCompatibility | None:
+        """
+        Return declarative OpenAPI compatibility metadata for a client method.
+        """
+        method = getattr(self, method_name, None)
+        if not callable(method):
+            return None
+        return versioning.get_method_compatibility(method)
 
     async def is_local_available(self) -> bool:
         """

--- a/src/busylib/client/firmware.py
+++ b/src/busylib/client/firmware.py
@@ -8,9 +8,33 @@ from .base import AsyncClientBase, SyncClientBase
 logger = logging.getLogger(__name__)
 
 
+def _handle_compatibility(
+    *,
+    mode: versioning.CompatibilityMode,
+    library_version: str,
+    device_version: str,
+) -> None:
+    """
+    Apply configured API compatibility policy after `/api/version`.
+    """
+    if mode == "none":
+        return
+
+    error = versioning.compatibility_error(
+        library_version=library_version,
+        device_version=device_version,
+    )
+    if error is None:
+        return
+    if mode == "strict":
+        raise error
+
+    logger.warning("%s", error)
+
+
 class FirmwareMixin(SyncClientBase):
     """
-    Version, transport, and system status methods.
+    Version, transport, system status, and system maintenance methods.
     """
 
     def version(self) -> types.VersionInfo:
@@ -22,7 +46,8 @@ class FirmwareMixin(SyncClientBase):
         version_info = types.VersionInfo.model_validate(data)
         if version_info.api_semver:
             self._device_api_version = version_info.api_semver
-            versioning.ensure_compatible(
+            _handle_compatibility(
+                mode=self.compatibility_mode,
                 library_version=self.api_version,
                 device_version=version_info.api_semver,
             )
@@ -76,6 +101,22 @@ class FirmwareMixin(SyncClientBase):
         data = self._request("GET", "/api/status/power")
         return types.StatusPower.model_validate(data)
 
+    @versioning.requires_openapi("24.3.0", path="/api/log_dump", method="POST")
+    def log_dump(self, path: str | None = None) -> types.SuccessResponse:
+        """
+        Dump the in-memory device log buffer to a storage file.
+        """
+        logger.info("log_dump path=%s", path)
+        data = self._request(
+            "POST",
+            "/api/log_dump",
+            params={"path": path} if path is not None else None,
+            allow_text=True,
+        )
+        if data == "":
+            return types.SuccessResponse(result="OK")
+        return types.SuccessResponse.model_validate(data)
+
     def name(self) -> types.DeviceNameResponse:
         """
         Fetch device name via GET /api/name.
@@ -120,7 +161,8 @@ class AsyncFirmwareMixin(AsyncClientBase):
         version_info = types.VersionInfo.model_validate(data)
         if version_info.api_semver:
             self._device_api_version = version_info.api_semver
-            versioning.ensure_compatible(
+            _handle_compatibility(
+                mode=self.compatibility_mode,
                 library_version=self.api_version,
                 device_version=version_info.api_semver,
             )
@@ -173,6 +215,22 @@ class AsyncFirmwareMixin(AsyncClientBase):
         logger.info("async status_power")
         data = await self._request("GET", "/api/status/power")
         return types.StatusPower.model_validate(data)
+
+    @versioning.requires_openapi("24.3.0", path="/api/log_dump", method="POST")
+    async def log_dump(self, path: str | None = None) -> types.SuccessResponse:
+        """
+        Dump the in-memory device log buffer to a storage file.
+        """
+        logger.info("async log_dump path=%s", path)
+        data = await self._request(
+            "POST",
+            "/api/log_dump",
+            params={"path": path} if path is not None else None,
+            allow_text=True,
+        )
+        if data == "":
+            return types.SuccessResponse(result="OK")
+        return types.SuccessResponse.model_validate(data)
 
     async def name(self) -> types.DeviceNameResponse:
         """

--- a/src/busylib/types.py
+++ b/src/busylib/types.py
@@ -12,9 +12,9 @@ from pydantic import (
     field_validator,
     model_validator,
 )
-from pydantic_extra_types.color import Color
 
 from . import exceptions
+from ._utils import ColorInput, normalize_rgba_color
 
 
 class BaseModel(PydanticBaseModel):
@@ -115,6 +115,7 @@ class DisplayElementType(StrEnum):
     IMAGE = "image"
     ANIMATION = "animation"
     COUNTDOWN = "countdown"
+    RECTANGLE = "rectangle"
 
 
 class DisplayName(StrEnum):
@@ -172,6 +173,10 @@ class StatusDevice(BaseModel):
     otp_valid: bool | None = None
     otp_model: str | None = None
     otp_timestamp: int | None = None
+    firmware_security: str | None = Field(
+        default=None,
+        description="Firmware security status: secure, insecure, other, or unknown.",
+    )
 
     model_config = ConfigDict(extra="ignore")
 
@@ -531,17 +536,9 @@ class DisplayElementBase(BaseModel):
     id: str
     timeout: int | None = Field(default=None, ge=0)
     display_until: str | None = None
+    x: int = Field(default=0, ge=-4096, le=4095)
+    y: int = Field(default=0, ge=-4096, le=4095)
     display: DisplayName | None = DisplayName.FRONT
-
-    model_config = ConfigDict(extra="allow")
-
-
-class TextElement(DisplayElementBase):
-    type: Literal["text"] = "text"
-    x: int
-    y: int
-    text: str
-    font: DisplayFontName
     align: (
         Literal[
             "top_left",
@@ -556,87 +553,124 @@ class TextElement(DisplayElementBase):
         ]
         | None
     ) = None
-    color: str | Sequence[int | float] | None = None
+
+    model_config = ConfigDict(extra="allow")
+
+
+class TextElement(DisplayElementBase):
+    type: Literal["text"] = "text"
+    text: str
+    font: DisplayFontName
+    color: ColorInput | None = None
     width: int | None = Field(default=None, gt=0)
-    scroll_rate: int | None = Field(default=None, gt=0)
+    scroll_rate: int | None = Field(default=None, ge=0)
+    scroll_start_delay: int | None = Field(default=None, ge=0)
+    scroll_repeat_delay: int | None = Field(default=None, ge=0)
 
     @field_validator("color", mode="before")
     @classmethod
-    def _normalize_color(cls, value: str | Sequence[int | float] | None) -> str | None:
-        if value is None:
-            return None
-
-        if isinstance(value, (list, tuple)):
-            if len(value) not in (3, 4):
-                raise ValueError(
-                    "Color tuple/list must have 3 (RGB) or 4 (RGBA) elements"
-                )
-
-            def to_channel(component: int | float) -> int:
-                # Accept 0-1 floats or 0-255 ints
-                if isinstance(component, float):
-                    scaled = component * 255 if component <= 1 else component
-                    return int(round(scaled))
-                return int(component)
-
-            r, g, b = [max(0, min(255, to_channel(c))) for c in value[:3]]
-            alpha_component = value[3] if len(value) == 4 else 255
-            alpha = max(0, min(255, to_channel(alpha_component)))
-            return f"#{r:02X}{g:02X}{b:02X}{alpha:02X}"
-
-        if not isinstance(value, str):
-            raise ValueError("Color must be a string or RGB/RGBA tuple")
-
-        col = Color(value)
-        hex_value = col.as_hex().upper()
-        if len(hex_value) == 9:  # #RRGGBBAA
-            return hex_value
-        if len(hex_value) == 7:  # #RRGGBB, append opaque alpha
-            return f"{hex_value}FF"
-
-        rgb = col.as_rgb_tuple()
-        r, g, b = rgb[0], rgb[1], rgb[2]
-        return f"#{r:02X}{g:02X}{b:02X}FF"
+    def _normalize_color(cls, value: ColorInput | None) -> str | None:
+        return normalize_rgba_color(value)
 
 
 class ImageElement(DisplayElementBase):
     type: Literal["image"] = "image"
-    x: int
-    y: int
     path: str | None = None
     stock_path: str | None = None
+    opacity: int = Field(default=100, ge=0, le=100)
 
 
 class AnimationElement(DisplayElementBase):
     type: Literal["animation"] = "animation"
-    x: int
-    y: int
     path: str | None = None
     stock_path: str | None = None
     loop: bool = False
     await_previous_end: bool = False
     section: str | None = None
+    opacity: int = Field(default=100, ge=0, le=100)
 
 
 class CountdownElement(DisplayElementBase):
     type: Literal["countdown"] = "countdown"
-    x: int
-    y: int
     timestamp: str
-    color: str | Sequence[int | float] | None = None
+    color: ColorInput | None = None
     direction: Literal["time_left", "time_since"]
     show_hours: Literal["when_non_zero", "always"]
 
+    @field_validator("color", mode="before")
+    @classmethod
+    def _normalize_color(cls, value: ColorInput | None) -> str | None:
+        return normalize_rgba_color(value)
 
-DisplayElement = TextElement | ImageElement | AnimationElement | CountdownElement
+
+class RectangleElement(DisplayElementBase):
+    type: Literal["rectangle"] = "rectangle"
+    width: int = Field(gt=0)
+    height: int = Field(gt=0)
+    radius: int = Field(default=0, ge=0)
+    fill: Literal["none", "solid", "gradient_h", "gradient_v"] = "none"
+    fill_colors: list[ColorInput] = Field(
+        default_factory=lambda: ["#FFFFFFFF", "#00000000"],
+        min_length=1,
+        max_length=2,
+    )
+    border_width: int = Field(default=1, ge=0)
+    border_color: ColorInput = "#FFFFFFFF"
+
+    @field_validator("fill_colors", mode="before")
+    @classmethod
+    def _normalize_fill_colors(
+        cls,
+        value: Sequence[ColorInput | None] | None,
+    ) -> list[str]:
+        """
+        Normalize rectangle fill colors while preserving OpenAPI list shape.
+        """
+        if value is None:
+            return ["#FFFFFFFF", "#00000000"]
+        if isinstance(value, str):
+            raise ValueError("fill_colors must be a list of colors")
+
+        colors: list[str] = []
+        for item in value:
+            if item is None:
+                raise ValueError("fill_colors must not contain null values")
+            normalized = normalize_rgba_color(item)
+            if normalized is None:
+                raise ValueError("fill_colors must not contain null values")
+            colors.append(normalized)
+        return colors
+
+    @field_validator("border_color", mode="before")
+    @classmethod
+    def _normalize_border_color(
+        cls,
+        value: ColorInput | None,
+    ) -> str | None:
+        return normalize_rgba_color(value)
+
+
+DisplayElement = Annotated[
+    TextElement | ImageElement | AnimationElement | CountdownElement | RectangleElement,
+    Field(discriminator="type"),
+]
 
 
 class DisplayElements(BaseModel):
     application_name: str = Field(min_length=1)
     priority: int = Field(default=50, ge=1, le=100)
-    elements: list[DisplayElement]
+    led_notification_color: ColorInput | None = None
+    elements: list[DisplayElement] = Field(min_length=1)
 
     model_config = ConfigDict(extra="ignore", populate_by_name=True)
+
+    @field_validator("led_notification_color", mode="before")
+    @classmethod
+    def _normalize_led_color(
+        cls,
+        value: ColorInput | None,
+    ) -> str | None:
+        return normalize_rgba_color(value)
 
 
 class DisplayBrightnessInfo(BaseModel):

--- a/src/busylib/versioning.py
+++ b/src/busylib/versioning.py
@@ -2,11 +2,59 @@ from __future__ import annotations
 
 import os
 import re
+from collections.abc import Callable
+from typing import Literal, TypeVar
 
 from . import exceptions
 
 API_VERSION = os.environ.get("BUSY_API_VERSION", "0.1.0")
 API_VERSION_HEADER = "X-Busy-Api-Version"
+CompatibilityMode = Literal["warn", "strict", "none"]
+F = TypeVar("F", bound=Callable[..., object])
+
+
+class MethodCompatibility(dict[str, str]):
+    """
+    Dictionary metadata describing when a client helper appeared in OpenAPI.
+    """
+
+
+def requires_openapi(
+    version: str,
+    *,
+    path: str,
+    method: str,
+) -> Callable[[F], F]:
+    """
+    Attach declarative OpenAPI compatibility metadata to a client method.
+    """
+
+    def decorator(func: F) -> F:
+        setattr(
+            func,
+            "__busy_openapi__",
+            MethodCompatibility(
+                version=version,
+                path=path,
+                method=method,
+            ),
+        )
+        return func
+
+    return decorator
+
+
+def get_method_compatibility(
+    method: Callable[..., object],
+) -> MethodCompatibility | None:
+    """
+    Return OpenAPI compatibility metadata attached to a client method.
+    """
+    target = getattr(method, "__func__", method)
+    metadata = getattr(target, "__busy_openapi__", None)
+    if isinstance(metadata, MethodCompatibility):
+        return metadata
+    return None
 
 
 def _parse_major_minor(version: str) -> tuple[int, int]:
@@ -46,3 +94,21 @@ def ensure_compatible(*, library_version: str, device_version: str) -> None:
             device_version=device_version,
             message="Device API minor version is behind Busy Lib; please update firmware.",
         )
+
+
+def compatibility_error(
+    *,
+    library_version: str,
+    device_version: str,
+) -> exceptions.BusyBarAPIVersionError | None:
+    """
+    Return compatibility error instead of raising it.
+    """
+    try:
+        ensure_compatible(
+            library_version=library_version,
+            device_version=device_version,
+        )
+    except exceptions.BusyBarAPIVersionError as exc:
+        return exc
+    return None

--- a/tests/busylib/client/test_client.py
+++ b/tests/busylib/client/test_client.py
@@ -67,6 +67,23 @@ def test_version_success():
     assert result.branch == "main"
 
 
+def test_version_default_api_version_remains_device_semver() -> None:
+    """
+    Keep the default API compatibility header on the device semver track.
+    """
+    seen: dict[str, str | None] = {}
+
+    def responder(request: httpx.Request) -> httpx.Response:
+        seen["header"] = request.headers.get("x-busy-api-version")
+        return httpx.Response(200, json={"api_semver": "0.1.0"})
+
+    client = make_client(responder)
+    result = client.version()
+
+    assert result.api_semver == "0.1.0"
+    assert seen["header"] == "0.1.0"
+
+
 def test_name_and_time():
     """
     Fetch device name and time from their respective endpoints.
@@ -226,9 +243,26 @@ def test_plain_text_error_response():
     assert "HTTP 404" in str(exc.value)
 
 
-def test_version_incompatible_requires_device_update():
+def test_version_incompatible_warns_by_default(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
     """
-    Reject incompatible firmware API versions.
+    Warn by default instead of blocking callers on API version mismatch.
+    """
+
+    def responder(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json={"api_semver": "0.9.0"})
+
+    client = make_client(responder, api_version="1.0.0")
+    result = client.version()
+
+    assert result.api_semver == "0.9.0"
+    assert "update firmware" in caplog.text
+
+
+def test_version_incompatible_strict_requires_device_update():
+    """
+    Reject incompatible firmware API versions in strict mode.
 
     Ensures the version guard raises a dedicated error.
     """
@@ -236,10 +270,55 @@ def test_version_incompatible_requires_device_update():
     def responder(request: httpx.Request) -> httpx.Response:
         return httpx.Response(200, json={"api_semver": "0.9.0"})
 
-    client = make_client(responder, api_version="1.0.0")
+    client = make_client(
+        responder,
+        api_version="1.0.0",
+        compatibility_mode="strict",
+    )
     with pytest.raises(exceptions.BusyBarAPIVersionError) as exc:
         client.version()
     assert "update firmware" in str(exc.value)
+
+
+def test_version_incompatible_can_skip_compatibility_check() -> None:
+    """
+    Allow callers to opt out from compatibility checks.
+    """
+
+    def responder(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json={"api_semver": "0.9.0"})
+
+    client = make_client(
+        responder,
+        api_version="1.0.0",
+        compatibility_mode="none",
+    )
+    result = client.version()
+
+    assert result.api_semver == "0.9.0"
+
+
+def test_client_rejects_unknown_compatibility_mode() -> None:
+    """
+    Validate compatibility policy names at client construction.
+    """
+    with pytest.raises(ValueError):
+        make_client(lambda _request: httpx.Response(200), compatibility_mode="fail")
+
+
+def test_method_compatibility_metadata() -> None:
+    """
+    Expose declarative OpenAPI metadata for version-gated helpers.
+    """
+    client = make_client(lambda _request: httpx.Response(200, json={"result": "OK"}))
+    metadata = client.method_compatibility("log_dump")
+
+    assert metadata == {
+        "version": "24.3.0",
+        "path": "/api/log_dump",
+        "method": "POST",
+    }
+    assert client.method_compatibility("missing") is None
 
 
 def test_request_carries_api_version_header():

--- a/tests/busylib/client/test_openapi_sync.py
+++ b/tests/busylib/client/test_openapi_sync.py
@@ -5,7 +5,7 @@ import json
 import httpx
 import pytest
 
-from busylib import AsyncBusyBar, BusyBar, types
+from busylib import AsyncBusyBar, BusyBar, exceptions, types
 
 
 def _make_sync_client(responder) -> BusyBar:
@@ -151,6 +151,7 @@ def test_system_time_update_and_storage_endpoints_match_openapi() -> None:
                     "serial_number": "203638485431500400123456",
                     "usb_mac": "0c:fa:22:21:2a:31",
                     "otp_valid": True,
+                    "firmware_security": "secure",
                 },
             )
         if request.url.path == "/api/status/firmware":
@@ -183,29 +184,216 @@ def test_system_time_update_and_storage_endpoints_match_openapi() -> None:
                     "interval_end": "08:00",
                 },
             )
+        if request.url.path == "/api/log_dump":
+            return httpx.Response(200)
         return httpx.Response(200, json={"result": "OK"})
 
     client = _make_sync_client(responder)
     assert client.transport().type == "wifi"
-    assert client.status_device().serial_number == "203638485431500400123456"
+    device = client.status_device()
+    assert device.serial_number == "203638485431500400123456"
+    assert device.firmware_security == "secure"
     assert client.status_firmware().target == 22
     assert client.time_timezone_info().abbr == "IST"
     assert client.time_timezone_list().list[0].name == "UTC"
     assert client.storage_rename("/ext/a.txt", "/ext/b.txt").result == "OK"
+    assert client.log_dump("/ext/dump.log").result == "OK"
     autoupdate = client.update_autoupdate()
     assert autoupdate.is_enabled is True
     assert client.update_autoupdate_set({"is_enabled": False}).result == "OK"
 
-    assert seen[5] == {
+    storage_request = next(
+        item for item in seen if item["path"] == "/api/storage/rename"
+    )
+    log_dump_request = next(item for item in seen if item["path"] == "/api/log_dump")
+    autoupdate_put = next(
+        item
+        for item in seen
+        if item["path"] == "/api/update/autoupdate" and item["body"] != b""
+    )
+
+    assert storage_request == {
         "method": "POST",
         "path": "/api/storage/rename",
         "params": {"old_path": "/ext/a.txt", "new_path": "/ext/b.txt"},
         "body": b"",
     }
-    assert seen[7]["path"] == "/api/update/autoupdate"
-    autoupdate_body = seen[7]["body"]
+    assert log_dump_request == {
+        "method": "POST",
+        "path": "/api/log_dump",
+        "params": {"path": "/ext/dump.log"},
+        "body": b"",
+    }
+    autoupdate_body = autoupdate_put["body"]
     assert isinstance(autoupdate_body, bytes)
     assert json.loads(autoupdate_body) == {"is_enabled": False}
+
+
+def test_display_rectangle_payload_matches_openapi() -> None:
+    """
+    Ensure display draw serializes newly documented rectangle and LED fields.
+    """
+    seen: list[dict[str, object]] = []
+
+    def responder(request: httpx.Request) -> httpx.Response:
+        seen.append(
+            {
+                "method": request.method,
+                "path": request.url.path,
+                "body": request.content,
+            }
+        )
+        return httpx.Response(200, json={"result": "OK"})
+
+    client = _make_sync_client(responder)
+    response = client.display_draw(
+        {
+            "application_name": "my_app",
+            "priority": 90,
+            "led_notification_color": "red",
+            "elements": [
+                {
+                    "id": "text",
+                    "type": "text",
+                    "text": "Hello",
+                    "font": "normal",
+                    "x": 1,
+                    "y": 2,
+                    "scroll_start_delay": 1000,
+                    "scroll_repeat_delay": 2500,
+                },
+                {
+                    "id": "rect",
+                    "type": "rectangle",
+                    "width": 10,
+                    "height": 5,
+                    "radius": 2,
+                    "fill": "gradient_h",
+                    "fill_colors": ["#FF0000FF", "blue"],
+                    "border_width": 2,
+                    "border_color": (0, 255, 0, 0.5),
+                },
+                {
+                    "id": "image",
+                    "type": "image",
+                    "path": "data.png",
+                    "opacity": 75,
+                },
+            ],
+        }
+    )
+
+    assert response.result == "OK"
+    assert seen[0]["method"] == "POST"
+    assert seen[0]["path"] == "/api/display/draw"
+    body = seen[0]["body"]
+    assert isinstance(body, bytes)
+    assert json.loads(body) == {
+        "application_name": "my_app",
+        "priority": 90,
+        "led_notification_color": "#FF0000FF",
+        "elements": [
+            {
+                "id": "text",
+                "x": 1,
+                "y": 2,
+                "display": "front",
+                "type": "text",
+                "text": "Hello",
+                "font": "normal",
+                "scroll_start_delay": 1000,
+                "scroll_repeat_delay": 2500,
+            },
+            {
+                "id": "rect",
+                "x": 0,
+                "y": 0,
+                "display": "front",
+                "type": "rectangle",
+                "width": 10,
+                "height": 5,
+                "radius": 2,
+                "fill": "gradient_h",
+                "fill_colors": ["#FF0000FF", "#0000FFFF"],
+                "border_width": 2,
+                "border_color": "#00FF0080",
+            },
+            {
+                "id": "image",
+                "x": 0,
+                "y": 0,
+                "display": "front",
+                "type": "image",
+                "path": "data.png",
+                "opacity": 75,
+            },
+        ],
+    }
+
+
+def test_display_payload_validation_matches_openapi_discriminator() -> None:
+    """
+    Reject missing element types, empty element lists, and invalid fill colors.
+    """
+    with pytest.raises(exceptions.BusyBarResponseValidationError):
+        types.DisplayElements.model_validate(
+            {"application_name": "my_app", "elements": [{"id": "bare"}]}
+        )
+
+    with pytest.raises(exceptions.BusyBarResponseValidationError):
+        types.DisplayElements.model_validate(
+            {"application_name": "my_app", "elements": []}
+        )
+
+    with pytest.raises(exceptions.BusyBarResponseValidationError):
+        types.DisplayElements.model_validate(
+            {
+                "application_name": "my_app",
+                "elements": [
+                    {
+                        "id": "rect",
+                        "type": "rectangle",
+                        "width": 10,
+                        "height": 5,
+                        "fill_colors": ["red", None],
+                    }
+                ],
+            }
+        )
+
+    with pytest.raises(exceptions.BusyBarResponseValidationError):
+        types.DisplayElements.model_validate(
+            {
+                "application_name": "my_app",
+                "elements": [
+                    {
+                        "id": "rect",
+                        "type": "rectangle",
+                        "width": 10,
+                        "height": 5,
+                        "fill_colors": "red",
+                    }
+                ],
+            }
+        )
+
+    display = types.DisplayElements.model_validate(
+        {
+            "application_name": "my_app",
+            "elements": [
+                {
+                    "id": "text",
+                    "type": "text",
+                    "text": "Hello",
+                    "font": "normal",
+                    "scroll_rate": 0,
+                }
+            ],
+        }
+    )
+    text = display.elements[0]
+    assert isinstance(text, types.TextElement)
+    assert text.scroll_rate == 0
 
 
 def test_smart_home_sync_requests_match_openapi() -> None:
@@ -287,6 +475,8 @@ async def test_async_new_openapi_helpers() -> None:
             return httpx.Response(200, json=_busy_profile_payload())
         if request.url.path == "/api/smart_home/switch":
             return httpx.Response(200, json={"state": True})
+        if request.url.path == "/api/log_dump":
+            return httpx.Response(200)
         return httpx.Response(200, json={"result": "OK"})
 
     client = _make_async_client(responder)
@@ -294,6 +484,7 @@ async def test_async_new_openapi_helpers() -> None:
     assert (await client.busy_profile("busy")).title == "Focus"
     assert (await client.smart_home_switch()).state is True
     assert (await client.storage_rename("/a", "/b")).result == "OK"
+    assert (await client.log_dump()).result == "OK"
     await client.aclose()
 
     assert seen == [
@@ -301,6 +492,7 @@ async def test_async_new_openapi_helpers() -> None:
         "GET /api/busy/profiles/busy",
         "GET /api/smart_home/switch",
         "POST /api/storage/rename",
+        "POST /api/log_dump",
     ]
 
 


### PR DESCRIPTION
## Summary

- Added `log_dump()` helpers for sync and async clients so callers can use the documented `/api/log_dump` endpoint, including empty 200 responses from the firmware spec.
- Extended status and display models with firmware security, LED notification color, image and animation opacity, text scroll delays, and rectangle elements to match the latest OpenAPI schemas.
- Tightened display payload validation with OpenAPI discriminator semantics, non-empty element lists, strict rectangle fill colors, and `scroll_rate=0` support.
- Added configurable API compatibility handling: default warnings, strict fail-fast mode, disabled checks, and declarative OpenAPI metadata for version-gated helpers.
- Added OpenAPI regression coverage and README notes for the new system, display, and compatibility behavior.

## Validation

- `uv run pytest -q`
- `uv run pyright src tests`
- `uv run python -m pre_commit run --all-files`

Note: direct `uv run pyright` still reports pre-existing errors under `examples/`; the changed `src` and `tests` trees pass.
