### PR TITLE
Mark the token endpoints as experimental, and cover them with tests

### DIFF
--- a/src/busylib/client/access.py
+++ b/src/busylib/client/access.py
@@ -3,12 +3,16 @@ from __future__ import annotations
 import logging
 from typing import Literal
 
-from .. import types
+from .. import types, versioning
 from .base import AsyncClientBase, SyncClientBase
 
 logger = logging.getLogger(__name__)
 
 HttpAccessMode = Literal["disabled", "enabled", "key"]
+
+# Named once so the marker and the docstrings cannot drift apart, and so the
+# whole set can be swapped for a version floor when the firmware work ships.
+TOKENS_NOTE = "requires firmware from busy-app/busybar-firmware#886, not released yet"
 
 
 class AccessMixin(SyncClientBase):
@@ -33,40 +37,72 @@ class AccessMixin(SyncClientBase):
         data = self._request("POST", "/api/access", params=params)
         return types.SuccessResponse.model_validate(data)
 
+    @versioning.experimental_endpoint(
+        path="/api/access/tokens",
+        method="GET",
+        note=TOKENS_NOTE,
+    )
     def access_tokens_list(self) -> types.AccessTokensInfo:
         """
         List issued access tokens via GET /api/access/tokens.
 
         The secret itself is returned only when a token is minted, so every
         token here has `token` set to None.
+
+        Experimental: needs firmware from busy-app/busybar-firmware#886, which
+        is not released yet, so it answers 404 on every released firmware.
         """
         logger.info("access_tokens_list")
         data = self._request("GET", "/api/access/tokens")
         return types.AccessTokensInfo.model_validate(data)
 
+    @versioning.experimental_endpoint(
+        path="/api/access/tokens",
+        method="POST",
+        note=TOKENS_NOTE,
+    )
     def access_token_mint(self, name: str) -> types.AccessToken:
         """
         Issue a new access token via POST /api/access/tokens.
 
         This is the only time the device discloses the secret; it cannot be
         read back afterwards.
+
+        Experimental: needs firmware from busy-app/busybar-firmware#886, which
+        is not released yet, so it answers 404 on every released firmware.
         """
         logger.info("access_token_mint name=%s", name)
         payload = types.AccessTokenMintRequest(name=name).model_dump()
         data = self._request("POST", "/api/access/tokens", json_payload=payload)
         return types.AccessToken.model_validate(data)
 
+    @versioning.experimental_endpoint(
+        path="/api/access/tokens",
+        method="DELETE",
+        note=TOKENS_NOTE,
+    )
     def access_tokens_delete_all(self) -> types.SuccessResponse:
         """
         Revoke every access token via DELETE /api/access/tokens.
+
+        Experimental: needs firmware from busy-app/busybar-firmware#886, which
+        is not released yet, so it answers 404 on every released firmware.
         """
         logger.info("access_tokens_delete_all")
         data = self._request("DELETE", "/api/access/tokens")
         return types.SuccessResponse.model_validate(data)
 
+    @versioning.experimental_endpoint(
+        path="/api/access/tokens/{short_id}",
+        method="DELETE",
+        note=TOKENS_NOTE,
+    )
     def access_tokens_revoke(self, short_id: str) -> types.SuccessResponse:
         """
         Revoke one access token via DELETE /api/access/tokens/{short_id}.
+
+        Experimental: needs firmware from busy-app/busybar-firmware#886, which
+        is not released yet, so it answers 404 on every released firmware.
         """
         logger.info("access_tokens_revoke short_id=%s", short_id)
         data = self._request("DELETE", f"/api/access/tokens/{short_id}")
@@ -95,40 +131,72 @@ class AsyncAccessMixin(AsyncClientBase):
         data = await self._request("POST", "/api/access", params=params)
         return types.SuccessResponse.model_validate(data)
 
+    @versioning.experimental_endpoint(
+        path="/api/access/tokens",
+        method="GET",
+        note=TOKENS_NOTE,
+    )
     async def access_tokens_list(self) -> types.AccessTokensInfo:
         """
         List issued access tokens via GET /api/access/tokens.
 
         The secret itself is returned only when a token is minted, so every
         token here has `token` set to None.
+
+        Experimental: needs firmware from busy-app/busybar-firmware#886, which
+        is not released yet, so it answers 404 on every released firmware.
         """
         logger.info("async access_tokens_list")
         data = await self._request("GET", "/api/access/tokens")
         return types.AccessTokensInfo.model_validate(data)
 
+    @versioning.experimental_endpoint(
+        path="/api/access/tokens",
+        method="POST",
+        note=TOKENS_NOTE,
+    )
     async def access_token_mint(self, name: str) -> types.AccessToken:
         """
         Issue a new access token via POST /api/access/tokens.
 
         This is the only time the device discloses the secret; it cannot be
         read back afterwards.
+
+        Experimental: needs firmware from busy-app/busybar-firmware#886, which
+        is not released yet, so it answers 404 on every released firmware.
         """
         logger.info("async access_token_mint name=%s", name)
         payload = types.AccessTokenMintRequest(name=name).model_dump()
         data = await self._request("POST", "/api/access/tokens", json_payload=payload)
         return types.AccessToken.model_validate(data)
 
+    @versioning.experimental_endpoint(
+        path="/api/access/tokens",
+        method="DELETE",
+        note=TOKENS_NOTE,
+    )
     async def access_tokens_delete_all(self) -> types.SuccessResponse:
         """
         Revoke every access token via DELETE /api/access/tokens.
+
+        Experimental: needs firmware from busy-app/busybar-firmware#886, which
+        is not released yet, so it answers 404 on every released firmware.
         """
         logger.info("async access_tokens_delete_all")
         data = await self._request("DELETE", "/api/access/tokens")
         return types.SuccessResponse.model_validate(data)
 
+    @versioning.experimental_endpoint(
+        path="/api/access/tokens/{short_id}",
+        method="DELETE",
+        note=TOKENS_NOTE,
+    )
     async def access_tokens_revoke(self, short_id: str) -> types.SuccessResponse:
         """
         Revoke one access token via DELETE /api/access/tokens/{short_id}.
+
+        Experimental: needs firmware from busy-app/busybar-firmware#886, which
+        is not released yet, so it answers 404 on every released firmware.
         """
         logger.info("async access_tokens_revoke short_id=%s", short_id)
         data = await self._request("DELETE", f"/api/access/tokens/{short_id}")

--- a/src/busylib/versioning.py
+++ b/src/busylib/versioning.py
@@ -19,8 +19,9 @@ class MethodCompatibility(dict[str, str]):
     """
     Dictionary metadata describing a client helper's OpenAPI compatibility.
 
-    Carries either the minimum `version` a helper targets, or `status`
-    `"removed"` with the `replacement` to use instead.
+    Carries the minimum `version` a helper targets, or a `status`:
+    `"removed"` with the `replacement` to use instead, or `"experimental"`
+    with a `note` about the firmware that introduces the endpoint.
     """
 
 
@@ -109,6 +110,42 @@ def removed_endpoint(
 
         setattr(wrapper, "__busy_openapi__", metadata)
         return cast(F, wrapper)
+
+    return decorator
+
+
+def experimental_endpoint(
+    *,
+    path: str,
+    method: str,
+    note: str,
+) -> Callable[[F], F]:
+    """
+    Mark a helper whose device endpoint is not in released firmware yet.
+
+    The counterpart to `requires_openapi`, for the other end of an endpoint's
+    life: there is no minimum API version to state because no released
+    firmware serves it, so a version floor would have to be invented. The
+    call is left working - it succeeds against firmware that does have the
+    endpoint - and the situation is recorded in the metadata instead, where
+    `method_compatibility()` and the API reference can show it.
+
+    `note` says which firmware work introduces the endpoint, so the marker
+    can be replaced with a real version once that ships.
+    """
+
+    def decorator(func: F) -> F:
+        setattr(
+            func,
+            "__busy_openapi__",
+            MethodCompatibility(
+                path=path,
+                method=method,
+                status="experimental",
+                note=note,
+            ),
+        )
+        return func
 
     return decorator
 

--- a/tests/busylib/client/test_access_tokens.py
+++ b/tests/busylib/client/test_access_tokens.py
@@ -1,0 +1,138 @@
+from __future__ import annotations
+
+import httpx
+import pytest
+
+from busylib import AsyncBusyBar, BusyBar, types
+
+TOKEN_PAYLOAD = {
+    "short_id": "ab12",
+    "display_id": "ab12-cdef",
+    "name": "laptop",
+    "created_at": 1785515110,
+    "last_used_at": 1785515200,
+    "token": "secret-value",
+}
+
+
+def _client(responder) -> BusyBar:
+    return BusyBar(addr="http://device.local", transport=httpx.MockTransport(responder))
+
+
+def _async_client(responder) -> AsyncBusyBar:
+    return AsyncBusyBar(
+        addr="http://device.local", transport=httpx.MockTransport(responder)
+    )
+
+
+def test_tokens_list_parses_the_collection() -> None:
+    """
+    A token listing comes back as models, not raw dicts.
+    """
+    seen: dict[str, str] = {}
+
+    def responder(request: httpx.Request) -> httpx.Response:
+        seen["path"] = request.url.path
+        seen["method"] = request.method
+        return httpx.Response(200, json={"tokens": [TOKEN_PAYLOAD]})
+
+    info = _client(responder).access_tokens_list()
+
+    assert seen == {"path": "/api/access/tokens", "method": "GET"}
+    assert isinstance(info, types.AccessTokensInfo)
+    assert info.tokens[0].short_id == "ab12"
+
+
+def test_token_mint_sends_the_name_and_returns_the_secret() -> None:
+    """
+    Minting posts the requested name and yields the one-time secret.
+    """
+    seen: dict[str, object] = {}
+
+    def responder(request: httpx.Request) -> httpx.Response:
+        seen["path"] = request.url.path
+        seen["body"] = request.content
+        return httpx.Response(200, json=TOKEN_PAYLOAD)
+
+    token = _client(responder).access_token_mint("laptop")
+
+    assert seen["path"] == "/api/access/tokens"
+    assert b"laptop" in bytes(seen["body"])  # type: ignore[arg-type]
+    assert token.token == "secret-value"
+
+
+def test_token_without_a_secret_parses() -> None:
+    """
+    Listing omits the secret, so the field has to stay optional.
+
+    The device returns it only when the token is minted.
+    """
+    payload = {k: v for k, v in TOKEN_PAYLOAD.items() if k != "token"}
+
+    def responder(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json={"tokens": [payload]})
+
+    info = _client(responder).access_tokens_list()
+
+    assert info.tokens[0].token is None
+
+
+def test_tokens_delete_all_uses_delete_on_the_collection() -> None:
+    """
+    Revoking everything is a DELETE on the collection.
+    """
+    seen: dict[str, str] = {}
+
+    def responder(request: httpx.Request) -> httpx.Response:
+        seen["path"] = request.url.path
+        seen["method"] = request.method
+        return httpx.Response(200, json={"result": "OK"})
+
+    assert _client(responder).access_tokens_delete_all().result == "OK"
+    assert seen == {"path": "/api/access/tokens", "method": "DELETE"}
+
+
+def test_tokens_revoke_addresses_a_single_token() -> None:
+    """
+    Revoking one token puts its short id in the path.
+    """
+    seen: dict[str, str] = {}
+
+    def responder(request: httpx.Request) -> httpx.Response:
+        seen["path"] = request.url.path
+        seen["method"] = request.method
+        return httpx.Response(200, json={"result": "OK"})
+
+    _client(responder).access_tokens_revoke("ab12")
+
+    assert seen == {"path": "/api/access/tokens/ab12", "method": "DELETE"}
+
+
+@pytest.mark.asyncio
+async def test_async_token_helpers_hit_the_same_endpoints() -> None:
+    """
+    The async client mirrors the sync one, path for path.
+    """
+    seen: list[tuple[str, str]] = []
+
+    def responder(request: httpx.Request) -> httpx.Response:
+        seen.append((request.method, request.url.path))
+        if request.method == "GET":
+            return httpx.Response(200, json={"tokens": []})
+        if request.method == "POST":
+            return httpx.Response(200, json=TOKEN_PAYLOAD)
+        return httpx.Response(200, json={"result": "OK"})
+
+    client = _async_client(responder)
+    await client.access_tokens_list()
+    await client.access_token_mint("laptop")
+    await client.access_tokens_revoke("ab12")
+    await client.access_tokens_delete_all()
+    await client.aclose()
+
+    assert seen == [
+        ("GET", "/api/access/tokens"),
+        ("POST", "/api/access/tokens"),
+        ("DELETE", "/api/access/tokens/ab12"),
+        ("DELETE", "/api/access/tokens"),
+    ]

--- a/tests/busylib/test_devices.py
+++ b/tests/busylib/test_devices.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+import pytest
+
+from busylib import AsyncBusyBar, BusyBar
+from busylib.devices import (
+    BusyBarAddress,
+    BusyBarAddressAffinity,
+    BusyBarDevice,
+)
+
+USB_IP = "10.0.4.20"
+WIFI_IP = "192.168.1.20"
+
+
+def _device(*, usb: bool = True, wifi: bool = True) -> BusyBarDevice:
+    addresses = set()
+    if usb:
+        addresses.add(
+            BusyBarAddress(ip_address=USB_IP, affinity=BusyBarAddressAffinity.OVER_USB)
+        )
+    if wifi:
+        addresses.add(
+            BusyBarAddress(
+                ip_address=WIFI_IP, affinity=BusyBarAddressAffinity.OVER_WIFI
+            )
+        )
+    return BusyBarDevice(name="bar", device_id="aabbcc", addresses=addresses)
+
+
+@pytest.mark.parametrize(
+    "affinity,expected",
+    [("over_usb", USB_IP), ("over_wifi", WIFI_IP)],
+)
+def test_get_address_selects_by_affinity(affinity: str, expected: str) -> None:
+    """
+    Each transport resolves to its own address.
+    """
+    assert _device().get_address(affinity) == expected  # type: ignore[arg-type]
+
+
+def test_get_address_prefers_usb_when_unspecified() -> None:
+    """
+    With no affinity given, USB wins over Wi-Fi.
+
+    A USB link is present only when the bar is plugged into this machine,
+    so it is the more specific answer of the two.
+    """
+    assert _device().get_address() == USB_IP
+    assert _device(usb=False).get_address() == WIFI_IP
+
+
+def test_get_address_returns_none_when_the_transport_is_absent() -> None:
+    """
+    Asking for a transport the device doesn't have yields None.
+    """
+    assert _device(usb=False).get_address("over_usb") is None
+    assert BusyBarDevice(name="x", device_id="y", addresses=set()).get_address() is None
+
+
+def test_client_factories_build_clients_for_the_right_address() -> None:
+    """
+    The factories hand back a client pointed at the chosen transport.
+    """
+    device = _device()
+
+    assert isinstance(device.to_sync_client(), BusyBar)
+    assert isinstance(device.to_async_client(), AsyncBusyBar)
+
+    over_usb = device.to_sync_client("over_usb")
+    over_wifi = device.to_sync_client("over_wifi")
+    assert over_usb is not None and over_wifi is not None
+    assert USB_IP in over_usb.base_url
+    assert WIFI_IP in over_wifi.base_url
+
+
+def test_client_factories_forward_keyword_arguments() -> None:
+    """
+    Extra arguments reach the client, which is how a token is passed.
+    """
+    client = _device().to_sync_client("over_wifi", token="1234")
+
+    assert client is not None
+    assert client.client.headers.get("X-API-Token") == "1234"
+
+
+def test_client_factories_return_none_without_an_address() -> None:
+    """
+    No usable address means no client, rather than one pointed at nothing.
+    """
+    device = _device(usb=False)
+
+    assert device.to_sync_client("over_usb") is None
+    assert device.to_async_client("over_usb") is None

--- a/tests/busylib/test_versioning_tags.py
+++ b/tests/busylib/test_versioning_tags.py
@@ -47,3 +47,69 @@ def test_endpoints_present_since_the_first_api_are_left_untagged(
     """
     for name in ("display_draw", "audio_play", "storage_write", "version"):
         assert versioning.get_method_compatibility(getattr(client, name)) is None
+
+
+EXPERIMENTAL = [
+    "access_tokens_list",
+    "access_token_mint",
+    "access_tokens_delete_all",
+    "access_tokens_revoke",
+]
+
+
+@pytest.mark.parametrize("name", EXPERIMENTAL)
+@pytest.mark.parametrize("client", [BusyBar, AsyncBusyBar])
+def test_endpoints_ahead_of_released_firmware_are_marked(
+    client: type, name: str
+) -> None:
+    """
+    Helpers for unreleased endpoints say so instead of claiming a version.
+
+    No released firmware serves these, so a version floor would have to be
+    invented; the marker records that and names the firmware work, so it can
+    be swapped for a real floor once that ships.
+    """
+    metadata = versioning.get_method_compatibility(getattr(client, name))
+
+    assert metadata is not None
+    assert metadata["status"] == "experimental"
+    assert "886" in metadata["note"]
+
+
+@pytest.mark.parametrize("name", EXPERIMENTAL)
+def test_experimental_helpers_still_call_the_device(name: str) -> None:
+    """
+    Marking is documentation, not a block: the call still goes out.
+
+    Unlike a removed endpoint, this one works against firmware that has it.
+    """
+    import httpx
+
+    seen: list[str] = []
+
+    bodies = {
+        "access_tokens_list": {"tokens": []},
+        "access_token_mint": {
+            "short_id": "ab",
+            "display_id": "abcd",
+            "name": "x",
+            "created_at": 0,
+            "last_used_at": 0,
+        },
+        "access_tokens_delete_all": {"result": "OK"},
+        "access_tokens_revoke": {"result": "OK"},
+    }
+
+    def responder(request: httpx.Request) -> httpx.Response:
+        seen.append(request.url.path)
+        return httpx.Response(200, json=bodies[name])
+
+    client = BusyBar(
+        addr="http://device.local", transport=httpx.MockTransport(responder)
+    )
+    getattr(client, name)("x") if name in (
+        "access_token_mint",
+        "access_tokens_revoke",
+    ) else getattr(client, name)()
+
+    assert seen and seen[0].startswith("/api/access/tokens")


### PR DESCRIPTION
Follow-up to #50, agreed there so that PR could ship without waiting. Now that #50 has landed, this is rebased onto `main` and stands on its own.

## Why the endpoints need marking

`/api/access/tokens` exists only on busybar-firmware's `porta/device-discovery` branch — firmware PR #886 is still open. On `1.1.1` and on `dev` the four token helpers answer `404` with nothing to explain it.

`requires_openapi` can't say that: it declares a *minimum* version, and there is no released version to name. So this adds `experimental_endpoint` as the other end of the same idea — an endpoint that isn't in released firmware yet, rather than one that has been withdrawn.

It records the situation in the metadata and leaves the call working, because unlike a removed endpoint this one succeeds against firmware that has it:

```python
>>> bb.method_compatibility("access_tokens_list")
{'path': '/api/access/tokens', 'method': 'GET', 'status': 'experimental',
 'note': 'requires firmware from busy-app/busybar-firmware#886, not released yet'}
```

The `note` names the firmware work so the marker can be swapped for a real version floor once #886 ships.

| Decorator | Meaning | On call |
| --- | --- | --- |
| `requires_openapi` | minimum API version | works |
| `removed_endpoint` | gone from every firmware | raises, names the replacement |
| **`experimental_endpoint`** | not in released firmware yet | **works**, documented |

## Tests

For the four token helpers on both clients — paths, methods, the minted secret being present while a listed token's is `None` — and for the discovery additions: address preference, the client factories, and that keyword arguments reach the client, which is how a token gets passed.

## Two things that follow

The **audit test now covers these helpers**. It previously skipped them for carrying no metadata; with the marker present it checks their declared paths against the actual `self._request` calls, and that sync and async agree. A path change after #886 that forgets the tag will now fail.

The **API reference shows the note**, because the docstrings say it in the source. Anything a decorator appends at runtime never reaches the docs — mkdocstrings reads files statically.

## Test plan

- [x] `uv run pytest -q`
- [x] `make lint`, `make typecheck`, `mkdocs build --strict`
- [x] Verified the experimental note renders in the built API reference
