### PR TITLE
Fix model validation on the pydantic versions the floor allows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,31 @@ jobs:
       - name: Run tests
         run: python -m pytest -q
 
+  # Every job above installs the newest dependency that satisfies the pins,
+  # so a floor that is lower than what the code actually needs looks fine
+  # here and fails only for users - which is exactly how #51 shipped. This
+  # job installs the oldest permitted version of each direct dependency.
+  minimum-dependencies:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-python@v7
+        with:
+          python-version: "3.10"
+
+      - uses: astral-sh/setup-uv@v7
+
+      - name: Install ffmpeg
+        run: sudo apt-get update && sudo apt-get install -y ffmpeg
+
+      - name: Install the lowest permitted dependency versions
+        run: uv pip install --system --resolution lowest-direct -e . --group dev
+
+      - name: Run tests
+        run: python -m pytest -q
+
   # Lint and type checks ran only in pre-commit hooks, so formatting and
   # typing drifted for anyone who committed without them installed.
   lint:

--- a/src/busylib/types.py
+++ b/src/busylib/types.py
@@ -41,15 +41,22 @@ class BaseModel(PydanticBaseModel):
         """
         Validate input object and convert schema errors to domain exceptions.
         """
+        # Only forward what the caller actually asked for. `by_alias`/`by_name`
+        # arrived in pydantic 2.11 and `extra` in 2.12, so passing them
+        # unconditionally made every call fail with a TypeError on the older
+        # pydantic this package claims to support.
+        options: dict[str, Any] = {
+            "strict": strict,
+            "from_attributes": from_attributes,
+            "context": context,
+            "by_alias": by_alias,
+            "by_name": by_name,
+            "extra": extra,
+        }
         try:
             return super().model_validate(
                 obj,
-                strict=strict,
-                from_attributes=from_attributes,
-                context=context,
-                by_alias=by_alias,
-                by_name=by_name,
-                extra=extra,
+                **{name: value for name, value in options.items() if value is not None},
             )
         except ValidationError as exc:
             raise exceptions.BusyBarResponseValidationError(

--- a/tests/busylib/test_types.py
+++ b/tests/busylib/test_types.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+import pytest
+from pydantic import BaseModel as PydanticBaseModel
+
+from busylib import exceptions, types
+
+
+def test_model_validate_forwards_only_what_was_asked_for(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    Unset options never reach pydantic.
+
+    `by_alias`/`by_name` exist only from pydantic 2.11 and `extra` from 2.12,
+    so forwarding them unconditionally raised `TypeError` on every call for
+    anyone on an older pydantic than the one this package develops against -
+    which the declared version floor still permits.
+    """
+    seen: dict[str, object] = {}
+    original = PydanticBaseModel.model_validate.__func__  # type: ignore[attr-defined]
+
+    def spy(cls: type, obj: object, **kwargs: object) -> object:
+        seen.update(kwargs)
+        return original(cls, obj, **kwargs)
+
+    monkeypatch.setattr(PydanticBaseModel, "model_validate", classmethod(spy))
+
+    types.VersionInfo.model_validate({"api_semver": "25.0.0"})
+
+    assert seen == {}
+
+
+def test_model_validate_still_passes_options_that_are_set() -> None:
+    """
+    An option the caller sets is honoured rather than dropped.
+    """
+    info = types.VersionInfo.model_validate({"api_semver": "25.0.0"}, strict=True)
+
+    assert info.api_semver == "25.0.0"
+
+
+def test_validation_failures_become_domain_errors() -> None:
+    """
+    A schema mismatch is reported as a busylib error, not a pydantic one.
+    """
+    with pytest.raises(exceptions.BusyBarResponseValidationError):
+        types.VersionInfo.model_validate({"api_semver": []})


### PR DESCRIPTION
Reported in #51: every call fails with `TypeError: BaseModel.model_validate() got an unexpected keyword argument 'extra'` before doing any work.

`busylib.types.BaseModel.model_validate` forwarded `by_alias`, `by_name` and `extra` to pydantic unconditionally. Those arrived in pydantic 2.11 and 2.12, but `pyproject.toml` allows `pydantic>=2.9` — so anyone with an older pydantic already installed gets a hard failure, and pip has no reason to upgrade them. Nothing in the package ever passes those options.

Now only the options the caller sets are forwarded, so the declared floor is true again. Reproduced against the published 1.3.0 with pydantic 2.11.9, and confirmed fixed down to 2.9.0.

Also adds a `minimum-dependencies` CI job: every existing job resolves to the newest version that satisfies the pins, so a floor lower than what the code needs looks fine in CI and fails only for users.