### PR TITLE
Add device discovery over mDNS

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,6 +222,24 @@ volume = bb.audio_volume()
 print(f"Volume: {volume.volume}")
 ```
 
+### Discovering devices on the network
+
+Instead of hardcoding an IP address, you can discover devices like so:
+
+```python
+from busylib import BusyBarDevices
+
+for device in BusyBarDevices.discover():
+    print(f"Device: {device.name}")
+    print(f"  Over USB: {device.get_address('over_usb')}")
+    print(f"  Over Wi-Fi: {device.get_address('over_wifi')}")
+
+# Example output:
+# Device: "Anna's Busy Bar"
+#   Over USB: 10.0.4.20
+#   Over Wi-Fi: 192.168.100.2
+```
+
 ### Preparing and Executing Requests Separately
 
 You can prepare a low-level request first and execute it later, optionally

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ dependencies = [
   "pydantic-settings>=2.12",
   "typing-extensions>=4.6",
   "websockets>=12",
+  "zeroconf>=0.150",
 ]
 urls.Documentation = "https://busylib.readthedocs.io"
 urls.Homepage = "https://github.com/busy-app/busylib-py"

--- a/src/busylib/__init__.py
+++ b/src/busylib/__init__.py
@@ -1,12 +1,14 @@
 from __future__ import annotations
 
 from . import exceptions, types
+from .devices import BusyBarDevices
 from .client import AsyncBusyBar, BusyBar, PreparedRequest
 
 __all__ = [
     "BusyBar",
     "AsyncBusyBar",
     "PreparedRequest",
+    "BusyBarDevices",
     "exceptions",
     "types",
 ]

--- a/src/busylib/devices.py
+++ b/src/busylib/devices.py
@@ -50,7 +50,9 @@ class BusyBarDevices:
         return BusyBarAddress(ip_address=address, affinity=BusyBarDevices._address_affinity(address))
 
     @staticmethod
-    def discover() -> list[BusyBarDevice]:
+    def discover(timeout: float = TIMEOUT) -> list[BusyBarDevice]:
+        ...
+        sleep(timeout)
         zeroconf = Zeroconf()
 
         devices_by_id: dict[str, BusyBarDevice] = {}
@@ -69,13 +71,14 @@ class BusyBarDevices:
             addresses = info.ip_addresses_by_version(IPVersion.V4Only)
             addresses = (BusyBarDevices._ip_address_to_our(addr.compressed) for addr in addresses)
 
-            device_name = str(info.properties[b"name"] or BUSYBAR_DEFAULT_NAME, "utf8")
+            raw_name = info.properties.get(b"name") or BUSYBAR_DEFAULT_NAME
+            device_name = raw_name.decode("utf-8", errors="replace")
             default_device = BusyBarDevice(name=device_name, temporary_id=temporary_id, addresses=set())
             device = devices_by_id.get(temporary_id, default_device)
             device.addresses = device.addresses.union(addresses)
             devices_by_id[temporary_id] = device
 
-        browser = ServiceBrowser(zeroconf, BUSYBAR_SERVICE, handlers=[_on_service_state_change])
+        ServiceBrowser(zeroconf, BUSYBAR_SERVICE, handlers=[_on_service_state_change])
         sleep(TIMEOUT)
         zeroconf.close()
 

--- a/src/busylib/devices.py
+++ b/src/busylib/devices.py
@@ -50,10 +50,9 @@ class BusyBarDevices:
         return BusyBarAddress(ip_address=address, affinity=BusyBarDevices._address_affinity(address))
 
     @staticmethod
-    def discover(timeout: float = TIMEOUT) -> list[BusyBarDevice]:
-        ...
-        sleep(timeout)
-        zeroconf = Zeroconf()
+    def discover(timeout: float = TIMEOUT, zeroconf: Zeroconf | None = None) -> list[BusyBarDevice]:
+        if not zeroconf:
+            zeroconf = Zeroconf()
 
         devices_by_id: dict[str, BusyBarDevice] = {}
 
@@ -79,7 +78,7 @@ class BusyBarDevices:
             devices_by_id[temporary_id] = device
 
         ServiceBrowser(zeroconf, BUSYBAR_SERVICE, handlers=[_on_service_state_change])
-        sleep(TIMEOUT)
+        sleep(timeout)
         zeroconf.close()
 
         return list(devices_by_id.values())

--- a/src/busylib/devices.py
+++ b/src/busylib/devices.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+from typing import Literal
+from dataclasses import dataclass
+from enum import Enum
+from time import sleep
+
+from zeroconf import (
+    IPVersion,
+    ServiceBrowser,
+    ServiceStateChange,
+    Zeroconf,
+)
+
+BUSYBAR_SERVICE = "_busybar._tcp.local."
+BUSYBAR_USB_SUBNET = "10.0.4."
+BUSYBAR_DEFAULT_NAME = b"BUSY Bar"
+TIMEOUT = 1.5
+
+class BusyBarAddressAffinity(Enum):
+    OVER_USB = "over_usb"
+    OVER_WIFI = "over_wifi"
+
+@dataclass(unsafe_hash=True)
+class BusyBarAddress:
+    ip_address: str
+    affinity: BusyBarAddressAffinity
+
+@dataclass
+class BusyBarDevice:
+    name: str
+    temporary_id: str
+    addresses: set[BusyBarAddress]
+
+    def get_address(self, affinity: Literal["over_usb"]|Literal["over_wifi"]) -> str|None:
+        for addr in self.addresses:
+            if addr.affinity.value == affinity:
+                return addr.ip_address
+        return None
+
+class BusyBarDevices:
+    @staticmethod
+    def _address_affinity(address: str) -> BusyBarAddressAffinity:
+        if address.startswith(BUSYBAR_USB_SUBNET):
+            return BusyBarAddressAffinity.OVER_USB
+        else:
+            return BusyBarAddressAffinity.OVER_WIFI
+
+    @staticmethod
+    def _ip_address_to_our(address: str) -> BusyBarAddress:
+        return BusyBarAddress(ip_address=address, affinity=BusyBarDevices._address_affinity(address))
+
+    @staticmethod
+    def discover() -> list[BusyBarDevice]:
+        zeroconf = Zeroconf()
+
+        devices_by_id: dict[str, BusyBarDevice] = {}
+
+        def _on_service_state_change(
+            zeroconf: Zeroconf, service_type: str, name: str, state_change: ServiceStateChange
+        ) -> None:
+            if state_change not in [ServiceStateChange.Added, ServiceStateChange.Updated]:
+                return
+            
+            info = zeroconf.get_service_info(service_type, name)
+            if not info:
+                return
+            
+            temporary_id = info.name.split(".")[0]
+            addresses = info.ip_addresses_by_version(IPVersion.V4Only)
+            addresses = (BusyBarDevices._ip_address_to_our(addr.compressed) for addr in addresses)
+
+            device_name = str(info.properties[b"name"] or BUSYBAR_DEFAULT_NAME, "utf8")
+            default_device = BusyBarDevice(name=device_name, temporary_id=temporary_id, addresses=set())
+            device = devices_by_id.get(temporary_id, default_device)
+            device.addresses = device.addresses.union(addresses)
+            devices_by_id[temporary_id] = device
+
+        browser = ServiceBrowser(zeroconf, BUSYBAR_SERVICE, handlers=[_on_service_state_change])
+        sleep(TIMEOUT)
+        zeroconf.close()
+
+        return list(devices_by_id.values())


### PR DESCRIPTION
Adds device discovery using mDNS

Requires firmware from https://github.com/busy-app/busybar-firmware/pull/886 until merged into `dev`.