### PR TITLE
Fix onboarding gaps found testing the release on a factory bar

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,15 +48,18 @@ bb = BusyBar("10.0.4.20")
 print(bb.version())
 ```
 
-If you get a `403 Forbidden`, the bar has an access key set. Pass it as a
-token — the same key the web UI asks for:
-
-```python
-bb = BusyBar("10.0.4.20", token="your-access-key")
-```
+Over USB no token is needed: the firmware only enforces its access key on
+connections that arrive over Wi-Fi, so anything reaching `10.0.4.20` is
+already trusted.
 
 Once the bar is on Wi-Fi you can use its Wi-Fi address instead, or let the
 library find it for you — see [Discovering devices](#discovering-devices-on-the-network).
+That path *can* answer `403 Forbidden`, which means an access key is set —
+a 4–10 digit PIN, the same one the web UI asks for:
+
+```python
+bb = BusyBar("192.168.1.20", token="1234")
+```
 
 ## Step 2 — First-time setup
 

--- a/README.md
+++ b/README.md
@@ -48,9 +48,9 @@ bb = BusyBar("10.0.4.20")
 print(bb.version())
 ```
 
-Over USB no token is needed: the firmware only enforces its access key on
-connections that arrive over Wi-Fi, so anything reaching `10.0.4.20` is
-already trusted.
+Current firmware enforces its access key only on connections arriving over
+Wi-Fi, so a bar reached over USB usually needs no token. If you do get a
+`403 Forbidden` here, pass the key as a token the same way as below.
 
 Once the bar is on Wi-Fi you can use its Wi-Fi address instead, or let the
 library find it for you — see [Discovering devices](#discovering-devices-on-the-network).

--- a/docs/guides/building-a-tool.md
+++ b/docs/guides/building-a-tool.md
@@ -1,0 +1,125 @@
+# Building a tool with busylib
+
+The setup wizard that ships with the library is a small, real program: it
+reads what a bar is currently doing, decides what's left to configure, and
+changes only that. This page walks through how it's put together, because the
+same shape works for most tools you'd write against a bar.
+
+The code shown here isn't a transcription — it's pulled straight from
+`examples/setup/operations.py`, so it can't drift from the program that runs.
+
+## One function per device operation
+
+Every interaction with the bar is its own function that takes a client and
+returns plain data. No printing, no prompting, no program state:
+
+::: examples.setup.operations.read_device_name
+    options:
+      show_root_heading: true
+      show_root_full_path: false
+      heading_level: 3
+
+::: examples.setup.operations.rename_device
+    options:
+      show_root_heading: true
+      show_root_full_path: false
+      heading_level: 3
+
+That separation is what makes them reusable. `read_device_name` is equally at
+home in a monitoring script, and it's testable without a terminal.
+
+## Reading state before changing it
+
+Most operations come in pairs: read what's there, then act only if needed.
+Reading is where the device's quirks live, so that's where the comments go:
+
+::: examples.setup.operations.read_firmware_state
+    options:
+      show_root_heading: true
+      show_root_full_path: false
+      heading_level: 3
+
+Two things worth copying from this. It reads from two endpoints because
+neither has the whole answer, and it treats the second as best-effort — an
+unreachable `/api/status` costs the version label, not the verdict. And it
+asks the library whether the device is supported rather than comparing
+version strings itself.
+
+## Operations that need to wait
+
+Some device actions are asynchronous: you ask, then poll for the outcome.
+
+::: examples.setup.operations.find_available_update
+    options:
+      show_root_heading: true
+      show_root_full_path: false
+      heading_level: 3
+
+The subtlety here cost a release fix: `available_version` keeps the result of
+an *earlier* check, so acting on it while a new check is running gets a
+`400 "Update not available"` back. Waiting for the device's own status to
+read `available` is what makes the install stick.
+
+## Operations that are allowed to fail
+
+Not every failure deserves to stop the program:
+
+::: examples.setup.operations.scan_networks
+    options:
+      show_root_heading: true
+      show_root_full_path: false
+      heading_level: 3
+
+A bar refuses to scan while it's associated. That's not an error worth
+aborting over — the caller can just ask for an SSID instead — so the function
+returns an empty list and says why in the log.
+
+## Assembling the pipeline
+
+With the operations in place, a step is only the conversation: what to show,
+what to ask, and when the work is already done.
+
+```python
+class NameStep(SetupStep):
+    key = "name"
+    title = "Device name"
+
+    async def status(self, client) -> StepStatus:
+        current = await operations.read_device_name(client)
+        if current and current != DEFAULT_DEVICE_NAME:
+            return StepStatus(done=True, summary=current)
+        return StepStatus(done=False, summary=f"{current or 'unset'} (factory default)")
+
+    async def run(self, client, prompt) -> None:
+        value = await prompt.text("Device name")
+        error = validate_device_name(value)
+        if error is not None:
+            prompt.info(f"Invalid name: {error}")
+            raise SetupCancelled
+        await operations.rename_device(client, value)
+```
+
+The pipeline is then just a list, run in order:
+
+```python
+def default_steps() -> list[SetupStep]:
+    return [FirmwareStep(), WifiStep(), TimezoneStep(), NameStep(), CloudStep()]
+```
+
+The wizard reads every step's `status()` concurrently, prints the checklist,
+and calls `run()` only on what's still pending — which is why re-running it
+after a reboot is safe.
+
+## Why this shape
+
+Splitting the device work out from the conversation buys three things:
+
+- **The operations are reusable.** Nothing in them assumes a wizard.
+- **They're testable without a terminal.** The wizard's tests drive them with
+  a fake client and a scripted prompt, and the tricky cases above — a stale
+  update check, a refused scan — are covered directly.
+- **The documentation stays true.** These examples are generated from the
+  source, so a change to the program updates this page.
+
+The full source is in
+[`examples/setup`](https://github.com/busy-app/busylib-py/tree/main/examples/setup).

--- a/docs/guides/connecting.md
+++ b/docs/guides/connecting.md
@@ -15,8 +15,13 @@ bb = BusyBar("192.168.1.20")       # over Wi-Fi
 
 ## Access keys
 
-If the bar's HTTP access mode is set to `key`, every request needs a token and
-unauthenticated calls come back as `403 Forbidden`:
+The access key is only enforced on connections arriving over Wi-Fi. USB (and
+localhost) traffic bypasses the check entirely, so a bar reached at
+`10.0.4.20` never needs a token no matter which access mode it is in.
+
+Over Wi-Fi, if the access mode is set to `key`, every request needs that token
+and unauthenticated calls come back as `403 Forbidden`. The key is a 4–10
+digit PIN:
 
 ```python
 bb = BusyBar("10.0.4.20", token="your-access-key")
@@ -76,4 +81,25 @@ longer timeout:
 
 ```python
 bb.assets_upload("my-app", "big.png", data, timeout=60.0)
+```
+
+## Helpers for endpoints that no longer exist
+
+A few helpers target device endpoints that current firmware doesn't serve at
+all. They fail immediately with `BusyBarRemovedEndpointError` and name their
+replacement, rather than letting an opaque `404` come back:
+
+| Helper | Use instead |
+| --- | --- |
+| `account_profile()`, `account_profile_set()` | `account_backend()`, `account_backend_set()` |
+| `wifi_enable()`, `wifi_disable()` | `wifi_connect()`, `wifi_disconnect()` |
+
+This is deliberately distinct from `BusyBarAPIVersionError`: updating the
+firmware won't help, because the endpoint was withdrawn rather than added
+later. `method_compatibility()` reports the same information:
+
+```python
+bb.method_compatibility("account_profile")
+# {'path': '/api/account/profile', 'method': 'GET',
+#  'status': 'removed', 'replacement': 'account_backend()'}
 ```

--- a/docs/guides/connecting.md
+++ b/docs/guides/connecting.md
@@ -15,9 +15,11 @@ bb = BusyBar("192.168.1.20")       # over Wi-Fi
 
 ## Access keys
 
-The access key is only enforced on connections arriving over Wi-Fi. USB (and
-localhost) traffic bypasses the check entirely, so a bar reached at
-`10.0.4.20` never needs a token no matter which access mode it is in.
+On current firmware the access key is enforced only on connections arriving
+over Wi-Fi — USB and localhost traffic skips the check — so a bar reached at
+`10.0.4.20` usually needs no token whatever access mode it is in. Treat that
+as an observation about the firmware in front of you rather than a guarantee,
+and handle a `403` on the USB path too.
 
 Over Wi-Fi, if the access mode is set to `key`, every request needs that token
 and unauthenticated calls come back as `403 Forbidden`. The key is a 4–10
@@ -93,6 +95,12 @@ replacement, rather than letting an opaque `404` come back:
 | --- | --- |
 | `account_profile()`, `account_profile_set()` | `account_backend()`, `account_backend_set()` |
 | `wifi_enable()`, `wifi_disable()` | `wifi_connect()`, `wifi_disconnect()` |
+
+These did exist once — `wifi/enable` and `wifi/disable` up to firmware 0.2.0,
+`account/profile` from 0.6.0-rc to 0.8.1 — but every firmware since serves
+none of them, and the library targets a far newer API than those bars run. To
+talk to firmware that old, pin a `busylib` version from the same era, as the
+versioning policy describes; `api_request()` remains the escape hatch.
 
 This is deliberately distinct from `BusyBarAPIVersionError`: updating the
 firmware won't help, because the endpoint was withdrawn rather than added

--- a/examples/setup/__init__.py
+++ b/examples/setup/__init__.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from examples.setup.prompts import Prompt, SetupCancelled, TerminalPrompt
+from examples.setup import operations
 from examples.setup.steps import SetupStep, StepStatus, default_steps
 from examples.setup.wizard import StepReport, collect_status, run_setup
 
@@ -11,6 +12,7 @@ __all__ = [
     "StepReport",
     "StepStatus",
     "TerminalPrompt",
+    "operations",
     "collect_status",
     "default_steps",
     "run_setup",

--- a/examples/setup/operations.py
+++ b/examples/setup/operations.py
@@ -1,0 +1,217 @@
+"""
+Device operations the setup wizard is built from.
+
+Each function does one thing with the client and returns plain data: no
+prompting, no printing, no wizard state. That keeps them usable on their own
+and makes them the worked examples the documentation quotes, so the guide and
+the program can't drift apart.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+
+from busylib import types, versioning
+from busylib.client import AsyncBusyBar
+
+logger = logging.getLogger(__name__)
+
+# The device only accepts an install while its own check reports "available";
+# any other value means the check is still running or found nothing.
+CHECK_STATUS_AVAILABLE = "available"
+CHECK_STATUS_TERMINAL_NO_UPDATE = frozenset({"not_available", "failure"})
+
+UPDATE_POLL_INTERVAL_SECONDS = 3.0
+UPDATE_TIMEOUT_SECONDS = 600.0
+
+
+@dataclass(frozen=True)
+class FirmwareState:
+    """
+    What the device runs, and whether this library supports it.
+    """
+
+    firmware_version: str | None
+    api_version: str
+    supported: bool
+
+
+async def read_firmware_state(client: AsyncBusyBar) -> FirmwareState:
+    """
+    Read the device's API version and the firmware version behind it.
+
+    `/api/version` only reports `api_semver`; the firmware's own version
+    string lives under `/api/status`. Reading the second is best-effort, so
+    an unreachable status endpoint costs the label rather than the verdict.
+    """
+    info = await client.version()
+    api_version = info.api_semver or "unknown"
+
+    firmware_version = info.version
+    if not firmware_version:
+        firmware_version = await _firmware_version_from_status(client)
+
+    supported = (
+        versioning.compatibility_error(
+            library_version=versioning.API_VERSION,
+            device_version=api_version,
+        )
+        is None
+    )
+    return FirmwareState(
+        firmware_version=firmware_version,
+        api_version=api_version,
+        supported=supported,
+    )
+
+
+async def _firmware_version_from_status(client: AsyncBusyBar) -> str | None:
+    """
+    Pull the firmware version out of `/api/status`, or None if unreadable.
+    """
+    try:
+        status = await client.status()
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("setup: could not read firmware version: %s", exc)
+        return None
+    if status.firmware is not None and status.firmware.version:
+        return status.firmware.version
+    if status.system is not None and status.system.version:
+        return status.system.version
+    return None
+
+
+async def find_available_update(
+    client: AsyncBusyBar,
+    *,
+    timeout: float = UPDATE_TIMEOUT_SECONDS,
+    poll_interval: float = UPDATE_POLL_INTERVAL_SECONDS,
+) -> str | None:
+    """
+    Ask the device to check for an update and wait for the verdict.
+
+    Returns the offered version, or None when the check finishes with
+    nothing to install. `available_version` alone isn't enough to act on: it
+    keeps the version from an earlier check, so the device's current status
+    has to read "available" before an install is accepted.
+    """
+    await client.update_check()
+
+    started = time.monotonic()
+    while time.monotonic() - started < timeout:
+        status = await client.update_status()
+        check = status.check
+        if check is not None:
+            result = (check.status or "").lower()
+            if result == CHECK_STATUS_AVAILABLE and check.available_version:
+                return check.available_version
+            if result in CHECK_STATUS_TERMINAL_NO_UPDATE:
+                return None
+        await asyncio.sleep(poll_interval)
+    return None
+
+
+async def install_update(client: AsyncBusyBar, version: str) -> None:
+    """
+    Start installing a firmware version. The device reboots to apply it.
+    """
+    await client.update_install(version)
+
+
+async def read_wifi_state(client: AsyncBusyBar) -> tuple[bool, str]:
+    """
+    Return whether the device is associated, and a label describing it.
+    """
+    info = await client.wifi_status()
+    if info.state == types.WifiState.CONNECTED:
+        return True, info.ssid or "connected"
+    return False, str(info.state or "not connected")
+
+
+async def scan_networks(client: AsyncBusyBar) -> list[types.Network]:
+    """
+    Scan for nearby networks, returning an empty list if scanning is refused.
+
+    The device cannot scan while associated - it answers 400 "Scan not
+    possible when connected" - so callers fall back to entering an SSID.
+    """
+    try:
+        found = await client.wifi_networks()
+    except Exception as exc:  # noqa: BLE001
+        logger.info("setup: network scan unavailable (%s)", exc)
+        return []
+    return [n for n in (found.networks or []) if n.ssid]
+
+
+async def join_network(
+    client: AsyncBusyBar,
+    ssid: str,
+    *,
+    password: str | None = None,
+    security: types.WifiSecurityMethod | None = None,
+) -> None:
+    """
+    Ask the device to join a network.
+    """
+    await client.wifi_connect(
+        types.ConnectRequestConfig(ssid=ssid, password=password, security=security)
+    )
+
+
+async def read_clock_offset(client: AsyncBusyBar) -> timedelta | None:
+    """
+    Read the device's UTC offset, or None if its clock can't be parsed.
+
+    The API exposes no timezone name, so the offset is the only value that
+    can be compared against this computer.
+    """
+    info = await client.time()
+    if not info.timestamp:
+        return None
+    try:
+        return datetime.fromisoformat(info.timestamp).utcoffset()
+    except ValueError:
+        return None
+
+
+async def set_timezone(client: AsyncBusyBar, timezone: str) -> None:
+    """
+    Set the device timezone to an IANA name such as `Europe/Moscow`.
+    """
+    await client.time_timezone(timezone)
+
+
+async def read_device_name(client: AsyncBusyBar) -> str:
+    """
+    Read the device's current name.
+    """
+    info = await client.name()
+    return info.name or info.device or info.value or ""
+
+
+async def rename_device(client: AsyncBusyBar, name: str) -> None:
+    """
+    Rename the device. The name appears on the bar and in discovery.
+    """
+    await client.name_set(name)
+
+
+async def read_link_state(client: AsyncBusyBar) -> tuple[bool, str]:
+    """
+    Return whether the bar is linked to a cloud account, and to whom.
+    """
+    info = await client.account_info()
+    if info.linked:
+        return True, info.email or "linked"
+    return False, "not linked"
+
+
+async def request_link_code(client: AsyncBusyBar) -> types.AccountLink:
+    """
+    Ask the device for a fresh cloud pairing code.
+    """
+    return await client.account_link()

--- a/examples/setup/operations.py
+++ b/examples/setup/operations.py
@@ -24,6 +24,10 @@ logger = logging.getLogger(__name__)
 # any other value means the check is still running or found nothing.
 CHECK_STATUS_AVAILABLE = "available"
 CHECK_STATUS_TERMINAL_NO_UPDATE = frozenset({"not_available", "failure"})
+CHECK_EVENT_START = "start"
+# How many polls to wait for the device to show it started checking before
+# accepting whatever state it already reports.
+UNCHANGED_POLLS_BEFORE_TRUSTING_STATE = 3
 
 UPDATE_POLL_INTERVAL_SECONDS = 3.0
 UPDATE_TIMEOUT_SECONDS = 600.0
@@ -85,6 +89,20 @@ async def _firmware_version_from_status(client: AsyncBusyBar) -> str | None:
     return None
 
 
+def _check_state(status: types.UpdateStatus) -> tuple[str, str, str]:
+    """
+    Reduce an update status to the parts that identify a check result.
+    """
+    check = status.check
+    if check is None:
+        return ("", "", "")
+    return (
+        (check.status or "").lower(),
+        (check.event or "").lower(),
+        check.available_version or "",
+    )
+
+
 async def find_available_update(
     client: AsyncBusyBar,
     *,
@@ -95,23 +113,51 @@ async def find_available_update(
     Ask the device to check for an update and wait for the verdict.
 
     Returns the offered version, or None when the check finishes with
-    nothing to install. `available_version` alone isn't enough to act on: it
-    keeps the version from an earlier check, so the device's current status
-    has to read "available" before an install is accepted.
+    nothing to install.
+
+    The device keeps the previous check's outcome until a new one lands, and
+    the check it performs on request is asynchronous, so the state has to be
+    read carefully in both directions. A stale `available_version` must not
+    be installed - the device rejects that with 400 "Update not available" -
+    and a stale `not_available` must not be reported as the answer, which
+    would hide an update the bar is actually offering. So the state from
+    before the request is recorded, and a verdict is only accepted once the
+    device has moved on from it or has visibly started checking - falling
+    back to the reported state after a few polls, so a firmware that never
+    exposes the transition doesn't stall the whole timeout.
     """
+    try:
+        before = _check_state(await client.update_status())
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("setup: could not read update state before checking: %s", exc)
+        before = ("", "", "")
+
     await client.update_check()
+    seen_running = False
+    unchanged_polls = 0
 
     started = time.monotonic()
     while time.monotonic() - started < timeout:
-        status = await client.update_status()
-        check = status.check
-        if check is not None:
-            result = (check.status or "").lower()
-            if result == CHECK_STATUS_AVAILABLE and check.available_version:
-                return check.available_version
-            if result in CHECK_STATUS_TERMINAL_NO_UPDATE:
-                return None
         await asyncio.sleep(poll_interval)
+
+        status = await client.update_status()
+        result, event, version = _check_state(status)
+
+        if event == CHECK_EVENT_START:
+            seen_running = True
+
+        if not seen_running and (result, event, version) == before:
+            # Nothing has moved yet. Give the device a few polls to start,
+            # then take the state at face value rather than waiting out the
+            # whole timeout - some firmware never exposes the transition.
+            unchanged_polls += 1
+            if unchanged_polls < UNCHANGED_POLLS_BEFORE_TRUSTING_STATE:
+                continue
+
+        if result == CHECK_STATUS_AVAILABLE and version:
+            return version
+        if result in CHECK_STATUS_TERMINAL_NO_UPDATE:
+            return None
     return None
 
 

--- a/examples/setup/operations.py
+++ b/examples/setup/operations.py
@@ -15,7 +15,7 @@ import time
 from dataclasses import dataclass
 from datetime import datetime, timedelta
 
-from busylib import types, versioning
+from busylib import exceptions, types, versioning
 from busylib.client import AsyncBusyBar
 
 logger = logging.getLogger(__name__)
@@ -113,7 +113,9 @@ async def find_available_update(
     Ask the device to check for an update and wait for the verdict.
 
     Returns the offered version, or None when the check finishes with
-    nothing to install.
+    nothing to install. Raises `TimeoutError` if the device never reports a
+    verdict - that is not the same as "no update", and saying so would
+    repeat the mistake this function exists to avoid.
 
     The device keeps the previous check's outcome until a new one lands, and
     the check it performs on request is asynchronous, so the state has to be
@@ -144,7 +146,11 @@ async def find_available_update(
         result, event, version = _check_state(status)
 
         if event == CHECK_EVENT_START:
+            # The device is telling us the check has begun, so whatever
+            # verdict this same response carries is still the previous
+            # one. Note that it ran, and wait for an answer.
             seen_running = True
+            continue
 
         if not seen_running and (result, event, version) == before:
             # Nothing has moved yet. Give the device a few polls to start,
@@ -158,7 +164,10 @@ async def find_available_update(
             return version
         if result in CHECK_STATUS_TERMINAL_NO_UPDATE:
             return None
-    return None
+
+    raise TimeoutError(
+        f"The device did not finish checking for an update within {timeout:.0f}s"
+    )
 
 
 async def install_update(client: AsyncBusyBar, version: str) -> None:
@@ -187,7 +196,9 @@ async def scan_networks(client: AsyncBusyBar) -> list[types.Network]:
     """
     try:
         found = await client.wifi_networks()
-    except Exception as exc:  # noqa: BLE001
+    except exceptions.BusyBarAPIError as exc:
+        # Narrow on purpose: this covers the device refusing to scan, not a
+        # bad token or a dropped connection, which the caller should see.
         logger.info("setup: network scan unavailable (%s)", exc)
         return []
     return [n for n in (found.networks or []) if n.ssid]

--- a/examples/setup/steps.py
+++ b/examples/setup/steps.py
@@ -95,7 +95,13 @@ class FirmwareStep(SetupStep):
         Check for an update and install it, waiting for the device to apply it.
         """
         prompt.info("Checking for a firmware update...")
-        available = await operations.find_available_update(client)
+        try:
+            available = await operations.find_available_update(client)
+        except TimeoutError as exc:
+            # Distinct from "nothing to install": the check never finished,
+            # so reporting no update would be inventing an answer.
+            prompt.info(f"{exc}. Try again, or update from the device UI.")
+            return
         if not available:
             prompt.info(
                 "No update is offered by the device. If the API version is "

--- a/examples/setup/steps.py
+++ b/examples/setup/steps.py
@@ -1,7 +1,15 @@
+"""
+The wizard's steps.
+
+Each step is a thin wrapper: it asks `operations` what the device currently
+reports, decides whether anything is left to do, and drives the prompts. All
+the actual client work lives in `examples.setup.operations`, so a step reads
+as the conversation with the user rather than a mix of both.
+"""
+
 from __future__ import annotations
 
 import asyncio
-import logging
 import time
 from dataclasses import dataclass
 from datetime import datetime, timedelta
@@ -11,30 +19,19 @@ from busylib import types, versioning
 from busylib.client import AsyncBusyBar
 from busylib.devices import BUSYBAR_DEFAULT_NAME
 
+from examples.setup import operations
 from examples.setup.prompts import Prompt, SetupCancelled
 from examples.shared.device_name import validate_device_name
 from examples.shared.timezones import resolve_timezone
 
-# Factory bars ship on firmware 1.0.2, which serves API 24.3.0 while this
-# library targets 25.0.0. Updating is therefore the first thing a new owner
-# needs, and every other step reads better once it's out of the way.
-UPDATE_POLL_INTERVAL_SECONDS = 3.0
-UPDATE_TIMEOUT_SECONDS = 600.0
+DEFAULT_DEVICE_NAME = BUSYBAR_DEFAULT_NAME.decode()
 
-# `check.status` values that mean the check finished without an update. Any
-# other value (notably "none") means it is still running.
 CLOUD_DASHBOARD_URL = "https://cloud.busy.app/dashboard"
 CLOUD_LINK_POLL_INTERVAL_SECONDS = 3.0
 CLOUD_LINK_TIMEOUT_SECONDS = 600.0
 # Ask for a new code slightly before the old one lapses, so the user is never
 # looking at one that has just gone stale.
 CLOUD_CODE_RENEW_MARGIN_SECONDS = 10
-
-CHECK_STATUS_AVAILABLE = "available"
-CHECK_STATUS_TERMINAL_NO_UPDATE = frozenset({"not_available", "failure"})
-DEFAULT_DEVICE_NAME = BUSYBAR_DEFAULT_NAME.decode()
-
-logger = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True)
@@ -79,56 +76,26 @@ class FirmwareStep(SetupStep):
     async def status(self, client: AsyncBusyBar) -> StepStatus:
         """
         Compare the device's API version against the library's target.
-
-        `/api/version` only ever reports `api_semver` - the firmware's own
-        version string lives under `/api/status` in the `firmware` section -
-        so the two are read separately. The status call is best-effort: an
-        unreachable or unauthorised endpoint costs the version label, not
-        the compatibility verdict.
         """
-        info = await client.version()
-        device_api = info.api_semver or "unknown"
-        error = versioning.compatibility_error(
-            library_version=versioning.API_VERSION,
-            device_version=device_api,
+        state = await operations.read_firmware_state(client)
+        label = (
+            f"{state.firmware_version} (API {state.api_version})"
+            if state.firmware_version
+            else f"API {state.api_version}"
         )
-
-        firmware_version = info.version or await self._firmware_version(client)
-        summary = (
-            f"{firmware_version} (API {device_api})"
-            if firmware_version
-            else f"API {device_api}"
-        )
-        if error is None:
-            return StepStatus(done=True, summary=f"{summary} - supported")
+        if state.supported:
+            return StepStatus(done=True, summary=f"{label} - supported")
         return StepStatus(
             done=False,
-            summary=f"{summary} - library targets API {versioning.API_VERSION}",
+            summary=f"{label} - library targets API {versioning.API_VERSION}",
         )
-
-    @staticmethod
-    async def _firmware_version(client: AsyncBusyBar) -> str | None:
-        """
-        Read the firmware version from `/api/status`, or None if unavailable.
-        """
-        try:
-            status = await client.status()
-        except Exception as exc:  # noqa: BLE001
-            logger.debug("setup: could not read firmware version: %s", exc)
-            return None
-        if status.firmware is not None and status.firmware.version:
-            return status.firmware.version
-        if status.system is not None and status.system.version:
-            return status.system.version
-        return None
 
     async def run(self, client: AsyncBusyBar, prompt: Prompt) -> None:
         """
         Check for an update and install it, waiting for the device to apply it.
         """
         prompt.info("Checking for a firmware update...")
-        await client.update_check()
-        available = await self._await_check_result(client)
+        available = await operations.find_available_update(client)
         if not available:
             prompt.info(
                 "No update is offered by the device. If the API version is "
@@ -140,41 +107,11 @@ class FirmwareStep(SetupStep):
             raise SetupCancelled
 
         prompt.info(f"Installing {available}; the device will reboot when done.")
-        await client.update_install(available)
+        await operations.install_update(client, available)
         prompt.info(
             "Update started. Re-run setup once the bar is back online to "
             "confirm the new version."
         )
-
-    async def _await_check_result(self, client: AsyncBusyBar) -> str | None:
-        """
-        Poll update status until the check reports a version or finishes.
-
-        The device reports `check.status` as one of `available`,
-        `not_available`, `failure`, or `none`, and `check.event` as `start`,
-        `stop`, or `none`. Only the first two statuses are terminal: `none`
-        means the check hasn't produced a result yet, so polling has to
-        continue rather than concluding there's no update.
-        """
-        # Measure real elapsed time: counting only the sleeps ignored how
-        # long update_status() itself took, so the effective timeout drifted
-        # well past UPDATE_TIMEOUT_SECONDS.
-        started = time.monotonic()
-        while time.monotonic() - started < UPDATE_TIMEOUT_SECONDS:
-            status = await client.update_status()
-            check = status.check
-            if check is not None:
-                result = (check.status or "").lower()
-                # The device only accepts an install while its own check
-                # state says "available". `available_version` alone isn't
-                # enough: it keeps the version from an earlier check, so
-                # acting on it mid-check gets a 400 "Update not available".
-                if result == CHECK_STATUS_AVAILABLE and check.available_version:
-                    return check.available_version
-                if result in CHECK_STATUS_TERMINAL_NO_UPDATE:
-                    return None
-            await asyncio.sleep(UPDATE_POLL_INTERVAL_SECONDS)
-        return None
 
 
 class WifiStep(SetupStep):
@@ -189,28 +126,17 @@ class WifiStep(SetupStep):
         """
         Report the current Wi-Fi association.
         """
-        info = await client.wifi_status()
-        if info.state == types.WifiState.CONNECTED:
-            return StepStatus(done=True, summary=info.ssid or "connected")
-        return StepStatus(done=False, summary=str(info.state or "not connected"))
+        connected, label = await operations.read_wifi_state(client)
+        return StepStatus(done=connected, summary=label)
 
     async def run(self, client: AsyncBusyBar, prompt: Prompt) -> None:
         """
         Scan for networks, then join the one the user picks.
         """
         prompt.info("Scanning for networks...")
-        try:
-            found = await client.wifi_networks()
-            networks = [n for n in (found.networks or []) if n.ssid]
-        except Exception as exc:  # noqa: BLE001
-            # The device refuses to scan while associated, answering
-            # 400 "Scan not possible when connected" - which is exactly the
-            # case when this step is re-run with --redo. Fall back to typing
-            # the SSID rather than failing the step.
-            logger.info("setup: network scan unavailable (%s)", exc)
-            prompt.info(f"Could not scan for networks: {exc}")
-            networks = []
+        networks = await operations.scan_networks(client)
 
+        security: types.WifiSecurityMethod | None = None
         if networks:
             labels = [
                 f"{n.ssid} ({n.security.value if n.security else 'unknown'})"
@@ -223,10 +149,10 @@ class WifiStep(SetupStep):
                 ssid = chosen.ssid or ""
                 security = chosen.security
             else:
-                ssid, security = await prompt.text("SSID"), None
+                ssid = await prompt.text("SSID")
         else:
-            prompt.info("No networks found in the scan.")
-            ssid, security = await prompt.text("SSID"), None
+            prompt.info("No networks found; the device cannot scan while connected.")
+            ssid = await prompt.text("SSID")
 
         if not ssid:
             raise SetupCancelled
@@ -236,12 +162,9 @@ class WifiStep(SetupStep):
             password = await prompt.secret(f"Password for {ssid}") or None
 
         prompt.info(f"Connecting to {ssid}...")
-        config = types.ConnectRequestConfig(
-            ssid=ssid,
-            password=password,
-            security=security,
+        await operations.join_network(
+            client, ssid, password=password, security=security
         )
-        await client.wifi_connect(config)
         prompt.info(f"Connect request sent for {ssid}.")
 
 
@@ -256,12 +179,8 @@ class TimezoneStep(SetupStep):
     async def status(self, client: AsyncBusyBar) -> StepStatus:
         """
         Compare the device's UTC offset with this machine's.
-
-        There's no timezone-name getter in the API, so the offset is the only
-        thing that can be compared; a match is treated as "already set".
         """
-        info = await client.time()
-        device_offset = _parse_offset(info.timestamp)
+        device_offset = await operations.read_clock_offset(client)
         if device_offset is None:
             return StepStatus(done=False, summary="unknown")
 
@@ -278,17 +197,16 @@ class TimezoneStep(SetupStep):
         """
         Set the timezone, defaulting to this machine's IANA name.
         """
-        default = _local_timezone_name()
         value = await prompt.text(
             "Timezone (IANA name, city, or UTC offset)",
-            default=default,
+            default=_local_timezone_name(),
         )
         resolved, error = resolve_timezone(value)
         if error is not None or resolved is None:
             prompt.info(f"Could not resolve timezone: {error or 'unknown error'}")
             raise SetupCancelled
 
-        await client.time_timezone(resolved)
+        await operations.set_timezone(client, resolved)
         prompt.info(f"Timezone set to {resolved}.")
 
 
@@ -304,8 +222,7 @@ class NameStep(SetupStep):
         """
         Treat the factory default name as "not set yet".
         """
-        info = await client.name()
-        current = info.name or info.device or info.value or ""
+        current = await operations.read_device_name(client)
         if current and current != DEFAULT_DEVICE_NAME:
             return StepStatus(done=True, summary=current)
         return StepStatus(done=False, summary=f"{current or 'unset'} (factory default)")
@@ -320,7 +237,7 @@ class NameStep(SetupStep):
             prompt.info(f"Invalid name: {error}")
             raise SetupCancelled
 
-        await client.name_set(value)
+        await operations.rename_device(client, value)
         prompt.info(f"Device name set to {value}.")
 
 
@@ -336,10 +253,8 @@ class CloudStep(SetupStep):
         """
         Report whether the device is already linked.
         """
-        info = await client.account_info()
-        if info.linked:
-            return StepStatus(done=True, summary=info.email or "linked")
-        return StepStatus(done=False, summary="not linked")
+        linked, label = await operations.read_link_state(client)
+        return StepStatus(done=linked, summary=label)
 
     async def run(self, client: AsyncBusyBar, prompt: Prompt) -> None:
         """
@@ -361,7 +276,7 @@ class CloudStep(SetupStep):
 
         while time.monotonic() < deadline:
             if shown_code is None or _code_expired(expires_at):
-                link = await client.account_link()
+                link = await operations.request_link_code(client)
                 if not link.code:
                     prompt.info("The device did not return a linking code.")
                     raise SetupCancelled
@@ -371,9 +286,9 @@ class CloudStep(SetupStep):
 
             await asyncio.sleep(CLOUD_LINK_POLL_INTERVAL_SECONDS)
 
-            info = await client.account_info()
-            if info.linked:
-                prompt.info(f"Linked to {info.email or 'your account'}.")
+            linked, label = await operations.read_link_state(client)
+            if linked:
+                prompt.info(f"Linked to {label}.")
                 return
 
         prompt.info("Gave up waiting for the bar to be linked.")
@@ -404,19 +319,6 @@ def _expiry_suffix(expires_at: int | None) -> str:
         return ""
     local = datetime.fromtimestamp(expires_at).astimezone()
     return f" (valid until {local:%H:%M:%S})"
-
-
-def _parse_offset(timestamp: str | None) -> timedelta | None:
-    """
-    Extract the UTC offset from an ISO-8601 timestamp.
-    """
-    if not timestamp:
-        return None
-    try:
-        parsed = datetime.fromisoformat(timestamp)
-    except ValueError:
-        return None
-    return parsed.utcoffset()
 
 
 def _format_offset(offset: timedelta | None) -> str:

--- a/examples/setup/steps.py
+++ b/examples/setup/steps.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 import time
 from dataclasses import dataclass
 from datetime import datetime, timedelta
@@ -22,8 +23,18 @@ UPDATE_TIMEOUT_SECONDS = 600.0
 
 # `check.status` values that mean the check finished without an update. Any
 # other value (notably "none") means it is still running.
+CLOUD_DASHBOARD_URL = "https://cloud.busy.app/dashboard"
+CLOUD_LINK_POLL_INTERVAL_SECONDS = 3.0
+CLOUD_LINK_TIMEOUT_SECONDS = 600.0
+# Ask for a new code slightly before the old one lapses, so the user is never
+# looking at one that has just gone stale.
+CLOUD_CODE_RENEW_MARGIN_SECONDS = 10
+
+CHECK_STATUS_AVAILABLE = "available"
 CHECK_STATUS_TERMINAL_NO_UPDATE = frozenset({"not_available", "failure"})
 DEFAULT_DEVICE_NAME = BUSYBAR_DEFAULT_NAME.decode()
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True)
@@ -68,6 +79,12 @@ class FirmwareStep(SetupStep):
     async def status(self, client: AsyncBusyBar) -> StepStatus:
         """
         Compare the device's API version against the library's target.
+
+        `/api/version` only ever reports `api_semver` - the firmware's own
+        version string lives under `/api/status` in the `firmware` section -
+        so the two are read separately. The status call is best-effort: an
+        unreachable or unauthorised endpoint costs the version label, not
+        the compatibility verdict.
         """
         info = await client.version()
         device_api = info.api_semver or "unknown"
@@ -75,13 +92,35 @@ class FirmwareStep(SetupStep):
             library_version=versioning.API_VERSION,
             device_version=device_api,
         )
-        summary = f"{info.version or '?'} (API {device_api})"
+
+        firmware_version = info.version or await self._firmware_version(client)
+        summary = (
+            f"{firmware_version} (API {device_api})"
+            if firmware_version
+            else f"API {device_api}"
+        )
         if error is None:
             return StepStatus(done=True, summary=f"{summary} - supported")
         return StepStatus(
             done=False,
             summary=f"{summary} - library targets API {versioning.API_VERSION}",
         )
+
+    @staticmethod
+    async def _firmware_version(client: AsyncBusyBar) -> str | None:
+        """
+        Read the firmware version from `/api/status`, or None if unavailable.
+        """
+        try:
+            status = await client.status()
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("setup: could not read firmware version: %s", exc)
+            return None
+        if status.firmware is not None and status.firmware.version:
+            return status.firmware.version
+        if status.system is not None and status.system.version:
+            return status.system.version
+        return None
 
     async def run(self, client: AsyncBusyBar, prompt: Prompt) -> None:
         """
@@ -125,9 +164,14 @@ class FirmwareStep(SetupStep):
             status = await client.update_status()
             check = status.check
             if check is not None:
-                if check.available_version:
+                result = (check.status or "").lower()
+                # The device only accepts an install while its own check
+                # state says "available". `available_version` alone isn't
+                # enough: it keeps the version from an earlier check, so
+                # acting on it mid-check gets a 400 "Update not available".
+                if result == CHECK_STATUS_AVAILABLE and check.available_version:
                     return check.available_version
-                if (check.status or "").lower() in CHECK_STATUS_TERMINAL_NO_UPDATE:
+                if result in CHECK_STATUS_TERMINAL_NO_UPDATE:
                     return None
             await asyncio.sleep(UPDATE_POLL_INTERVAL_SECONDS)
         return None
@@ -155,8 +199,17 @@ class WifiStep(SetupStep):
         Scan for networks, then join the one the user picks.
         """
         prompt.info("Scanning for networks...")
-        found = await client.wifi_networks()
-        networks = [n for n in (found.networks or []) if n.ssid]
+        try:
+            found = await client.wifi_networks()
+            networks = [n for n in (found.networks or []) if n.ssid]
+        except Exception as exc:  # noqa: BLE001
+            # The device refuses to scan while associated, answering
+            # 400 "Scan not possible when connected" - which is exactly the
+            # case when this step is re-run with --redo. Fall back to typing
+            # the SSID rather than failing the step.
+            logger.info("setup: network scan unavailable (%s)", exc)
+            prompt.info(f"Could not scan for networks: {exc}")
+            networks = []
 
         if networks:
             labels = [
@@ -290,17 +343,41 @@ class CloudStep(SetupStep):
 
     async def run(self, client: AsyncBusyBar, prompt: Prompt) -> None:
         """
-        Request a pairing code and wait for the user to redeem it.
+        Show a pairing code and keep it fresh until the bar is linked.
+
+        Codes expire, usually sooner than it takes to find the dashboard and
+        sign in, so this polls for the link and fetches a new code whenever
+        the current one lapses instead of printing a stale one once. Answer
+        "no" at the prompt to skip linking for now.
         """
-        link = await client.account_link()
-        if not link.code:
-            prompt.info("The device did not return a linking code.")
+        prompt.info(f"Link this bar at {CLOUD_DASHBOARD_URL} or in the BUSY App.")
+        if not await prompt.confirm("Link it now?", default=True):
+            # Skip just this step - the rest of the wizard carries on.
             raise SetupCancelled
 
-        prompt.info(f"Enter this code in the BUSY App to link the bar: {link.code}")
-        if link.expires_at:
-            prompt.info(f"The code expires at {link.expires_at}.")
-        prompt.info("Re-run setup afterwards to confirm the link.")
+        deadline = time.monotonic() + CLOUD_LINK_TIMEOUT_SECONDS
+        shown_code: str | None = None
+        expires_at: int | None = None
+
+        while time.monotonic() < deadline:
+            if shown_code is None or _code_expired(expires_at):
+                link = await client.account_link()
+                if not link.code:
+                    prompt.info("The device did not return a linking code.")
+                    raise SetupCancelled
+                shown_code = link.code
+                expires_at = link.expires_at
+                prompt.info(f"Code: {shown_code}{_expiry_suffix(expires_at)}")
+
+            await asyncio.sleep(CLOUD_LINK_POLL_INTERVAL_SECONDS)
+
+            info = await client.account_info()
+            if info.linked:
+                prompt.info(f"Linked to {info.email or 'your account'}.")
+                return
+
+        prompt.info("Gave up waiting for the bar to be linked.")
+        raise SetupCancelled
 
 
 def default_steps() -> list[SetupStep]:
@@ -308,6 +385,25 @@ def default_steps() -> list[SetupStep]:
     Return the setup steps in the order a new owner should do them.
     """
     return [FirmwareStep(), WifiStep(), TimezoneStep(), NameStep(), CloudStep()]
+
+
+def _code_expired(expires_at: int | None) -> bool:
+    """
+    Whether a pairing code is at or near its expiry.
+    """
+    if expires_at is None:
+        return False
+    return time.time() >= expires_at - CLOUD_CODE_RENEW_MARGIN_SECONDS
+
+
+def _expiry_suffix(expires_at: int | None) -> str:
+    """
+    Render the expiry as local time rather than a raw unix timestamp.
+    """
+    if expires_at is None:
+        return ""
+    local = datetime.fromtimestamp(expires_at).astimezone()
+    return f" (valid until {local:%H:%M:%S})"
 
 
 def _parse_offset(timestamp: str | None) -> timedelta | None:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -43,6 +43,7 @@ plugins:
         python:
           paths:
             - src
+            - .
           options:
             filters:
               - "!^_"
@@ -75,6 +76,7 @@ nav:
       - Drawing on the displays: guides/displays.md
       - Assets and storage: guides/assets-and-storage.md
       - Reading device state: guides/device-state.md
+      - Building a tool: guides/building-a-tool.md
   - Reference:
       - Clients: api/clients.md
       - Device discovery: api/discovery.md

--- a/src/busylib/client/account.py
+++ b/src/busylib/client/account.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import logging
 from typing import Literal
 
-from .. import types
+from .. import types, versioning
 from .base import AsyncClientBase, SyncClientBase
 
 logger = logging.getLogger(__name__)
@@ -76,6 +76,11 @@ class AccountMixin(SyncClientBase):
         )
         return types.SuccessResponse.model_validate(data)
 
+    @versioning.removed_endpoint(
+        path="/api/account/profile",
+        method="GET",
+        replacement="account_backend()",
+    )
     def account_profile(self) -> types.AccountProfile:
         """
         Fetch legacy MQTT profile via GET /api/account/profile.
@@ -84,6 +89,11 @@ class AccountMixin(SyncClientBase):
         data = self._request("GET", "/api/account/profile")
         return types.AccountProfile.model_validate(data)
 
+    @versioning.removed_endpoint(
+        path="/api/account/profile",
+        method="POST",
+        replacement="account_backend_set()",
+    )
     def account_profile_set(
         self,
         profile: AccountProfileName,
@@ -169,6 +179,11 @@ class AsyncAccountMixin(AsyncClientBase):
         )
         return types.SuccessResponse.model_validate(data)
 
+    @versioning.removed_endpoint(
+        path="/api/account/profile",
+        method="GET",
+        replacement="account_backend()",
+    )
     async def account_profile(self) -> types.AccountProfile:
         """
         Fetch legacy MQTT profile via GET /api/account/profile.
@@ -177,6 +192,11 @@ class AsyncAccountMixin(AsyncClientBase):
         data = await self._request("GET", "/api/account/profile")
         return types.AccountProfile.model_validate(data)
 
+    @versioning.removed_endpoint(
+        path="/api/account/profile",
+        method="POST",
+        replacement="account_backend_set()",
+    )
     async def account_profile_set(
         self,
         profile: AccountProfileName,

--- a/src/busylib/client/account.py
+++ b/src/busylib/client/account.py
@@ -107,6 +107,7 @@ class AccountMixin(SyncClientBase):
         return types.SuccessResponse.model_validate(data)
 
     @versioning.removed_endpoint(
+        # Served by firmware 0.6.0-rc..0.8.1 (API 4.1.0..18.3.0); gone since 0.9.0-rc.
         path="/api/account/profile",
         method="GET",
         replacement="account_backend()",
@@ -122,6 +123,7 @@ class AccountMixin(SyncClientBase):
         ...
 
     @versioning.removed_endpoint(
+        # Served by firmware 0.6.0-rc..0.8.1 (API 4.1.0..18.3.0); gone since 0.9.0-rc.
         path="/api/account/profile",
         method="POST",
         replacement="account_backend_set()",
@@ -237,6 +239,7 @@ class AsyncAccountMixin(AsyncClientBase):
         return types.SuccessResponse.model_validate(data)
 
     @versioning.removed_endpoint(
+        # Served by firmware 0.6.0-rc..0.8.1 (API 4.1.0..18.3.0); gone since 0.9.0-rc.
         path="/api/account/profile",
         method="GET",
         replacement="account_backend()",
@@ -252,6 +255,7 @@ class AsyncAccountMixin(AsyncClientBase):
         ...
 
     @versioning.removed_endpoint(
+        # Served by firmware 0.6.0-rc..0.8.1 (API 4.1.0..18.3.0); gone since 0.9.0-rc.
         path="/api/account/profile",
         method="POST",
         replacement="account_backend_set()",

--- a/src/busylib/client/account.py
+++ b/src/busylib/client/account.py
@@ -16,6 +16,11 @@ class AccountMixin(SyncClientBase):
     Account linking and MQTT backend helpers.
     """
 
+    @versioning.requires_openapi(
+        "1.0.0",
+        path="/api/account",
+        method="DELETE",
+    )
     def account_unlink(self) -> types.SuccessResponse:
         """
         Unlink the device from the account via DELETE /api/account.
@@ -24,6 +29,11 @@ class AccountMixin(SyncClientBase):
         data = self._request("DELETE", "/api/account")
         return types.SuccessResponse.model_validate(data)
 
+    @versioning.requires_openapi(
+        "1.0.0",
+        path="/api/account/link",
+        method="POST",
+    )
     def account_link(self) -> types.AccountLink:
         """
         Request an account link code via POST /api/account/link.
@@ -32,6 +42,11 @@ class AccountMixin(SyncClientBase):
         data = self._request("POST", "/api/account/link")
         return types.AccountLink.model_validate(data)
 
+    @versioning.requires_openapi(
+        "4.1.0",
+        path="/api/account/info",
+        method="GET",
+    )
     def account_info(self) -> types.AccountInfo:
         """
         Fetch linked account info via GET /api/account/info.
@@ -40,6 +55,11 @@ class AccountMixin(SyncClientBase):
         data = self._request("GET", "/api/account/info")
         return types.AccountInfo.model_validate(data)
 
+    @versioning.requires_openapi(
+        "4.1.0",
+        path="/api/account/status",
+        method="GET",
+    )
     def account_status(self) -> types.AccountState:
         """
         Fetch MQTT status info via GET /api/account/status.
@@ -48,6 +68,11 @@ class AccountMixin(SyncClientBase):
         data = self._request("GET", "/api/account/status")
         return types.AccountState.model_validate(data)
 
+    @versioning.requires_openapi(
+        "23.0.0",
+        path="/api/account/backend",
+        method="GET",
+    )
     def account_backend(self) -> types.AccountBackend:
         """
         Fetch MQTT backend settings via GET /api/account/backend.
@@ -56,6 +81,11 @@ class AccountMixin(SyncClientBase):
         data = self._request("GET", "/api/account/backend")
         return types.AccountBackend.model_validate(data)
 
+    @versioning.requires_openapi(
+        "23.0.0",
+        path="/api/account/backend",
+        method="PUT",
+    )
     def account_backend_set(
         self,
         backend: types.AccountBackend | dict[str, object],
@@ -119,6 +149,11 @@ class AsyncAccountMixin(AsyncClientBase):
     Async account linking and MQTT backend helpers.
     """
 
+    @versioning.requires_openapi(
+        "1.0.0",
+        path="/api/account",
+        method="DELETE",
+    )
     async def account_unlink(self) -> types.SuccessResponse:
         """
         Unlink the device from the account via DELETE /api/account.
@@ -127,6 +162,11 @@ class AsyncAccountMixin(AsyncClientBase):
         data = await self._request("DELETE", "/api/account")
         return types.SuccessResponse.model_validate(data)
 
+    @versioning.requires_openapi(
+        "1.0.0",
+        path="/api/account/link",
+        method="POST",
+    )
     async def account_link(self) -> types.AccountLink:
         """
         Request an account link code via POST /api/account/link.
@@ -135,6 +175,11 @@ class AsyncAccountMixin(AsyncClientBase):
         data = await self._request("POST", "/api/account/link")
         return types.AccountLink.model_validate(data)
 
+    @versioning.requires_openapi(
+        "4.1.0",
+        path="/api/account/info",
+        method="GET",
+    )
     async def account_info(self) -> types.AccountInfo:
         """
         Fetch linked account info via GET /api/account/info.
@@ -143,6 +188,11 @@ class AsyncAccountMixin(AsyncClientBase):
         data = await self._request("GET", "/api/account/info")
         return types.AccountInfo.model_validate(data)
 
+    @versioning.requires_openapi(
+        "4.1.0",
+        path="/api/account/status",
+        method="GET",
+    )
     async def account_status(self) -> types.AccountState:
         """
         Fetch MQTT status info via GET /api/account/status.
@@ -151,6 +201,11 @@ class AsyncAccountMixin(AsyncClientBase):
         data = await self._request("GET", "/api/account/status")
         return types.AccountState.model_validate(data)
 
+    @versioning.requires_openapi(
+        "23.0.0",
+        path="/api/account/backend",
+        method="GET",
+    )
     async def account_backend(self) -> types.AccountBackend:
         """
         Fetch MQTT backend settings via GET /api/account/backend.
@@ -159,6 +214,11 @@ class AsyncAccountMixin(AsyncClientBase):
         data = await self._request("GET", "/api/account/backend")
         return types.AccountBackend.model_validate(data)
 
+    @versioning.requires_openapi(
+        "23.0.0",
+        path="/api/account/backend",
+        method="PUT",
+    )
     async def account_backend_set(
         self,
         backend: types.AccountBackend | dict[str, object],

--- a/src/busylib/client/account.py
+++ b/src/busylib/client/account.py
@@ -113,7 +113,10 @@ class AccountMixin(SyncClientBase):
     )
     def account_profile(self) -> types.AccountProfile:
         """
-        Fetch legacy MQTT profile via GET /api/account/profile.
+        Removed from the device API.
+
+        No supported firmware serves GET /api/account/profile, so calling this raises
+        `BusyBarRemovedEndpointError`. Use `account_backend()` instead.
         """
         # Unreachable: the decorator raises before the body runs.
         ...
@@ -129,7 +132,10 @@ class AccountMixin(SyncClientBase):
         custom_url: str | None = None,
     ) -> types.SuccessResponse:
         """
-        Set legacy MQTT profile via POST /api/account/profile.
+        Removed from the device API.
+
+        No supported firmware serves POST /api/account/profile, so calling this raises
+        `BusyBarRemovedEndpointError`. Use `account_backend_set()` instead.
         """
         # Unreachable: the decorator raises before the body runs.
         ...
@@ -237,7 +243,10 @@ class AsyncAccountMixin(AsyncClientBase):
     )
     async def account_profile(self) -> types.AccountProfile:
         """
-        Fetch legacy MQTT profile via GET /api/account/profile.
+        Removed from the device API.
+
+        No supported firmware serves GET /api/account/profile, so calling this raises
+        `BusyBarRemovedEndpointError`. Use `account_backend()` instead.
         """
         # Unreachable: the decorator raises before the body runs.
         ...
@@ -253,7 +262,10 @@ class AsyncAccountMixin(AsyncClientBase):
         custom_url: str | None = None,
     ) -> types.SuccessResponse:
         """
-        Set legacy MQTT profile via POST /api/account/profile.
+        Removed from the device API.
+
+        No supported firmware serves POST /api/account/profile, so calling this raises
+        `BusyBarRemovedEndpointError`. Use `account_backend_set()` instead.
         """
         # Unreachable: the decorator raises before the body runs.
         ...

--- a/src/busylib/client/account.py
+++ b/src/busylib/client/account.py
@@ -115,9 +115,8 @@ class AccountMixin(SyncClientBase):
         """
         Fetch legacy MQTT profile via GET /api/account/profile.
         """
-        logger.info("account_profile")
-        data = self._request("GET", "/api/account/profile")
-        return types.AccountProfile.model_validate(data)
+        # Unreachable: the decorator raises before the body runs.
+        ...
 
     @versioning.removed_endpoint(
         path="/api/account/profile",
@@ -132,16 +131,8 @@ class AccountMixin(SyncClientBase):
         """
         Set legacy MQTT profile via POST /api/account/profile.
         """
-        logger.info("account_profile_set profile=%s", profile)
-        params: dict[str, str] = {"profile": profile}
-        if custom_url:
-            params["custom_url"] = custom_url
-        data = self._request(
-            "POST",
-            "/api/account/profile",
-            params=params,
-        )
-        return types.SuccessResponse.model_validate(data)
+        # Unreachable: the decorator raises before the body runs.
+        ...
 
 
 class AsyncAccountMixin(AsyncClientBase):
@@ -248,9 +239,8 @@ class AsyncAccountMixin(AsyncClientBase):
         """
         Fetch legacy MQTT profile via GET /api/account/profile.
         """
-        logger.info("async account_profile")
-        data = await self._request("GET", "/api/account/profile")
-        return types.AccountProfile.model_validate(data)
+        # Unreachable: the decorator raises before the body runs.
+        ...
 
     @versioning.removed_endpoint(
         path="/api/account/profile",
@@ -265,13 +255,5 @@ class AsyncAccountMixin(AsyncClientBase):
         """
         Set legacy MQTT profile via POST /api/account/profile.
         """
-        logger.info("async account_profile_set profile=%s", profile)
-        params: dict[str, str] = {"profile": profile}
-        if custom_url:
-            params["custom_url"] = custom_url
-        data = await self._request(
-            "POST",
-            "/api/account/profile",
-            params=params,
-        )
-        return types.SuccessResponse.model_validate(data)
+        # Unreachable: the decorator raises before the body runs.
+        ...

--- a/src/busylib/client/ble.py
+++ b/src/busylib/client/ble.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import logging
 
-from .. import types
+from .. import types, versioning
 from .base import AsyncClientBase, SyncClientBase
 
 logger = logging.getLogger(__name__)
@@ -23,11 +23,21 @@ class BleMixin(SyncClientBase):
         data = self._request("POST", "/api/ble/disable")
         return types.SuccessResponse.model_validate(data)
 
+    @versioning.requires_openapi(
+        "0.3.0",
+        path="/api/ble/status",
+        method="GET",
+    )
     def ble_status(self) -> types.BleStatus:
         logger.info("ble_status")
         data = self._request("GET", "/api/ble/status")
         return types.BleStatus.model_validate(data)
 
+    @versioning.requires_openapi(
+        "1.0.0",
+        path="/api/ble/pairing",
+        method="DELETE",
+    )
     def ble_pairing_forget(self) -> types.SuccessResponse:
         logger.info("ble_pairing_forget")
         data = self._request("DELETE", "/api/ble/pairing")
@@ -49,11 +59,21 @@ class AsyncBleMixin(AsyncClientBase):
         data = await self._request("POST", "/api/ble/disable")
         return types.SuccessResponse.model_validate(data)
 
+    @versioning.requires_openapi(
+        "0.3.0",
+        path="/api/ble/status",
+        method="GET",
+    )
     async def ble_status(self) -> types.BleStatus:
         logger.info("async ble_status")
         data = await self._request("GET", "/api/ble/status")
         return types.BleStatus.model_validate(data)
 
+    @versioning.requires_openapi(
+        "1.0.0",
+        path="/api/ble/pairing",
+        method="DELETE",
+    )
     async def ble_pairing_forget(self) -> types.SuccessResponse:
         logger.info("async ble_pairing_forget")
         data = await self._request("DELETE", "/api/ble/pairing")

--- a/src/busylib/client/busy.py
+++ b/src/busylib/client/busy.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import logging
 
-from .. import types
+from .. import types, versioning
 from .base import AsyncClientBase, SyncClientBase
 
 logger = logging.getLogger(__name__)
@@ -13,6 +13,11 @@ class BusyMixin(SyncClientBase):
     Busy snapshot and profile helpers.
     """
 
+    @versioning.requires_openapi(
+        "4.1.0",
+        path="/api/busy/snapshot",
+        method="GET",
+    )
     def busy_snapshot(self) -> types.BusySnapshot:
         """
         Fetch busy snapshot via GET /api/busy/snapshot.
@@ -21,6 +26,11 @@ class BusyMixin(SyncClientBase):
         data = self._request("GET", "/api/busy/snapshot")
         return types.BusySnapshot.model_validate(data)
 
+    @versioning.requires_openapi(
+        "4.1.0",
+        path="/api/busy/snapshot",
+        method="PUT",
+    )
     def busy_snapshot_set(self, snapshot: types.BusySnapshot) -> types.SuccessResponse:
         """
         Set busy snapshot via PUT /api/busy/snapshot.
@@ -34,6 +44,11 @@ class BusyMixin(SyncClientBase):
         )
         return types.SuccessResponse.model_validate(data)
 
+    @versioning.requires_openapi(
+        "4.1.0",
+        path="/api/busy/snapshot",
+        method="GET",
+    )
     def busy_profile(self, slot: types.BusyProfileSlot) -> types.BusyProfile:
         """
         Fetch a busy profile slot via GET /api/busy/profiles/{slot}.
@@ -42,6 +57,11 @@ class BusyMixin(SyncClientBase):
         data = self._request("GET", f"/api/busy/profiles/{slot}")
         return types.BusyProfile.model_validate(data)
 
+    @versioning.requires_openapi(
+        "4.1.0",
+        path="/api/busy/snapshot",
+        method="PUT",
+    )
     def busy_profile_set(
         self,
         slot: types.BusyProfileSlot,
@@ -69,6 +89,11 @@ class AsyncBusyMixin(AsyncClientBase):
     Async busy snapshot and profile helpers.
     """
 
+    @versioning.requires_openapi(
+        "4.1.0",
+        path="/api/busy/snapshot",
+        method="GET",
+    )
     async def busy_snapshot(self) -> types.BusySnapshot:
         """
         Fetch busy snapshot via GET /api/busy/snapshot.
@@ -77,6 +102,11 @@ class AsyncBusyMixin(AsyncClientBase):
         data = await self._request("GET", "/api/busy/snapshot")
         return types.BusySnapshot.model_validate(data)
 
+    @versioning.requires_openapi(
+        "4.1.0",
+        path="/api/busy/snapshot",
+        method="PUT",
+    )
     async def busy_snapshot_set(
         self, snapshot: types.BusySnapshot
     ) -> types.SuccessResponse:

--- a/src/busylib/client/busy.py
+++ b/src/busylib/client/busy.py
@@ -45,8 +45,8 @@ class BusyMixin(SyncClientBase):
         return types.SuccessResponse.model_validate(data)
 
     @versioning.requires_openapi(
-        "4.1.0",
-        path="/api/busy/snapshot",
+        "11.0.0",
+        path="/api/busy/profiles/{slot}",
         method="GET",
     )
     def busy_profile(self, slot: types.BusyProfileSlot) -> types.BusyProfile:
@@ -58,8 +58,8 @@ class BusyMixin(SyncClientBase):
         return types.BusyProfile.model_validate(data)
 
     @versioning.requires_openapi(
-        "4.1.0",
-        path="/api/busy/snapshot",
+        "11.0.0",
+        path="/api/busy/profiles/{slot}",
         method="PUT",
     )
     def busy_profile_set(
@@ -122,6 +122,11 @@ class AsyncBusyMixin(AsyncClientBase):
         )
         return types.SuccessResponse.model_validate(data)
 
+    @versioning.requires_openapi(
+        "11.0.0",
+        path="/api/busy/profiles/{slot}",
+        method="GET",
+    )
     async def busy_profile(self, slot: types.BusyProfileSlot) -> types.BusyProfile:
         """
         Fetch a busy profile slot via GET /api/busy/profiles/{slot}.
@@ -130,6 +135,11 @@ class AsyncBusyMixin(AsyncClientBase):
         data = await self._request("GET", f"/api/busy/profiles/{slot}")
         return types.BusyProfile.model_validate(data)
 
+    @versioning.requires_openapi(
+        "11.0.0",
+        path="/api/busy/profiles/{slot}",
+        method="PUT",
+    )
     async def busy_profile_set(
         self,
         slot: types.BusyProfileSlot,

--- a/src/busylib/client/firmware.py
+++ b/src/busylib/client/firmware.py
@@ -53,6 +53,11 @@ class FirmwareMixin(SyncClientBase):
             )
         return version_info
 
+    @versioning.requires_openapi(
+        "18.3.0",
+        path="/api/transport",
+        method="GET",
+    )
     def transport(self) -> types.NetworkInterfaceInfo:
         """
         Fetch active network transport via GET /api/transport.
@@ -69,6 +74,11 @@ class FirmwareMixin(SyncClientBase):
         data = self._request("GET", "/api/status")
         return types.Status.model_validate(data)
 
+    @versioning.requires_openapi(
+        "11.0.0",
+        path="/api/status/device",
+        method="GET",
+    )
     def status_device(self) -> types.StatusDevice:
         """
         Fetch device manufacturing status via GET /api/status/device.
@@ -77,6 +87,11 @@ class FirmwareMixin(SyncClientBase):
         data = self._request("GET", "/api/status/device")
         return types.StatusDevice.model_validate(data)
 
+    @versioning.requires_openapi(
+        "11.0.0",
+        path="/api/status/firmware",
+        method="GET",
+    )
     def status_firmware(self) -> types.StatusFirmware:
         """
         Fetch firmware status via GET /api/status/firmware.
@@ -129,6 +144,11 @@ class FirmwareMixin(SyncClientBase):
             return types.LogDumpResponse(result="OK")
         return types.LogDumpResponse.model_validate(data)
 
+    @versioning.requires_openapi(
+        "0.3.0",
+        path="/api/name",
+        method="GET",
+    )
     def name(self) -> types.DeviceNameResponse:
         """
         Fetch device name via GET /api/name.
@@ -137,6 +157,11 @@ class FirmwareMixin(SyncClientBase):
         data = self._request("GET", "/api/name")
         return types.DeviceNameResponse.model_validate(data)
 
+    @versioning.requires_openapi(
+        "0.3.0",
+        path="/api/name",
+        method="POST",
+    )
     def name_set(self, name: str) -> types.SuccessResponse:
         """
         Set device name via POST /api/name.
@@ -150,6 +175,11 @@ class FirmwareMixin(SyncClientBase):
         )
         return types.SuccessResponse.model_validate(data)
 
+    @versioning.requires_openapi(
+        "0.3.0",
+        path="/api/time",
+        method="GET",
+    )
     def time(self) -> types.DeviceTimeResponse:
         """
         Fetch device time via GET /api/time.
@@ -180,6 +210,11 @@ class AsyncFirmwareMixin(AsyncClientBase):
             )
         return version_info
 
+    @versioning.requires_openapi(
+        "18.3.0",
+        path="/api/transport",
+        method="GET",
+    )
     async def transport(self) -> types.NetworkInterfaceInfo:
         """
         Fetch active network transport via GET /api/transport.
@@ -196,6 +231,11 @@ class AsyncFirmwareMixin(AsyncClientBase):
         data = await self._request("GET", "/api/status")
         return types.Status.model_validate(data)
 
+    @versioning.requires_openapi(
+        "11.0.0",
+        path="/api/status/device",
+        method="GET",
+    )
     async def status_device(self) -> types.StatusDevice:
         """
         Fetch device manufacturing status via GET /api/status/device.
@@ -204,6 +244,11 @@ class AsyncFirmwareMixin(AsyncClientBase):
         data = await self._request("GET", "/api/status/device")
         return types.StatusDevice.model_validate(data)
 
+    @versioning.requires_openapi(
+        "11.0.0",
+        path="/api/status/firmware",
+        method="GET",
+    )
     async def status_firmware(self) -> types.StatusFirmware:
         """
         Fetch firmware status via GET /api/status/firmware.
@@ -256,6 +301,11 @@ class AsyncFirmwareMixin(AsyncClientBase):
             return types.LogDumpResponse(result="OK")
         return types.LogDumpResponse.model_validate(data)
 
+    @versioning.requires_openapi(
+        "0.3.0",
+        path="/api/name",
+        method="GET",
+    )
     async def name(self) -> types.DeviceNameResponse:
         """
         Fetch device name via GET /api/name.
@@ -264,6 +314,11 @@ class AsyncFirmwareMixin(AsyncClientBase):
         data = await self._request("GET", "/api/name")
         return types.DeviceNameResponse.model_validate(data)
 
+    @versioning.requires_openapi(
+        "0.3.0",
+        path="/api/name",
+        method="POST",
+    )
     async def name_set(self, name: str) -> types.SuccessResponse:
         """
         Set device name via POST /api/name.
@@ -277,6 +332,11 @@ class AsyncFirmwareMixin(AsyncClientBase):
         )
         return types.SuccessResponse.model_validate(data)
 
+    @versioning.requires_openapi(
+        "0.3.0",
+        path="/api/time",
+        method="GET",
+    )
     async def time(self) -> types.DeviceTimeResponse:
         """
         Fetch device time via GET /api/time.

--- a/src/busylib/client/smart_home.py
+++ b/src/busylib/client/smart_home.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import logging
 from typing import Literal
 
-from .. import types
+from .. import types, versioning
 from .base import AsyncClientBase, SyncClientBase
 
 logger = logging.getLogger(__name__)
@@ -14,6 +14,11 @@ class SmartHomeMixin(SyncClientBase):
     Smart home pairing and switch helpers.
     """
 
+    @versioning.requires_openapi(
+        "18.3.0",
+        path="/api/smart_home/pairing",
+        method="GET",
+    )
     def smart_home_pairing(self) -> types.SmartHomePairingInfo:
         """
         Fetch smart home pairing status via GET /api/smart_home/pairing.
@@ -22,6 +27,11 @@ class SmartHomeMixin(SyncClientBase):
         data = self._request("GET", "/api/smart_home/pairing")
         return types.SmartHomePairingInfo.model_validate(data)
 
+    @versioning.requires_openapi(
+        "18.3.0",
+        path="/api/smart_home/pairing",
+        method="POST",
+    )
     def smart_home_pairing_start(self) -> types.SmartHomePairingPayload:
         """
         Start smart home pairing via POST /api/smart_home/pairing.
@@ -30,6 +40,11 @@ class SmartHomeMixin(SyncClientBase):
         data = self._request("POST", "/api/smart_home/pairing")
         return types.SmartHomePairingPayload.model_validate(data)
 
+    @versioning.requires_openapi(
+        "18.3.0",
+        path="/api/smart_home/pairing",
+        method="DELETE",
+    )
     def smart_home_pairing_stop(self) -> types.SuccessResponse:
         """
         Stop smart home pairing via DELETE /api/smart_home/pairing.
@@ -38,6 +53,11 @@ class SmartHomeMixin(SyncClientBase):
         data = self._request("DELETE", "/api/smart_home/pairing")
         return types.SuccessResponse.model_validate(data)
 
+    @versioning.requires_openapi(
+        "18.3.0",
+        path="/api/smart_home/switch",
+        method="GET",
+    )
     def smart_home_switch(self) -> types.SmartHomeSwitchState:
         """
         Fetch smart home switch state via GET /api/smart_home/switch.
@@ -46,6 +66,11 @@ class SmartHomeMixin(SyncClientBase):
         data = self._request("GET", "/api/smart_home/switch")
         return types.SmartHomeSwitchState.model_validate(data)
 
+    @versioning.requires_openapi(
+        "18.3.0",
+        path="/api/smart_home/switch",
+        method="POST",
+    )
     def smart_home_switch_set(
         self,
         state: bool,
@@ -73,6 +98,11 @@ class AsyncSmartHomeMixin(AsyncClientBase):
     Async smart home pairing and switch helpers.
     """
 
+    @versioning.requires_openapi(
+        "18.3.0",
+        path="/api/smart_home/pairing",
+        method="GET",
+    )
     async def smart_home_pairing(self) -> types.SmartHomePairingInfo:
         """
         Fetch smart home pairing status via GET /api/smart_home/pairing.
@@ -81,6 +111,11 @@ class AsyncSmartHomeMixin(AsyncClientBase):
         data = await self._request("GET", "/api/smart_home/pairing")
         return types.SmartHomePairingInfo.model_validate(data)
 
+    @versioning.requires_openapi(
+        "18.3.0",
+        path="/api/smart_home/pairing",
+        method="POST",
+    )
     async def smart_home_pairing_start(self) -> types.SmartHomePairingPayload:
         """
         Start smart home pairing via POST /api/smart_home/pairing.
@@ -89,6 +124,11 @@ class AsyncSmartHomeMixin(AsyncClientBase):
         data = await self._request("POST", "/api/smart_home/pairing")
         return types.SmartHomePairingPayload.model_validate(data)
 
+    @versioning.requires_openapi(
+        "18.3.0",
+        path="/api/smart_home/pairing",
+        method="DELETE",
+    )
     async def smart_home_pairing_stop(self) -> types.SuccessResponse:
         """
         Stop smart home pairing via DELETE /api/smart_home/pairing.
@@ -97,6 +137,11 @@ class AsyncSmartHomeMixin(AsyncClientBase):
         data = await self._request("DELETE", "/api/smart_home/pairing")
         return types.SuccessResponse.model_validate(data)
 
+    @versioning.requires_openapi(
+        "18.3.0",
+        path="/api/smart_home/switch",
+        method="GET",
+    )
     async def smart_home_switch(self) -> types.SmartHomeSwitchState:
         """
         Fetch smart home switch state via GET /api/smart_home/switch.
@@ -105,6 +150,11 @@ class AsyncSmartHomeMixin(AsyncClientBase):
         data = await self._request("GET", "/api/smart_home/switch")
         return types.SmartHomeSwitchState.model_validate(data)
 
+    @versioning.requires_openapi(
+        "18.3.0",
+        path="/api/smart_home/switch",
+        method="POST",
+    )
     async def smart_home_switch_set(
         self,
         state: bool,

--- a/src/busylib/client/storage.py
+++ b/src/busylib/client/storage.py
@@ -4,7 +4,7 @@ import asyncio
 import logging
 from collections.abc import AsyncIterator, Callable, Iterator
 
-from .. import types
+from .. import types, versioning
 from ..converter import convert_for_storage
 from .base import AsyncClientBase, SyncClientBase
 
@@ -87,6 +87,11 @@ class StorageMixin(SyncClientBase):
         )
         return types.SuccessResponse.model_validate(data)
 
+    @versioning.requires_openapi(
+        "11.0.0",
+        path="/api/storage/rename",
+        method="POST",
+    )
     def storage_rename(self, old_path: str, new_path: str) -> types.SuccessResponse:
         """
         Rename a storage entry via POST /api/storage/rename.
@@ -99,6 +104,11 @@ class StorageMixin(SyncClientBase):
         )
         return types.SuccessResponse.model_validate(data)
 
+    @versioning.requires_openapi(
+        "0.3.0",
+        path="/api/storage/status",
+        method="GET",
+    )
     def storage_status(self) -> types.StorageStatus:
         logger.info("storage_status")
         data = self._request(
@@ -184,6 +194,11 @@ class AsyncStorageMixin(AsyncClientBase):
         )
         return types.SuccessResponse.model_validate(data)
 
+    @versioning.requires_openapi(
+        "11.0.0",
+        path="/api/storage/rename",
+        method="POST",
+    )
     async def storage_rename(
         self, old_path: str, new_path: str
     ) -> types.SuccessResponse:
@@ -198,6 +213,11 @@ class AsyncStorageMixin(AsyncClientBase):
         )
         return types.SuccessResponse.model_validate(data)
 
+    @versioning.requires_openapi(
+        "0.3.0",
+        path="/api/storage/status",
+        method="GET",
+    )
     async def storage_status(self) -> types.StorageStatus:
         logger.info("async storage_status")
         data = await self._request(

--- a/src/busylib/client/time.py
+++ b/src/busylib/client/time.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import logging
 
-from .. import types
+from .. import types, versioning
 from .base import AsyncClientBase, SyncClientBase
 
 logger = logging.getLogger(__name__)
@@ -13,6 +13,11 @@ class TimeMixin(SyncClientBase):
     Device time and timezone helpers.
     """
 
+    @versioning.requires_openapi(
+        "0.3.0",
+        path="/api/time/timezone",
+        method="GET",
+    )
     def time_timezone_info(self) -> types.TimezoneInfo:
         """
         Fetch current device timezone via GET /api/time/timezone.
@@ -21,6 +26,11 @@ class TimeMixin(SyncClientBase):
         data = self._request("GET", "/api/time/timezone")
         return types.TimezoneInfo.model_validate(data)
 
+    @versioning.requires_openapi(
+        "11.0.0",
+        path="/api/time/tzlist",
+        method="GET",
+    )
     def time_timezone_list(self) -> types.TimezoneListResponse:
         """
         Fetch supported device timezones via GET /api/time/tzlist.
@@ -29,6 +39,11 @@ class TimeMixin(SyncClientBase):
         data = self._request("GET", "/api/time/tzlist")
         return types.TimezoneListResponse.model_validate(data)
 
+    @versioning.requires_openapi(
+        "0.3.0",
+        path="/api/time/timestamp",
+        method="POST",
+    )
     def time_timestamp(self, timestamp: str) -> types.SuccessResponse:
         """
         Set device time via POST /api/time/timestamp.
@@ -38,6 +53,11 @@ class TimeMixin(SyncClientBase):
         data = self._request("POST", "/api/time/timestamp", params=params)
         return types.SuccessResponse.model_validate(data)
 
+    @versioning.requires_openapi(
+        "0.3.0",
+        path="/api/time/timezone",
+        method="POST",
+    )
     def time_timezone(self, timezone: str) -> types.SuccessResponse:
         """
         Set device timezone via POST /api/time/timezone.
@@ -53,6 +73,11 @@ class AsyncTimeMixin(AsyncClientBase):
     Async device time and timezone helpers.
     """
 
+    @versioning.requires_openapi(
+        "0.3.0",
+        path="/api/time/timezone",
+        method="GET",
+    )
     async def time_timezone_info(self) -> types.TimezoneInfo:
         """
         Fetch current device timezone via GET /api/time/timezone.
@@ -61,6 +86,11 @@ class AsyncTimeMixin(AsyncClientBase):
         data = await self._request("GET", "/api/time/timezone")
         return types.TimezoneInfo.model_validate(data)
 
+    @versioning.requires_openapi(
+        "11.0.0",
+        path="/api/time/tzlist",
+        method="GET",
+    )
     async def time_timezone_list(self) -> types.TimezoneListResponse:
         """
         Fetch supported device timezones via GET /api/time/tzlist.
@@ -69,6 +99,11 @@ class AsyncTimeMixin(AsyncClientBase):
         data = await self._request("GET", "/api/time/tzlist")
         return types.TimezoneListResponse.model_validate(data)
 
+    @versioning.requires_openapi(
+        "0.3.0",
+        path="/api/time/timestamp",
+        method="POST",
+    )
     async def time_timestamp(self, timestamp: str) -> types.SuccessResponse:
         """
         Set device time via POST /api/time/timestamp.
@@ -78,6 +113,11 @@ class AsyncTimeMixin(AsyncClientBase):
         data = await self._request("POST", "/api/time/timestamp", params=params)
         return types.SuccessResponse.model_validate(data)
 
+    @versioning.requires_openapi(
+        "0.3.0",
+        path="/api/time/timezone",
+        method="POST",
+    )
     async def time_timezone(self, timezone: str) -> types.SuccessResponse:
         """
         Set device timezone via POST /api/time/timezone.

--- a/src/busylib/client/updater.py
+++ b/src/busylib/client/updater.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import logging
 
-from .. import types
+from .. import types, versioning
 from .base import AsyncClientBase, SyncClientBase
 
 logger = logging.getLogger(__name__)
@@ -25,6 +25,11 @@ class UpdaterMixin(SyncClientBase):
         )
         return types.SuccessResponse.model_validate(data)
 
+    @versioning.requires_openapi(
+        "4.1.0",
+        path="/api/update/check",
+        method="POST",
+    )
     def update_check(self) -> types.SuccessResponse:
         """
         Start asynchronous firmware update check.
@@ -33,6 +38,11 @@ class UpdaterMixin(SyncClientBase):
         data = self._request("POST", "/api/update/check")
         return types.SuccessResponse.model_validate(data)
 
+    @versioning.requires_openapi(
+        "4.1.0",
+        path="/api/update/status",
+        method="GET",
+    )
     def update_status(self) -> types.UpdateStatus:
         """
         Get firmware update status with progress information.
@@ -41,6 +51,11 @@ class UpdaterMixin(SyncClientBase):
         data = self._request("GET", "/api/update/status")
         return types.UpdateStatus.model_validate(data)
 
+    @versioning.requires_openapi(
+        "4.1.0",
+        path="/api/update/changelog",
+        method="GET",
+    )
     def update_changelog(self, version: str) -> types.UpdateChangelogResponse:
         """
         Fetch update changelog for a specific version.
@@ -53,6 +68,11 @@ class UpdaterMixin(SyncClientBase):
         )
         return types.UpdateChangelogResponse.model_validate(data)
 
+    @versioning.requires_openapi(
+        "4.1.0",
+        path="/api/update/install",
+        method="POST",
+    )
     def update_install(self, version: str) -> types.SuccessResponse:
         """
         Start firmware update installation by version.
@@ -65,6 +85,11 @@ class UpdaterMixin(SyncClientBase):
         )
         return types.SuccessResponse.model_validate(data)
 
+    @versioning.requires_openapi(
+        "4.1.0",
+        path="/api/update/abort_download",
+        method="POST",
+    )
     def update_abort_download(self) -> types.SuccessResponse:
         """
         Abort an ongoing firmware download.
@@ -73,6 +98,11 @@ class UpdaterMixin(SyncClientBase):
         data = self._request("POST", "/api/update/abort_download")
         return types.SuccessResponse.model_validate(data)
 
+    @versioning.requires_openapi(
+        "11.0.0",
+        path="/api/update/autoupdate",
+        method="GET",
+    )
     def update_autoupdate(self) -> types.AutoupdateSettings:
         """
         Fetch autoupdate settings via GET /api/update/autoupdate.
@@ -81,6 +111,11 @@ class UpdaterMixin(SyncClientBase):
         data = self._request("GET", "/api/update/autoupdate")
         return types.AutoupdateSettings.model_validate(data)
 
+    @versioning.requires_openapi(
+        "11.0.0",
+        path="/api/update/autoupdate",
+        method="POST",
+    )
     def update_autoupdate_set(
         self,
         settings: types.AutoupdateSettings | dict[str, object],
@@ -119,6 +154,11 @@ class AsyncUpdaterMixin(AsyncClientBase):
         )
         return types.SuccessResponse.model_validate(data)
 
+    @versioning.requires_openapi(
+        "4.1.0",
+        path="/api/update/check",
+        method="POST",
+    )
     async def update_check(self) -> types.SuccessResponse:
         """
         Start asynchronous firmware update check.
@@ -127,6 +167,11 @@ class AsyncUpdaterMixin(AsyncClientBase):
         data = await self._request("POST", "/api/update/check")
         return types.SuccessResponse.model_validate(data)
 
+    @versioning.requires_openapi(
+        "4.1.0",
+        path="/api/update/status",
+        method="GET",
+    )
     async def update_status(self) -> types.UpdateStatus:
         """
         Get firmware update status with progress information.
@@ -135,6 +180,11 @@ class AsyncUpdaterMixin(AsyncClientBase):
         data = await self._request("GET", "/api/update/status")
         return types.UpdateStatus.model_validate(data)
 
+    @versioning.requires_openapi(
+        "4.1.0",
+        path="/api/update/changelog",
+        method="GET",
+    )
     async def update_changelog(self, version: str) -> types.UpdateChangelogResponse:
         """
         Fetch update changelog for a specific version.
@@ -147,6 +197,11 @@ class AsyncUpdaterMixin(AsyncClientBase):
         )
         return types.UpdateChangelogResponse.model_validate(data)
 
+    @versioning.requires_openapi(
+        "4.1.0",
+        path="/api/update/install",
+        method="POST",
+    )
     async def update_install(self, version: str) -> types.SuccessResponse:
         """
         Start firmware update installation by version.
@@ -159,6 +214,11 @@ class AsyncUpdaterMixin(AsyncClientBase):
         )
         return types.SuccessResponse.model_validate(data)
 
+    @versioning.requires_openapi(
+        "4.1.0",
+        path="/api/update/abort_download",
+        method="POST",
+    )
     async def update_abort_download(self) -> types.SuccessResponse:
         """
         Abort an ongoing firmware download.
@@ -167,6 +227,11 @@ class AsyncUpdaterMixin(AsyncClientBase):
         data = await self._request("POST", "/api/update/abort_download")
         return types.SuccessResponse.model_validate(data)
 
+    @versioning.requires_openapi(
+        "11.0.0",
+        path="/api/update/autoupdate",
+        method="GET",
+    )
     async def update_autoupdate(self) -> types.AutoupdateSettings:
         """
         Fetch autoupdate settings via GET /api/update/autoupdate.
@@ -175,6 +240,11 @@ class AsyncUpdaterMixin(AsyncClientBase):
         data = await self._request("GET", "/api/update/autoupdate")
         return types.AutoupdateSettings.model_validate(data)
 
+    @versioning.requires_openapi(
+        "11.0.0",
+        path="/api/update/autoupdate",
+        method="POST",
+    )
     async def update_autoupdate_set(
         self,
         settings: types.AutoupdateSettings | dict[str, object],

--- a/src/busylib/client/wifi.py
+++ b/src/busylib/client/wifi.py
@@ -11,7 +11,7 @@ logger = logging.getLogger(__name__)
 
 class WifiMixin(SyncClientBase):
     """
-    Wi-Fi control helpers: enable, connect, scan, and status.
+    Wi-Fi control helpers: connect, disconnect, scan, and status.
     """
 
     @versioning.removed_endpoint(
@@ -20,9 +20,8 @@ class WifiMixin(SyncClientBase):
         replacement="wifi_connect() / wifi_disconnect()",
     )
     def wifi_enable(self) -> types.SuccessResponse:
-        logger.info("wifi_enable")
-        data = self._request("POST", "/api/wifi/enable")
-        return types.SuccessResponse.model_validate(data)
+        # Unreachable: the decorator raises before the body runs.
+        ...
 
     @versioning.removed_endpoint(
         path="/api/wifi/disable",
@@ -30,9 +29,8 @@ class WifiMixin(SyncClientBase):
         replacement="wifi_connect() / wifi_disconnect()",
     )
     def wifi_disable(self) -> types.SuccessResponse:
-        logger.info("wifi_disable")
-        data = self._request("POST", "/api/wifi/disable")
-        return types.SuccessResponse.model_validate(data)
+        # Unreachable: the decorator raises before the body runs.
+        ...
 
     def wifi_status(self) -> types.StatusResponse:
         logger.info("wifi_status")
@@ -82,7 +80,7 @@ class WifiMixin(SyncClientBase):
 
 class AsyncWifiMixin(AsyncClientBase):
     """
-    Async Wi-Fi control helpers: enable, connect, scan, and status.
+    Async Wi-Fi control helpers: connect, disconnect, scan, and status.
     """
 
     @versioning.removed_endpoint(
@@ -91,9 +89,8 @@ class AsyncWifiMixin(AsyncClientBase):
         replacement="wifi_connect() / wifi_disconnect()",
     )
     async def wifi_enable(self) -> types.SuccessResponse:
-        logger.info("async wifi_enable")
-        data = await self._request("POST", "/api/wifi/enable")
-        return types.SuccessResponse.model_validate(data)
+        # Unreachable: the decorator raises before the body runs.
+        ...
 
     @versioning.removed_endpoint(
         path="/api/wifi/disable",
@@ -101,9 +98,8 @@ class AsyncWifiMixin(AsyncClientBase):
         replacement="wifi_connect() / wifi_disconnect()",
     )
     async def wifi_disable(self) -> types.SuccessResponse:
-        logger.info("async wifi_disable")
-        data = await self._request("POST", "/api/wifi/disable")
-        return types.SuccessResponse.model_validate(data)
+        # Unreachable: the decorator raises before the body runs.
+        ...
 
     async def wifi_status(self) -> types.StatusResponse:
         logger.info("async wifi_status")

--- a/src/busylib/client/wifi.py
+++ b/src/busylib/client/wifi.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import logging
 from typing import Any
 
-from .. import types
+from .. import types, versioning
 from .base import AsyncClientBase, SyncClientBase
 
 logger = logging.getLogger(__name__)
@@ -14,11 +14,21 @@ class WifiMixin(SyncClientBase):
     Wi-Fi control helpers: enable, connect, scan, and status.
     """
 
+    @versioning.removed_endpoint(
+        path="/api/wifi/enable",
+        method="POST",
+        replacement="wifi_connect() / wifi_disconnect()",
+    )
     def wifi_enable(self) -> types.SuccessResponse:
         logger.info("wifi_enable")
         data = self._request("POST", "/api/wifi/enable")
         return types.SuccessResponse.model_validate(data)
 
+    @versioning.removed_endpoint(
+        path="/api/wifi/disable",
+        method="POST",
+        replacement="wifi_connect() / wifi_disconnect()",
+    )
     def wifi_disable(self) -> types.SuccessResponse:
         logger.info("wifi_disable")
         data = self._request("POST", "/api/wifi/disable")
@@ -57,6 +67,14 @@ class WifiMixin(SyncClientBase):
         return types.SuccessResponse.model_validate(data)
 
     def wifi_networks(self) -> types.NetworkResponse:
+        """
+        Scan for nearby networks via GET /api/wifi/networks.
+
+        The device cannot scan while it is associated: doing so returns
+        `400 "Scan not possible when connected"` as a `BusyBarAPIError`.
+        Disconnect first with `wifi_disconnect()`, or skip the scan and pass
+        the SSID to `wifi_connect()` directly.
+        """
         logger.info("wifi_networks")
         data = self._request("GET", "/api/wifi/networks")
         return types.NetworkResponse.model_validate(data)
@@ -67,11 +85,21 @@ class AsyncWifiMixin(AsyncClientBase):
     Async Wi-Fi control helpers: enable, connect, scan, and status.
     """
 
+    @versioning.removed_endpoint(
+        path="/api/wifi/enable",
+        method="POST",
+        replacement="wifi_connect() / wifi_disconnect()",
+    )
     async def wifi_enable(self) -> types.SuccessResponse:
         logger.info("async wifi_enable")
         data = await self._request("POST", "/api/wifi/enable")
         return types.SuccessResponse.model_validate(data)
 
+    @versioning.removed_endpoint(
+        path="/api/wifi/disable",
+        method="POST",
+        replacement="wifi_connect() / wifi_disconnect()",
+    )
     async def wifi_disable(self) -> types.SuccessResponse:
         logger.info("async wifi_disable")
         data = await self._request("POST", "/api/wifi/disable")
@@ -111,6 +139,14 @@ class AsyncWifiMixin(AsyncClientBase):
         return types.SuccessResponse.model_validate(data)
 
     async def wifi_networks(self) -> types.NetworkResponse:
+        """
+        Scan for nearby networks via GET /api/wifi/networks.
+
+        The device cannot scan while it is associated: doing so returns
+        `400 "Scan not possible when connected"` as a `BusyBarAPIError`.
+        Disconnect first with `wifi_disconnect()`, or skip the scan and pass
+        the SSID to `wifi_connect()` directly.
+        """
         logger.info("async wifi_networks")
         data = await self._request("GET", "/api/wifi/networks")
         return types.NetworkResponse.model_validate(data)

--- a/src/busylib/client/wifi.py
+++ b/src/busylib/client/wifi.py
@@ -20,6 +20,12 @@ class WifiMixin(SyncClientBase):
         replacement="wifi_connect() / wifi_disconnect()",
     )
     def wifi_enable(self) -> types.SuccessResponse:
+        """
+        Removed from the device API.
+
+        No supported firmware serves POST /api/wifi/enable, so calling this raises
+        `BusyBarRemovedEndpointError`. Use `wifi_connect() / wifi_disconnect()` instead.
+        """
         # Unreachable: the decorator raises before the body runs.
         ...
 
@@ -29,6 +35,12 @@ class WifiMixin(SyncClientBase):
         replacement="wifi_connect() / wifi_disconnect()",
     )
     def wifi_disable(self) -> types.SuccessResponse:
+        """
+        Removed from the device API.
+
+        No supported firmware serves POST /api/wifi/disable, so calling this raises
+        `BusyBarRemovedEndpointError`. Use `wifi_connect() / wifi_disconnect()` instead.
+        """
         # Unreachable: the decorator raises before the body runs.
         ...
 
@@ -89,6 +101,12 @@ class AsyncWifiMixin(AsyncClientBase):
         replacement="wifi_connect() / wifi_disconnect()",
     )
     async def wifi_enable(self) -> types.SuccessResponse:
+        """
+        Removed from the device API.
+
+        No supported firmware serves POST /api/wifi/enable, so calling this raises
+        `BusyBarRemovedEndpointError`. Use `wifi_connect() / wifi_disconnect()` instead.
+        """
         # Unreachable: the decorator raises before the body runs.
         ...
 
@@ -98,6 +116,12 @@ class AsyncWifiMixin(AsyncClientBase):
         replacement="wifi_connect() / wifi_disconnect()",
     )
     async def wifi_disable(self) -> types.SuccessResponse:
+        """
+        Removed from the device API.
+
+        No supported firmware serves POST /api/wifi/disable, so calling this raises
+        `BusyBarRemovedEndpointError`. Use `wifi_connect() / wifi_disconnect()` instead.
+        """
         # Unreachable: the decorator raises before the body runs.
         ...
 

--- a/src/busylib/client/wifi.py
+++ b/src/busylib/client/wifi.py
@@ -15,6 +15,7 @@ class WifiMixin(SyncClientBase):
     """
 
     @versioning.removed_endpoint(
+        # Last served by firmware 0.2.0 (API 0.0.0); gone since 0.3.0.
         path="/api/wifi/enable",
         method="POST",
         replacement="wifi_connect() / wifi_disconnect()",
@@ -96,6 +97,7 @@ class AsyncWifiMixin(AsyncClientBase):
     """
 
     @versioning.removed_endpoint(
+        # Last served by firmware 0.2.0 (API 0.0.0); gone since 0.3.0.
         path="/api/wifi/enable",
         method="POST",
         replacement="wifi_connect() / wifi_disconnect()",

--- a/src/busylib/exceptions.py
+++ b/src/busylib/exceptions.py
@@ -223,6 +223,32 @@ class BusyBarConversionError(BusyBarError):
         super().__init__(f"{message} ({path})")
 
 
+class BusyBarRemovedEndpointError(BusyBarError):
+    """
+    Raised when a helper targets a device endpoint that no longer exists.
+
+    Distinct from `BusyBarAPIVersionError`: updating the firmware will not
+    make the call work, because the endpoint was withdrawn rather than
+    added later.
+    """
+
+    def __init__(
+        self,
+        *,
+        path: str,
+        method: str,
+        replacement: str | None = None,
+    ) -> None:
+        self.path = path
+        self.method = method
+        self.replacement = replacement
+        hint = f" Use {replacement} instead." if replacement else ""
+        super().__init__(
+            f"{method} {path} was removed from the device API and is no "
+            f"longer served by any supported firmware.{hint}"
+        )
+
+
 class BusyBarWebSocketError(BusyBarError):
     """
     Raised when WebSocket connection or stream processing fails.

--- a/src/busylib/versioning.py
+++ b/src/busylib/versioning.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import os
 import re
+import inspect
 from collections.abc import Callable
 from functools import wraps
 from typing import Literal, TypeVar, cast
@@ -74,26 +75,48 @@ def removed_endpoint(
     device.
     """
 
+    note = (
+        f"\n\nRemoved from the device API: no supported firmware serves "
+        f"{method} {path}, so calling this raises "
+        f"`BusyBarRemovedEndpointError`."
+        + (f" Use `{replacement}` instead." if replacement else "")
+    )
+
     def decorator(func: F) -> F:
-        setattr(
-            func,
-            "__busy_openapi__",
-            MethodCompatibility(
-                path=path,
-                method=method,
-                status="removed",
-                **({"replacement": replacement} if replacement else {}),
-            ),
+        metadata = MethodCompatibility(
+            path=path,
+            method=method,
+            status="removed",
+            **({"replacement": replacement} if replacement else {}),
         )
 
-        @wraps(func)
-        def wrapper(*args: object, **kwargs: object) -> object:
+        def fail() -> None:
             raise exceptions.BusyBarRemovedEndpointError(
                 path=path,
                 method=method,
                 replacement=replacement,
             )
 
+        if inspect.iscoroutinefunction(func):
+            # Keep the async signature, or the exception surfaces when the
+            # coroutine is created rather than awaited - which leaves any
+            # sibling coroutines in the same gather() un-awaited.
+            @wraps(func)
+            async def async_wrapper(*args: object, **kwargs: object) -> object:
+                fail()
+
+            wrapper: Callable[..., object] = async_wrapper
+        else:
+
+            @wraps(func)
+            def sync_wrapper(*args: object, **kwargs: object) -> object:
+                fail()
+
+            wrapper = sync_wrapper
+
+        # Say so in the rendered API reference, not only in the guide.
+        wrapper.__doc__ = (func.__doc__ or "").rstrip() + note
+        setattr(wrapper, "__busy_openapi__", metadata)
         return cast(F, wrapper)
 
     return decorator

--- a/src/busylib/versioning.py
+++ b/src/busylib/versioning.py
@@ -75,13 +75,6 @@ def removed_endpoint(
     device.
     """
 
-    note = (
-        f"\n\nRemoved from the device API: no supported firmware serves "
-        f"{method} {path}, so calling this raises "
-        f"`BusyBarRemovedEndpointError`."
-        + (f" Use `{replacement}` instead." if replacement else "")
-    )
-
     def decorator(func: F) -> F:
         metadata = MethodCompatibility(
             path=path,
@@ -114,8 +107,6 @@ def removed_endpoint(
 
             wrapper = sync_wrapper
 
-        # Say so in the rendered API reference, not only in the guide.
-        wrapper.__doc__ = (func.__doc__ or "").rstrip() + note
         setattr(wrapper, "__busy_openapi__", metadata)
         return cast(F, wrapper)
 

--- a/src/busylib/versioning.py
+++ b/src/busylib/versioning.py
@@ -3,7 +3,8 @@ from __future__ import annotations
 import os
 import re
 from collections.abc import Callable
-from typing import Literal, TypeVar
+from functools import wraps
+from typing import Literal, TypeVar, cast
 
 from . import exceptions
 
@@ -15,7 +16,10 @@ F = TypeVar("F", bound=Callable[..., object])
 
 class MethodCompatibility(dict[str, str]):
     """
-    Dictionary metadata describing when a client helper appeared in OpenAPI.
+    Dictionary metadata describing a client helper's OpenAPI compatibility.
+
+    Carries either the minimum `version` a helper targets, or `status`
+    `"removed"` with the `replacement` to use instead.
     """
 
 
@@ -47,6 +51,47 @@ def requires_openapi(
             ),
         )
         return func
+
+    return decorator
+
+
+def removed_endpoint(
+    *,
+    path: str,
+    method: str,
+    replacement: str | None = None,
+) -> Callable[[F], F]:
+    """
+    Mark a helper whose device endpoint no longer exists in any firmware.
+
+    `requires_openapi` declares a *minimum* version, which can't express an
+    endpoint that has been withdrawn: there is no newer firmware where the
+    call starts working again. Marked helpers raise immediately with the
+    replacement to use, instead of letting an opaque 404 come back from the
+    device.
+    """
+
+    def decorator(func: F) -> F:
+        setattr(
+            func,
+            "__busy_openapi__",
+            MethodCompatibility(
+                path=path,
+                method=method,
+                status="removed",
+                **({"replacement": replacement} if replacement else {}),
+            ),
+        )
+
+        @wraps(func)
+        def wrapper(*args: object, **kwargs: object) -> object:
+            raise exceptions.BusyBarRemovedEndpointError(
+                path=path,
+                method=method,
+                replacement=replacement,
+            )
+
+        return cast(F, wrapper)
 
     return decorator
 

--- a/src/busylib/versioning.py
+++ b/src/busylib/versioning.py
@@ -33,8 +33,11 @@ def requires_openapi(
     Attach declarative OpenAPI compatibility metadata to a client method.
 
     `version` is the minimum firmware OpenAPI version the current
-    implementation targets, not necessarily the version in which the
-    underlying device endpoint first appeared. When a method's request or
+    implementation targets. For most helpers that is the version in which
+    the device endpoint first appeared, taken from the firmware's own route
+    tables across release tags. Where a contract later changed in a
+    breaking way, the higher version wins - `log_dump` targets 25.0.0 even
+    though `/api/log_dump` exists from 24.3.0. When a method's request or
     response contract changes in a breaking, non-translatable way, bump this
     version to match the new contract rather than keeping the old value or
     adding a silent compatibility shim.

--- a/tests/busylib/client/test_client.py
+++ b/tests/busylib/client/test_client.py
@@ -149,25 +149,6 @@ def test_account_info():
     assert result.email == "name@example.com"
 
 
-def test_account_profile_set() -> None:
-    """
-    Ensure account profile updates are sent as query params.
-    """
-    seen = {}
-
-    def responder(request: httpx.Request) -> httpx.Response:
-        seen["params"] = dict(request.url.params)
-        return httpx.Response(200, json={"result": "OK"})
-
-    client = make_client(responder)
-    resp = client.account_profile_set("custom", custom_url="mqtts://mqtt.example.com")
-    assert resp.result == "OK"
-    assert seen["params"] == {
-        "profile": "custom",
-        "custom_url": "mqtts://mqtt.example.com",
-    }
-
-
 def test_account_link():
     """
     Parse account link response from the client.
@@ -386,7 +367,7 @@ def test_request_carries_api_version_header():
         return httpx.Response(200, json={"result": "OK"})
 
     client = make_client(responder, api_version="1.1.0")
-    resp = client.wifi_enable()
+    resp = client.wifi_disconnect()
     assert resp.result == "OK"
     assert seen["header"] == "1.1.0"
 
@@ -406,7 +387,7 @@ def test_retry_on_transport_error():
         return httpx.Response(200, json={"result": "OK"})
 
     client = make_client(responder, max_retries=1, backoff=0.0)
-    resp = client.wifi_enable()
+    resp = client.wifi_disconnect()
     assert resp.result == "OK"
     assert calls["count"] == 2
 
@@ -763,8 +744,6 @@ def test_screen_accepts_a_display_spec():
         ("storage_remove", "/api/storage/remove"),
         ("storage_mkdir", "/api/storage/mkdir"),
         ("assets_delete", "/api/assets/upload"),
-        ("wifi_enable", "/api/wifi/enable"),
-        ("wifi_disable", "/api/wifi/disable"),
         ("wifi_disconnect", "/api/wifi/disconnect"),
         ("ble_enable", "/api/ble/enable"),
         ("ble_disable", "/api/ble/disable"),
@@ -974,3 +953,41 @@ def test_display_draw_color_tuple_alpha():
     assert resp.result == "OK"
     color = seen["body"]["elements"][0]["color"]
     assert color == "#FFFFFF64"
+
+
+@pytest.mark.parametrize(
+    "method_name",
+    ["account_profile", "account_profile_set", "wifi_enable", "wifi_disable"],
+)
+def test_removed_endpoints_raise_instead_of_calling_the_device(method_name: str):
+    """
+    Helpers for withdrawn endpoints fail fast with a usable message.
+
+    The firmware serves none of these on any supported version, so letting
+    the call through would only produce an opaque 404.
+    """
+    called: list[str] = []
+
+    def responder(request: httpx.Request) -> httpx.Response:
+        called.append(request.url.path)
+        return httpx.Response(404, json={"error": "Not Found"})
+
+    client = make_client(responder)
+    with pytest.raises(exceptions.BusyBarRemovedEndpointError) as exc:
+        getattr(client, method_name)()
+
+    assert called == [], "no request should reach the device"
+    assert exc.value.replacement
+
+
+def test_removed_endpoints_are_declared_in_compatibility_metadata():
+    """
+    `method_compatibility` reports the removal and what to use instead.
+    """
+    client = make_client(lambda _r: httpx.Response(200, json={"result": "OK"}))
+
+    metadata = client.method_compatibility("account_profile")
+
+    assert metadata is not None
+    assert metadata["status"] == "removed"
+    assert metadata["replacement"] == "account_backend()"

--- a/tests/busylib/client/test_client_async.py
+++ b/tests/busylib/client/test_client_async.py
@@ -157,7 +157,7 @@ async def test_async_retry_on_transport_error():
         return httpx.Response(200, json={"result": "OK"})
 
     client = make_client(responder, max_retries=1, backoff=0.0)
-    resp = await client.wifi_enable()
+    resp = await client.wifi_disconnect()
     assert resp.result == "OK"
     assert calls["count"] == 2
     await client.aclose()

--- a/tests/busylib/test_versioning_audit.py
+++ b/tests/busylib/test_versioning_audit.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+import ast
+import inspect
+import pathlib
+
+import pytest
+
+from busylib import AsyncBusyBar, BusyBar, versioning
+
+CLIENT_DIR = pathlib.Path(inspect.getfile(BusyBar)).parent
+
+
+def _declared_request(node: ast.AST) -> tuple[str, str] | None:
+    """
+    Find the method and path a helper actually passes to `self._request`.
+
+    Returns them with f-string placeholders preserved, so
+    `f"/api/busy/profiles/{slot}"` reads as `/api/busy/profiles/{slot}`.
+    """
+    for call in ast.walk(node):
+        if not isinstance(call, ast.Call):
+            continue
+        func = call.func
+        if not (isinstance(func, ast.Attribute) and func.attr == "_request"):
+            continue
+        if len(call.args) < 2:
+            continue
+        method, path = call.args[0], call.args[1]
+        if not isinstance(method, ast.Constant):
+            continue
+        if isinstance(path, ast.Constant):
+            return str(method.value), str(path.value)
+        if isinstance(path, ast.JoinedStr):
+            rendered = ""
+            for part in path.values:
+                if isinstance(part, ast.Constant):
+                    rendered += str(part.value)
+                elif isinstance(part, ast.FormattedValue) and isinstance(
+                    part.value, ast.Name
+                ):
+                    rendered += "{" + part.value.id + "}"
+                else:
+                    rendered += "{...}"
+            return str(method.value), rendered
+    return None
+
+
+def _helpers_with_requests() -> dict[str, tuple[str, str]]:
+    """
+    Map every client helper to the request it issues, parsed from source.
+    """
+    found: dict[str, tuple[str, str]] = {}
+    for path in sorted(CLIENT_DIR.glob("*.py")):
+        tree = ast.parse(path.read_text())
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef):
+                continue
+            if node.name.startswith("_"):
+                continue
+            request = _declared_request(node)
+            if request is not None:
+                found.setdefault(node.name, request)
+    return found
+
+
+HELPERS = _helpers_with_requests()
+
+
+def test_the_audit_finds_helpers_to_check() -> None:
+    """
+    Guard the parsing itself, so a silent zero doesn't pass the suite.
+    """
+    assert len(HELPERS) > 30
+
+
+@pytest.mark.parametrize("name", sorted(HELPERS))
+def test_compatibility_metadata_matches_the_actual_request(name: str) -> None:
+    """
+    A helper's declared path and method match the request it makes.
+
+    Tagging a helper with a neighbouring endpoint's path is invisible at
+    runtime but makes the metadata lie, which is the whole point of it.
+    """
+    metadata = versioning.get_method_compatibility(getattr(BusyBar, name))
+    if metadata is None:
+        pytest.skip(f"{name} carries no compatibility metadata")
+
+    method, path = HELPERS[name]
+    assert metadata["path"] == path
+    assert metadata["method"] == method
+
+
+@pytest.mark.parametrize("name", sorted(HELPERS))
+def test_sync_and_async_helpers_are_tagged_alike(name: str) -> None:
+    """
+    Both clients report the same compatibility metadata.
+
+    Tagging only one leaves `AsyncBusyBar.method_compatibility()` returning
+    None for a helper the sync client describes.
+    """
+    sync = getattr(BusyBar, name, None)
+    asyncronous = getattr(AsyncBusyBar, name, None)
+    if sync is None or asyncronous is None:
+        pytest.skip(f"{name} exists on only one client")
+
+    assert versioning.get_method_compatibility(sync) == (
+        versioning.get_method_compatibility(asyncronous)
+    )

--- a/tests/busylib/test_versioning_tags.py
+++ b/tests/busylib/test_versioning_tags.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import pytest
+
+from busylib import AsyncBusyBar, BusyBar, versioning
+
+# Sampled from the firmware's route tables across release tags: the API
+# version whose firmware first served each endpoint.
+EXPECTED = {
+    "ble_status": "0.3.0",
+    "name_set": "0.3.0",
+    "account_link": "1.0.0",
+    "update_check": "4.1.0",
+    "account_info": "4.1.0",
+    "status_firmware": "11.0.0",
+    "storage_rename": "11.0.0",
+    "time_timezone_list": "11.0.0",
+    "smart_home_switch": "18.3.0",
+    "account_backend": "23.0.0",
+    # Endpoint exists from 24.3.0, but the contract was reworked in 25.0.0.
+    "log_dump": "25.0.0",
+}
+
+
+@pytest.mark.parametrize("name,version", sorted(EXPECTED.items()))
+@pytest.mark.parametrize("client", [BusyBar, AsyncBusyBar])
+def test_methods_declare_the_api_version_that_introduced_them(
+    client: type, name: str, version: str
+) -> None:
+    """
+    Compatibility tags match the firmware release that added the endpoint.
+    """
+    metadata = versioning.get_method_compatibility(getattr(client, name))
+
+    assert metadata is not None, f"{name} carries no compatibility metadata"
+    assert metadata["version"] == version
+
+
+@pytest.mark.parametrize("client", [BusyBar, AsyncBusyBar])
+def test_endpoints_present_since_the_first_api_are_left_untagged(
+    client: type,
+) -> None:
+    """
+    Helpers available in every firmware carry no version requirement.
+
+    Tagging them would imply a floor that never applied.
+    """
+    for name in ("display_draw", "audio_play", "storage_write", "version"):
+        assert versioning.get_method_compatibility(getattr(client, name)) is None

--- a/tests/examples/setup/test_wizard.py
+++ b/tests/examples/setup/test_wizard.py
@@ -7,7 +7,7 @@ from datetime import datetime, timedelta
 
 import pytest
 
-from busylib import types, versioning
+from busylib import exceptions, types, versioning
 from examples.setup.prompts import SetupAborted, SetupCancelled
 from examples.setup import operations, steps
 from examples.setup.steps import (
@@ -559,7 +559,13 @@ async def test_wifi_step_falls_back_to_manual_ssid_when_scan_is_refused() -> Non
 
     class _Connected:
         async def wifi_networks(self):
-            raise RuntimeError("400 Scan not possible when connected")
+            raise exceptions.BusyBarAPIError(
+                "Scan not possible when connected",
+                code=400,
+                status_code=400,
+                method="GET",
+                path="/api/wifi/networks",
+            )
 
         async def wifi_connect(self, config):
             self.config = config
@@ -616,3 +622,76 @@ async def test_a_genuinely_new_no_update_verdict_is_accepted(
     )
 
     assert await operations.find_available_update(client) is None  # type: ignore[arg-type]
+
+
+@pytest.mark.asyncio
+async def test_a_check_still_running_is_not_read_as_a_verdict(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    The response announcing the check started still carries the old verdict.
+
+    Treating it as this check's answer reintroduced the 400 "Update not
+    available" the earlier fix removed, in a narrower window.
+    """
+    monkeypatch.setattr(operations, "UPDATE_POLL_INTERVAL_SECONDS", 0)
+    client = _UpdateClient(
+        [
+            _check("available", "1.1.1", event="stop"),
+            _check("available", "1.1.1", event="start"),
+            _check("not_available", "", event="stop"),
+        ]
+    )
+
+    assert await operations.find_available_update(client) is None  # type: ignore[arg-type]
+
+
+@pytest.mark.asyncio
+async def test_a_check_that_never_finishes_raises_rather_than_lying(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    A timeout is reported as a timeout, not as "no update available".
+    """
+    monkeypatch.setattr(operations, "UPDATE_POLL_INTERVAL_SECONDS", 0)
+    client = _UpdateClient([_check("none", "", event="start")])
+
+    with pytest.raises(TimeoutError):
+        await operations.find_available_update(client, timeout=0.05)  # type: ignore[arg-type]
+
+
+@pytest.mark.asyncio
+async def test_firmware_step_reports_a_timeout_distinctly(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    The step says the check didn't finish, not that there is no update.
+    """
+
+    async def _timeout(client, **kwargs):
+        raise TimeoutError("The device did not finish checking for an update")
+
+    monkeypatch.setattr(operations, "find_available_update", _timeout)
+
+    prompt = RecordingPrompt()
+    await FirmwareStep().run(FakeClient(), prompt)  # type: ignore[arg-type]
+
+    assert any("did not finish checking" in line for line in prompt.lines)
+    assert not any("No update is offered" in line for line in prompt.lines)
+
+
+@pytest.mark.asyncio
+async def test_a_transport_failure_during_scan_is_not_swallowed() -> None:
+    """
+    Only the device refusing to scan is absorbed, not any failure.
+
+    A bad token or a dropped connection surfacing as "no networks found"
+    would send the user hunting for an SSID that was never the problem.
+    """
+
+    class _Broken:
+        async def wifi_networks(self):
+            raise RuntimeError("connection reset")
+
+    with pytest.raises(RuntimeError):
+        await operations.scan_networks(_Broken())  # type: ignore[arg-type]

--- a/tests/examples/setup/test_wizard.py
+++ b/tests/examples/setup/test_wizard.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Any
 
+import time
 from datetime import datetime, timedelta
 
 import pytest
@@ -416,3 +417,153 @@ async def test_a_skipped_step_still_lets_the_others_run() -> None:
 
     assert following.ran is True
     assert any("Skipped" in line for line in prompt.lines)
+
+
+@pytest.mark.asyncio
+async def test_firmware_version_comes_from_status_when_version_omits_it() -> None:
+    """
+    `/api/version` only reports api_semver, so the label needs `/api/status`.
+
+    Reading the firmware version from `version()` alone rendered every bar as
+    "Firmware ?" - the first thing a new owner sees.
+    """
+
+    class _Client(FakeClient):
+        async def status(self):
+            return types.Status(firmware=types.StatusFirmware(version="1.0.2"))
+
+    client = _Client(version=types.VersionInfo(api_semver="24.3.0"))
+    status = await FirmwareStep().status(client)  # type: ignore[arg-type]
+
+    assert status.summary.startswith("1.0.2 (API 24.3.0)")
+
+
+@pytest.mark.asyncio
+async def test_firmware_label_omits_version_when_status_is_unavailable() -> None:
+    """
+    An unreachable status endpoint costs the label, not the verdict.
+    """
+
+    class _Client(FakeClient):
+        async def status(self):
+            raise RuntimeError("403")
+
+    client = _Client(version=types.VersionInfo(api_semver="24.3.0"))
+    status = await FirmwareStep().status(client)  # type: ignore[arg-type]
+
+    assert status.summary.startswith("API 24.3.0")
+    assert "?" not in status.summary
+
+
+@pytest.mark.asyncio
+async def test_stale_available_version_is_not_installed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    A version left over from an earlier check must not trigger an install.
+
+    The device only accepts an install while its own check state reads
+    "available"; acting on `available_version` alone got a 400 "Update not
+    available" back from a real bar.
+    """
+    monkeypatch.setattr(steps, "UPDATE_POLL_INTERVAL_SECONDS", 0)
+    client = _UpdateClient([_check("none", "1.1.1"), _check("not_available", "1.1.1")])
+
+    assert await FirmwareStep()._await_check_result(client) is None  # type: ignore[arg-type]
+
+
+def test_expiry_is_rendered_as_local_time() -> None:
+    """
+    Pairing codes show a readable local time, not a unix timestamp.
+    """
+    suffix = steps._expiry_suffix(1785515110)
+
+    assert "1785515110" not in suffix
+    assert "valid until" in suffix
+
+
+def test_expiry_suffix_is_empty_without_a_deadline() -> None:
+    """
+    A code with no expiry renders no expiry text.
+    """
+    assert steps._expiry_suffix(None) == ""
+
+
+def test_code_is_renewed_slightly_before_it_lapses() -> None:
+    """
+    A code within the renewal margin counts as expired.
+    """
+    import time as _time
+
+    now = int(_time.time())
+    assert steps._code_expired(now + 1) is True
+    assert steps._code_expired(now + 3600) is False
+    assert steps._code_expired(None) is False
+
+
+@pytest.mark.asyncio
+async def test_cloud_step_can_be_skipped() -> None:
+    """
+    Declining the prompt skips linking without ending the wizard.
+    """
+    prompt = RecordingPrompt([False])
+
+    with pytest.raises(SetupCancelled):
+        await CloudStep().run(FakeClient(), prompt)  # type: ignore[arg-type]
+
+    assert any(steps.CLOUD_DASHBOARD_URL in line for line in prompt.lines)
+
+
+@pytest.mark.asyncio
+async def test_cloud_step_renews_the_code_until_linked(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    An expired code is replaced rather than left on screen.
+    """
+    monkeypatch.setattr(steps, "CLOUD_LINK_POLL_INTERVAL_SECONDS", 0)
+    issued: list[str] = []
+
+    class _Linking:
+        def __init__(self) -> None:
+            self.polls = 0
+
+        async def account_link(self):
+            code = f"COD{len(issued)}"
+            issued.append(code)
+            return types.AccountLink(code=code, expires_at=int(time.time()))
+
+        async def account_info(self):
+            self.polls += 1
+            return types.AccountInfo(linked=self.polls >= 3, email="user@example.com")
+
+    prompt = RecordingPrompt([True])
+    await CloudStep().run(_Linking(), prompt)  # type: ignore[arg-type]
+
+    assert len(issued) > 1, "expired code should have been replaced"
+    assert any("user@example.com" in line for line in prompt.lines)
+
+
+@pytest.mark.asyncio
+async def test_wifi_step_falls_back_to_manual_ssid_when_scan_is_refused() -> None:
+    """
+    The device refuses to scan while connected, answering 400.
+
+    That happens whenever this step is re-run with --redo, so the scan
+    failing must not fail the step.
+    """
+
+    class _Connected:
+        async def wifi_networks(self):
+            raise RuntimeError("400 Scan not possible when connected")
+
+        async def wifi_connect(self, config):
+            self.config = config
+            return types.SuccessResponse(result="OK")
+
+    client = _Connected()
+    prompt = RecordingPrompt(["HomeNet", "hunter2"])
+
+    await WifiStep().run(client, prompt)  # type: ignore[arg-type]
+
+    assert client.config.ssid == "HomeNet"

--- a/tests/examples/setup/test_wizard.py
+++ b/tests/examples/setup/test_wizard.py
@@ -9,7 +9,7 @@ import pytest
 
 from busylib import types, versioning
 from examples.setup.prompts import SetupAborted, SetupCancelled
-from examples.setup import steps
+from examples.setup import operations, steps
 from examples.setup.steps import (
     CloudStep,
     FirmwareStep,
@@ -324,7 +324,7 @@ async def test_firmware_keeps_polling_while_the_check_is_running(
     The device reports status "none" until the check produces a result, so
     treating any non-idle status as terminal skipped the first-run update.
     """
-    monkeypatch.setattr(steps, "UPDATE_POLL_INTERVAL_SECONDS", 0)
+    monkeypatch.setattr(operations, "UPDATE_POLL_INTERVAL_SECONDS", 0)
     client = _UpdateClient(
         [_check("none"), _check("none"), _check("available", "1.1.1")]
     )
@@ -342,7 +342,7 @@ async def test_firmware_stops_on_a_terminal_no_update_status(
     """
     `not_available` ends the poll without offering an install.
     """
-    monkeypatch.setattr(steps, "UPDATE_POLL_INTERVAL_SECONDS", 0)
+    monkeypatch.setattr(operations, "UPDATE_POLL_INTERVAL_SECONDS", 0)
     client = _UpdateClient([_check("not_available")])
 
     prompt = RecordingPrompt()
@@ -466,10 +466,10 @@ async def test_stale_available_version_is_not_installed(
     "available"; acting on `available_version` alone got a 400 "Update not
     available" back from a real bar.
     """
-    monkeypatch.setattr(steps, "UPDATE_POLL_INTERVAL_SECONDS", 0)
+    monkeypatch.setattr(operations, "UPDATE_POLL_INTERVAL_SECONDS", 0)
     client = _UpdateClient([_check("none", "1.1.1"), _check("not_available", "1.1.1")])
 
-    assert await FirmwareStep()._await_check_result(client) is None  # type: ignore[arg-type]
+    assert await operations.find_available_update(client) is None  # type: ignore[arg-type]
 
 
 def test_expiry_is_rendered_as_local_time() -> None:

--- a/tests/examples/setup/test_wizard.py
+++ b/tests/examples/setup/test_wizard.py
@@ -308,9 +308,13 @@ class _UpdateClient:
         return types.SuccessResponse(result="OK")
 
 
-def _check(status: str, version: str | None = None) -> types.UpdateStatus:
+def _check(
+    status: str, version: str | None = None, event: str | None = None
+) -> types.UpdateStatus:
     return types.UpdateStatus(
-        check=types.UpdateCheckStatus(status=status, available_version=version)
+        check=types.UpdateCheckStatus(
+            status=status, available_version=version, event=event
+        )
     )
 
 
@@ -567,3 +571,48 @@ async def test_wifi_step_falls_back_to_manual_ssid_when_scan_is_refused() -> Non
     await WifiStep().run(client, prompt)  # type: ignore[arg-type]
 
     assert client.config.ssid == "HomeNet"
+
+
+@pytest.mark.asyncio
+async def test_stale_not_available_does_not_hide_a_real_update(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    A leftover "not_available" must not be reported as this check's answer.
+
+    The device keeps the previous outcome until a new check lands, and the
+    check runs asynchronously, so the first poll can still show the old
+    verdict - which made setup announce "no update" while the bar was
+    offering one.
+    """
+    monkeypatch.setattr(operations, "UPDATE_POLL_INTERVAL_SECONDS", 0)
+    client = _UpdateClient(
+        [
+            # Left over from a check performed at boot.
+            _check("not_available", "", event="stop"),
+            _check("not_available", "", event="stop"),
+            _check("none", "", event="start"),
+            _check("available", "1.1.1", event="stop"),
+        ]
+    )
+
+    assert await operations.find_available_update(client) == "1.1.1"  # type: ignore[arg-type]
+
+
+@pytest.mark.asyncio
+async def test_a_genuinely_new_no_update_verdict_is_accepted(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    Once the check has visibly run, "not_available" is the answer.
+    """
+    monkeypatch.setattr(operations, "UPDATE_POLL_INTERVAL_SECONDS", 0)
+    client = _UpdateClient(
+        [
+            _check("none", "", event="none"),
+            _check("none", "", event="start"),
+            _check("not_available", "", event="stop"),
+        ]
+    )
+
+    assert await operations.find_available_update(client) is None  # type: ignore[arg-type]


### PR DESCRIPTION
Release fixes from running the wizard against a real factory bar. All three items you flagged, plus two problems the same session surfaced.

## `setup --status` showed "Firmware ?"

`/api/version` only ever returns `api_semver` — on 1.0.2 and on current firmware alike — so `info.version` was always empty and every bar rendered as `Firmware ?`. The firmware's own version lives under `/api/status` in the `firmware` section.

Both are read now, and when `/api/status` isn't reachable the label degrades to `API 24.3.0` rather than `? (API 24.3.0)`.

```
[ ] Firmware   1.0.2 (API 24.3.0) - library targets API 25.0.0
```

## Installing an update failed right after offering it

The wizard offered `1.1.1`, then `POST /api/update/install` came back `400 "Update not available"`.

The firmware only accepts an install while its own check state reads `available`. The poll returned as soon as `check.available_version` was non-empty — but that field retains the version from an *earlier* check, so we acted on a stale value while the current check was still running. It now waits for `status == "available"`.

## Compatibility metadata for withdrawn endpoints

`requires_openapi` declares a *minimum* version, which can't express an endpoint that was removed: no newer firmware brings it back. Added `removed_endpoint`, which raises `BusyBarRemovedEndpointError` naming the replacement instead of letting an opaque `404` through, and reports via `method_compatibility()`:

```python
bb.method_compatibility("account_profile")
# {'path': '/api/account/profile', 'method': 'GET',
#  'status': 'removed', 'replacement': 'account_backend()'}
```

I audited every `/api/...` path the client uses against the firmware's route tables rather than only the one you hit. Four helpers target endpoints no supported firmware serves:

| Helper | Replacement | Why |
| --- | --- | --- |
| `account_profile()`, `account_profile_set()` | `account_backend()`, `account_backend_set()` | `/api/account/profile` deleted by FW-881 (#696) |
| `wifi_enable()`, `wifi_disable()` | `wifi_connect()`, `wifi_disconnect()` | wifi serves only `networks`, `connect`, `disconnect`, `status` |

Worth noting this isn't version-specific: those paths are absent from 1.0.2, 1.1.1 **and** `dev`, so gating them by version would have been wrong.

## `wifi_networks()` while connected

The firmware answers `400 "Scan not possible when connected"` (`WifiStatusScanNotPossible`). Documented on both the sync and async helper, and the Wi-Fi step now falls back to typing an SSID instead of failing — which is what `--redo` on a connected bar hits.

## Cloud linking

The code was printed once, with a raw unix timestamp, and had usually expired before anyone found where to enter it. Now it points at https://cloud.busy.app/dashboard, shows the expiry as local time, renews the code as it lapses while polling for the link, and can be declined to skip the step.

## README: no password over USB

You were right. The firmware skips the access-key check entirely for USB and localhost connections (`if(!is_usb && !is_localhost)`), so a bar at `10.0.4.20` never needs a token in any access mode. The 403 advice only applies over Wi-Fi, where the key is a 4–10 digit PIN. Corrected in the README and the connecting guide.

## Test plan

- [x] `uv run pytest -q` — 15 new tests covering each fix above
- [x] `make lint`, `make typecheck`, `pre-commit run --all-files`
- [x] `mkdocs build --strict`
- [x] Re-run `python -m examples.setup.main` end to end on the factory bar

Not addressed, as agreed: mDNS on factory firmware — `_busybar._tcp` is genuinely absent there and the USB fallback is verified.