### PR TITLE
Add a cloud_message example for posting to a bar over the internet

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,6 +273,27 @@ device, and running setup:
 uv run python -m examples.remote.main 10.0.4.20
 ```
 
+### Post a message over the internet
+
+The examples above talk to a bar over USB or the LAN. `examples/cloud_message`
+shows a bar that is somewhere else entirely: requests travel through the BUSY
+cloud service, so the script does not need to share a network with the device.
+
+Create an API token at [cloud.busy.app](https://cloud.busy.app) with the
+**BUSY Bar** access scope, then:
+
+```bash
+export BUSY_BAR_TOKEN=...
+uv run python -m examples.cloud_message.main "Deploy running" --background red
+uv run python -m examples.cloud_message.main --clear
+```
+
+Cloud requests are authenticated with `Authorization: Bearer <token>` and are
+served under `https://api.busy.app/busybar/<endpoint>` rather than the
+on-device `/api/<endpoint>`, so the example builds calls with
+`prepare_request()` and executes them against a client bound to that base URL.
+An `account`-scoped token is rejected with `403`.
+
 ## Going further
 
 Client method names follow BUSY Bar API path segments instead of generic

--- a/examples/cloud_message/cloud.py
+++ b/examples/cloud_message/cloud.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+import logging
+from contextlib import AbstractContextManager
+from types import TracebackType
+from typing import Any
+
+import httpx
+
+from busylib import BusyBar, types
+
+logger = logging.getLogger(__name__)
+
+# Documented at https://docs.busy.app/bar/dev/http-api ("via internet").
+CLOUD_BASE_URL = "https://api.busy.app/busybar"
+
+
+class CloudBar(AbstractContextManager["CloudBar"]):
+    """
+    Talk to a BUSY Bar over the internet instead of USB or the LAN.
+
+    `BusyBar(token=...)` already selects cloud mode and sets the bearer header,
+    but the cloud service exposes the device API under `/busybar/<endpoint>`
+    rather than the on-device `/api/<endpoint>`. So requests are built with
+    `prepare_request()` and executed against a client bound to the cloud base
+    URL -- the documented hook for custom transports, which keeps busylib's
+    error mapping and retry behaviour.
+    """
+
+    def __init__(
+        self,
+        token: str,
+        *,
+        base_url: str = CLOUD_BASE_URL,
+        timeout: float = 30.0,
+    ) -> None:
+        self._bar = BusyBar(token=token)
+        # Reuse the headers busylib built (bearer auth plus API version), so
+        # the cloud client stays in sync with the library's expectations.
+        self._cloud = httpx.Client(
+            base_url=base_url,
+            headers=dict(self._bar.client.headers),
+            timeout=timeout,
+        )
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        tb: TracebackType | None,
+    ) -> None:
+        self.close()
+
+    def close(self) -> None:
+        """
+        Release both the busylib client and the cloud transport.
+        """
+        self._cloud.close()
+        self._bar.close()
+
+    def status(self) -> Any:
+        """
+        Fetch the device status snapshot, confirming the bar is reachable.
+        """
+        return self._request("GET", "/status")
+
+    def draw(self, elements: types.DisplayElements) -> Any:
+        """
+        Draw display elements on the bar.
+        """
+        logger.info("draw application_name=%s", elements.application_name)
+        return self._request(
+            "POST",
+            "/display/draw",
+            json_payload=elements.model_dump(exclude_none=True),
+        )
+
+    def clear(self, application_name: str) -> Any:
+        """
+        Remove the elements this application drew.
+        """
+        logger.info("clear application_name=%s", application_name)
+        return self._request(
+            "DELETE",
+            "/display/draw",
+            params={"application_name": application_name},
+        )
+
+    def _request(
+        self,
+        method: str,
+        path: str,
+        *,
+        params: dict[str, object] | None = None,
+        json_payload: Any | None = None,
+    ) -> Any:
+        prepared = self._bar.prepare_request(
+            method,
+            path,
+            params=params,
+            json_payload=json_payload,
+        )
+        result = self._bar.execute_prepared_request(prepared, client=self._cloud)
+        return result

--- a/examples/cloud_message/colors.py
+++ b/examples/cloud_message/colors.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+# Kept as hex for readability; parse_color converts to RGBA channels.
+NAMED_COLORS = {
+    "amber": "FFBF00",
+    "azure": "0080FF",
+    "black": "000000",
+    "blue": "0000FF",
+    "cyan": "00FFFF",
+    "gray": "808080",
+    "green": "00FF00",
+    "grey": "808080",
+    "lime": "80FF00",
+    "magenta": "FF00FF",
+    "orange": "FF8000",
+    "pink": "FF4080",
+    "purple": "8000FF",
+    "red": "FF0000",
+    "teal": "00FF80",
+    "violet": "8000FF",
+    "white": "FFFFFF",
+    "yellow": "FFFF00",
+}
+
+Rgba = tuple[int, int, int, int]
+
+
+class ColorError(ValueError):
+    """
+    Raised when a color string cannot be resolved to RGBA channels.
+    """
+
+
+def parse_color(value: str, *, default_alpha: int = 0xFF) -> Rgba:
+    """
+    Resolve "red", "red@40", "#FF0000" or "#FF000055" to (r, g, b, a).
+
+    An explicit alpha always wins. The "@<percent>" suffix is easier to reason
+    about than a hex byte when picking a translucent overlay.
+
+    Channels are returned rather than a "#RRGGBBAA" string so that busylib
+    normalizes them. Passing hex strings would route through
+    `pydantic_extra_types.color.Color.as_hex()`, whose short form collapses
+    values such as "#FF000055" to "#f005" and loses the alpha.
+    """
+    spec = value.strip()
+    alpha: int | None = None
+
+    if "@" in spec:
+        spec, _, percent = spec.partition("@")
+        try:
+            percent_value = float(percent)
+        except ValueError:
+            raise ColorError(
+                f"invalid alpha percentage {percent!r} in {value!r}"
+            ) from None
+        if not 0.0 <= percent_value <= 100.0:
+            raise ColorError(f"alpha percentage out of range 0-100 in {value!r}")
+        alpha = round(percent_value * 255 / 100)
+
+    spec = spec.strip()
+    key = spec.lower()
+    if key in NAMED_COLORS:
+        digits = NAMED_COLORS[key]
+    else:
+        digits = spec.removeprefix("#").upper()
+        if len(digits) == 8 and _is_hex(digits):
+            if alpha is None:
+                alpha = int(digits[6:], 16)
+            digits = digits[:6]
+        elif not (len(digits) == 6 and _is_hex(digits)):
+            names = ", ".join(sorted(NAMED_COLORS))
+            raise ColorError(
+                f"unrecognised color {value!r}; use a name ({names}), "
+                "#RRGGBB, or #RRGGBBAA, optionally with '@<percent>'"
+            )
+
+    return (
+        int(digits[0:2], 16),
+        int(digits[2:4], 16),
+        int(digits[4:6], 16),
+        default_alpha if alpha is None else alpha,
+    )
+
+
+def _is_hex(value: str) -> bool:
+    """
+    Report whether every character is a hexadecimal digit.
+    """
+    return all(char in "0123456789ABCDEF" for char in value)

--- a/examples/cloud_message/main.py
+++ b/examples/cloud_message/main.py
@@ -1,0 +1,167 @@
+from __future__ import annotations
+
+import argparse
+import logging
+import os
+import sys
+
+from busylib import exceptions
+
+from examples.cloud_message.cloud import CLOUD_BASE_URL, CloudBar
+from examples.cloud_message.colors import NAMED_COLORS, ColorError
+from examples.cloud_message.message import (
+    APPLICATION_NAME,
+    DEFAULT_BACKGROUND_ALPHA,
+    DEFAULT_PRIORITY,
+    Message,
+    build_elements,
+)
+
+TOKEN_ENV_VAR = "BUSY_BAR_TOKEN"
+
+FONTS = [
+    "tiny",
+    "small",
+    "normal",
+    "condensed",
+    "bold",
+    "large",
+    "extra_large",
+    "global",
+]
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    """
+    Parse CLI arguments for the cloud message example.
+    """
+    background_percent = DEFAULT_BACKGROUND_ALPHA * 100 // 255
+    parser = argparse.ArgumentParser(
+        prog="cloud_message",
+        description=(
+            "Show a status message on a BUSY Bar over the internet. The bar "
+            "does not need to be on the same network: requests go through the "
+            f"cloud service at {CLOUD_BASE_URL}. Requires an API token with "
+            "the 'BUSY Bar' access scope, created at https://cloud.busy.app."
+        ),
+    )
+    parser.add_argument("text", nargs="?", help="Message text (printable ASCII)")
+    parser.add_argument(
+        "--token",
+        default=None,
+        help=f"API token; defaults to the {TOKEN_ENV_VAR} environment variable",
+    )
+    parser.add_argument("--color", default="white", help="Text color")
+    parser.add_argument(
+        "--background",
+        default=None,
+        help=(
+            "Translucent color overlay, e.g. 'red' or 'red@40'. Bare names get "
+            f"{background_percent}%% alpha, because an opaque fill hides the text"
+        ),
+    )
+    parser.add_argument("--led", default=None, help="Status LED blink color")
+    parser.add_argument("--font", choices=FONTS, default="normal", help="Font name")
+    parser.add_argument(
+        "--no-scroll", action="store_true", help="Do not scroll long text"
+    )
+    parser.add_argument(
+        "--priority",
+        type=int,
+        default=DEFAULT_PRIORITY,
+        help=(
+            f"Draw priority 1-100 (default {DEFAULT_PRIORITY}, which preempts "
+            "an active work session at 90)"
+        ),
+    )
+    parser.add_argument(
+        "--clear", action="store_true", help="Clear this app's elements and exit"
+    )
+    parser.add_argument(
+        "--status", action="store_true", help="Print device status and exit"
+    )
+    parser.add_argument(
+        "--list-colors", action="store_true", help="List color names and exit"
+    )
+    parser.add_argument("--log-level", default="WARNING", help="Logging level")
+    return parser.parse_args(argv)
+
+
+def resolve_token(explicit: str | None) -> str:
+    """
+    Return the API token from the CLI flag or the environment.
+    """
+    token = explicit or os.environ.get(TOKEN_ENV_VAR)
+    if not token:
+        raise SystemExit(
+            f"No API token. Pass --token or set {TOKEN_ENV_VAR}.\n"
+            "Create one at https://cloud.busy.app with the 'BUSY Bar' access "
+            "scope; an 'account'-scoped token is rejected with 403."
+        )
+    return token
+
+
+def main(argv: list[str] | None = None) -> int:
+    """
+    Run the cloud message example.
+    """
+    args = parse_args(argv)
+    logging.basicConfig(level=args.log_level.upper())
+
+    if args.list_colors:
+        for name in sorted(NAMED_COLORS):
+            print(f"  {name:9s} #{NAMED_COLORS[name]}")
+        return 0
+
+    if not args.clear and not args.status and not args.text:
+        raise SystemExit("Provide message text, or use --clear or --status.")
+
+    # Validate everything before touching the device.
+    message: Message | None = None
+    if args.text and not args.clear:
+        try:
+            message = Message(
+                text=args.text,
+                color=args.color,
+                background=args.background,
+                led=args.led,
+                font=args.font,
+                scroll=not args.no_scroll,
+                priority=args.priority,
+            )
+            elements = build_elements(message)
+        except (ColorError, ValueError) as exc:
+            raise SystemExit(f"Invalid message: {exc}") from None
+
+    token = resolve_token(args.token)
+
+    try:
+        with CloudBar(token) as bar:
+            if args.status:
+                print(bar.status())
+                return 0
+            if args.clear:
+                bar.clear(APPLICATION_NAME)
+                print("cleared")
+                return 0
+            assert message is not None
+            bar.draw(elements)
+            print(f"posted: {message.text}")
+    except exceptions.BusyBarAPIError as exc:
+        if exc.status_code == 403:
+            raise SystemExit(
+                "403 Forbidden: the token was not accepted for this bar. "
+                "Check that it has the 'BUSY Bar' access scope rather than "
+                "'account', and that the bar is linked to the same account."
+            ) from None
+        if exc.status_code == 409:
+            raise SystemExit(
+                f"409 Conflict: priority {args.priority} is below the app "
+                "currently on screen. Retry with a higher --priority."
+            ) from None
+        raise
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/examples/cloud_message/message.py
+++ b/examples/cloud_message/message.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from busylib import types
+
+from examples.cloud_message.colors import parse_color
+
+APPLICATION_NAME = "cloud_message"
+
+# The front display is a 72x16 RGB LED matrix.
+FRONT_WIDTH = 72
+FRONT_HEIGHT = 16
+
+# System app priorities: stub/poweroff 0, built-in apps 10, an active
+# BUSY/CUSTOM work session 90. Default above 90 so a deliberate notification
+# is not silently rejected with 409 while the owner is in a session.
+DEFAULT_PRIORITY = 95
+
+# A filled rectangle is composited over text regardless of element order, so it
+# cannot act as an opaque backdrop. Overlaying it with alpha tints the whole
+# display while keeping the text brighter than the background, which reads as
+# coloured-background text. Fully opaque fills hide the text entirely.
+DEFAULT_BACKGROUND_ALPHA = 0x55
+
+
+@dataclass(frozen=True)
+class Message:
+    """
+    A single glanceable status line to show on the front display.
+    """
+
+    text: str
+    color: str = "white"
+    background: str | None = None
+    led: str | None = None
+    font: str = "normal"
+    scroll: bool = True
+    priority: int = DEFAULT_PRIORITY
+
+    def __post_init__(self) -> None:
+        if not self.text.strip():
+            raise ValueError("message text must not be empty")
+        # Fonts are bitmap ASCII, so anything outside printable ASCII is
+        # rejected by the device rather than rendered.
+        if any(not 0x20 <= ord(char) <= 0x7E for char in self.text):
+            raise ValueError("message text must be printable ASCII")
+        if not 1 <= self.priority <= 100:
+            raise ValueError("priority must be between 1 and 100")
+
+
+def build_elements(message: Message) -> types.DisplayElements:
+    """
+    Turn a `Message` into a validated display payload.
+    """
+    text_element: dict[str, object] = {
+        "id": "msg",
+        "type": "text",
+        "x": 0,
+        "y": 4,
+        "text": message.text,
+        "font": message.font,
+        "color": parse_color(message.color),
+    }
+    if message.scroll:
+        # Anything wider than the display has to scroll to be readable.
+        text_element.update(
+            width=FRONT_WIDTH,
+            scroll_rate=600,
+            scroll_start_delay=500,
+        )
+
+    elements: list[dict[str, object]] = [text_element]
+    if message.background:
+        elements.append(
+            {
+                "id": "bg",
+                "type": "rectangle",
+                "x": 0,
+                "y": 0,
+                "align": "top_left",
+                "display": "front",
+                "width": FRONT_WIDTH,
+                "height": FRONT_HEIGHT,
+                "fill": "solid",
+                "fill_colors": [
+                    parse_color(
+                        message.background,
+                        default_alpha=DEFAULT_BACKGROUND_ALPHA,
+                    )
+                ],
+                "border_width": 0,
+            }
+        )
+
+    payload: dict[str, object] = {
+        "application_name": APPLICATION_NAME,
+        "priority": message.priority,
+        "elements": elements,
+    }
+    if message.led:
+        payload["led_notification_color"] = parse_color(message.led)
+
+    return types.DisplayElements.model_validate(payload)

--- a/tests/examples/cloud_message/test_colors.py
+++ b/tests/examples/cloud_message/test_colors.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+import pytest
+
+from examples.cloud_message.colors import ColorError, parse_color
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        ("red", (0xFF, 0x00, 0x00, 0xFF)),
+        ("RED", (0xFF, 0x00, 0x00, 0xFF)),
+        ("  white  ", (0xFF, 0xFF, 0xFF, 0xFF)),
+        ("#FF0000", (0xFF, 0x00, 0x00, 0xFF)),
+        ("ff0000", (0xFF, 0x00, 0x00, 0xFF)),
+        ("#FF000055", (0xFF, 0x00, 0x00, 0x55)),
+        ("red@40", (0xFF, 0x00, 0x00, 0x66)),
+        ("red@0", (0xFF, 0x00, 0x00, 0x00)),
+        ("red@100", (0xFF, 0x00, 0x00, 0xFF)),
+        ("#FF0000@50", (0xFF, 0x00, 0x00, 0x80)),
+        ("orange", (0xFF, 0x80, 0x00, 0xFF)),
+    ],
+)
+def test_parse_color_accepted_forms(value: str, expected: tuple[int, ...]) -> None:
+    """
+    Names, hex values, and percentage alpha all resolve to RGBA channels.
+    """
+    assert parse_color(value) == expected
+
+
+def test_parse_color_applies_default_alpha_to_bare_color() -> None:
+    """
+    A color without its own alpha picks up the caller's default.
+    """
+    assert parse_color("red", default_alpha=0x55) == (0xFF, 0x00, 0x00, 0x55)
+
+
+def test_parse_color_explicit_alpha_beats_default() -> None:
+    """
+    An alpha carried by the value itself wins over the caller's default, so a
+    translucent overlay default cannot silently override an explicit choice.
+    """
+    assert parse_color("#FF0000FF", default_alpha=0x55) == (0xFF, 0x00, 0x00, 0xFF)
+    assert parse_color("red@100", default_alpha=0x55) == (0xFF, 0x00, 0x00, 0xFF)
+
+
+@pytest.mark.parametrize(
+    "value",
+    ["puce", "#GGGGGG", "#FFF", "", "red@120", "red@-1", "red@abc"],
+)
+def test_parse_color_rejects_invalid_values(value: str) -> None:
+    """
+    Unknown names, malformed hex, and out-of-range alpha raise ColorError.
+    """
+    with pytest.raises(ColorError):
+        parse_color(value)

--- a/tests/examples/cloud_message/test_message.py
+++ b/tests/examples/cloud_message/test_message.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+import pytest
+
+from busylib import types
+from examples.cloud_message.message import (
+    APPLICATION_NAME,
+    DEFAULT_PRIORITY,
+    Message,
+    build_elements,
+)
+
+
+def test_build_elements_produces_validated_payload() -> None:
+    """
+    A plain message becomes a scrolling white text element for this app.
+    """
+    elements = build_elements(Message(text="Deploy running"))
+
+    assert isinstance(elements, types.DisplayElements)
+    assert elements.application_name == APPLICATION_NAME
+    assert elements.priority == DEFAULT_PRIORITY
+
+    payload = elements.model_dump(exclude_none=True)
+    assert len(payload["elements"]) == 1
+    text = payload["elements"][0]
+    assert text["type"] == "text"
+    assert text["color"] == "#FFFFFFFF"
+    assert text["scroll_rate"] == 600
+
+
+def test_build_elements_background_is_translucent_and_drawn_last() -> None:
+    """
+    The background rectangle must be translucent and come after the text.
+
+    A filled rectangle is composited over text regardless of element order, so
+    an opaque fill would hide the message entirely.
+    """
+    elements = build_elements(Message(text="Deploy running", background="red"))
+    payload = elements.model_dump(exclude_none=True)
+
+    assert [element["type"] for element in payload["elements"]] == [
+        "text",
+        "rectangle",
+    ]
+    fill = payload["elements"][1]["fill_colors"][0]
+    assert fill.startswith("#FF0000")
+    assert fill != "#FF0000FF", "opaque background would hide the text"
+
+
+def test_build_elements_omits_scroll_when_disabled() -> None:
+    """
+    Static text carries no scroll fields.
+    """
+    payload = build_elements(Message(text="Idle", scroll=False)).model_dump(
+        exclude_none=True
+    )
+    assert "scroll_rate" not in payload["elements"][0]
+
+
+def test_build_elements_sets_led_only_when_requested() -> None:
+    """
+    The status LED stays quiet unless a color is asked for.
+    """
+    without = build_elements(Message(text="Idle")).model_dump(exclude_none=True)
+    assert "led_notification_color" not in without
+
+    with_led = build_elements(Message(text="Idle", led="yellow")).model_dump(
+        exclude_none=True
+    )
+    assert with_led["led_notification_color"] == "#FFFF00FF"
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "match"),
+    [
+        ({"text": "   "}, "must not be empty"),
+        ({"text": "héllo"}, "printable ASCII"),
+        ({"text": "ok", "priority": 0}, "between 1 and 100"),
+        ({"text": "ok", "priority": 101}, "between 1 and 100"),
+    ],
+)
+def test_message_rejects_invalid_input(kwargs: dict[str, object], match: str) -> None:
+    """
+    Validation happens before any device call.
+    """
+    with pytest.raises(ValueError, match=match):
+        Message(**kwargs)  # type: ignore[arg-type]


### PR DESCRIPTION
## What

Adds `examples/cloud_message`, an example for showing a status message on a bar
that is **not** on the local network. The existing `setup`, `remote`, and `bc`
examples all connect over USB or the LAN, so the "via internet" path from the
[HTTP API docs](https://docs.busy.app/bar/dev/http-api) had no example.

```bash
export BUSY_BAR_TOKEN=...   # 'BUSY Bar' access scope, from cloud.busy.app
uv run python -m examples.cloud_message.main "Deploy running" --background red
uv run python -m examples.cloud_message.main --clear
```

Layered per `AGENTS.md`: `colors.py` (input parsing), `message.py` (payload
building, using `types.DisplayElements`), `cloud.py` (the only place that talks
to the device), `main.py` (argument parsing and workflow). All input is
validated before anything touches the bar.

## Why it does not just call `BusyBar(token=...)` methods

`BusyBar(token=...)` already selects cloud mode and sets the bearer header, but
the cloud service serves the device API under `/busybar/<endpoint>` while the
client methods request `/api/<endpoint>`. The example therefore builds requests
with `prepare_request()` and executes them against an `httpx.Client` bound to
the cloud base URL — the documented hook for custom transports, so busylib's
error mapping and retries still apply.

I have filed two issues for the underlying library behaviour this example had to
work around, so the example can be simplified once they are addressed:

- cloud mode is unusable as shipped (`settings.cloud_base_url` points at a
  hostname that does not resolve, and the `/api` prefix does not match the cloud
  paths)
- `normalize_rgba_color()` silently drops alpha for 15 of 256 values

## Two findings baked into the example

**Alpha is dropped for round values.** Colors are resolved to RGBA channel
tuples rather than `#RRGGBBAA` strings. `normalize_rgba_color()` routes strings
through `pydantic_extra_types.color.Color.as_hex()`, whose short form collapses
`#FF000055` to `#f005`; that value matches neither the 9- nor the 7-character
branch, so it falls through to a path that hardcodes the alpha to `FF`. Tuples
take the branch that preserves alpha.

**A filled rectangle cannot be a backdrop.** It is composited over text
regardless of element order, so an opaque fill hides the message entirely. The
example overlays it with alpha, which keeps the text brighter than the
background and reads as coloured-background text.

## Testing

- `tests/examples/cloud_message/` adds 28 tests covering colour parsing and
  payload building, including a regression test asserting the background stays
  translucent and is ordered after the text.
- `ruff check` and `ruff format --check` are clean over `src/busylib tests examples`.
- The README addition is a `bash` block, so the set of Python blocks executed by
  `tests/test_readme_examples.py` is unchanged (16 before and after).
- Verified end to end against a physical bar (BB.1, firmware 1.1.1) over the
  cloud: draw, `--clear`, `--status`, and the 403/409 error paths.
- `tests/examples/setup/test_wizard.py` has 94 pre-existing failures on `main`
  in my environment, unchanged by this branch (looks like #51).