### PR TITLE
Stop Dependabot duplicating pip updates, and watch the hooks instead

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,10 +15,13 @@ updates:
       interval: "weekly"
     open-pull-requests-limit: 5
 
-  # pre-commit
-  - package-ecosystem: "pip"
+  # .pre-commit-config.yaml. This used to say "pip" with the same directory as
+  # the block above, which opened every Python update twice and left the hook
+  # revisions untouched. The linter versions here and in pyproject.toml's dev
+  # group have to move together - tests/test_tooling_pins.py enforces that -
+  # so expect a pair of pull requests to land as one.
+  - package-ecosystem: "pre-commit"
     directory: "/"
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 5
-    target-branch: "main"

--- a/tests/test_tooling_pins.py
+++ b/tests/test_tooling_pins.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+import pathlib
+import re
+import sys
+
+import pytest
+
+if sys.version_info >= (3, 11):
+    import tomllib
+else:  # pragma: no cover - exercised on 3.10 only
+    import tomli as tomllib
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[1]
+PYPROJECT = REPO_ROOT / "pyproject.toml"
+PRE_COMMIT = REPO_ROOT / ".pre-commit-config.yaml"
+
+# The hook repositories whose revision has to match a pin in the dev group.
+# Anything not listed here - pre-commit-hooks, for instance - carries no
+# counterpart in pyproject.toml and is left alone.
+HOOK_REPO_TO_PACKAGE = {
+    "https://github.com/astral-sh/ruff-pre-commit": "ruff",
+    "https://github.com/tox-dev/pyproject-fmt": "pyproject-fmt",
+    "https://github.com/RobertCraigie/pyright-python": "pyright",
+}
+
+
+def _pinned_dev_versions() -> dict[str, str]:
+    """
+    Read the exact-pinned dev dependencies out of pyproject.toml.
+    """
+    data = tomllib.loads(PYPROJECT.read_text())
+    pins: dict[str, str] = {}
+    for entry in data["dependency-groups"]["dev"]:
+        name, separator, version = entry.partition("==")
+        if separator:
+            pins[name.strip()] = version.strip()
+    return pins
+
+
+def _hook_revisions() -> dict[str, str]:
+    """
+    Map each pre-commit hook repository to the revision it is pinned at.
+
+    Parsed with a regex rather than a YAML library because the project has no
+    YAML dependency, and this file is a flat list of `repo`/`rev` pairs.
+    """
+    text = PRE_COMMIT.read_text()
+    pairs = re.findall(
+        r"^\s*-\s*repo:\s*(\S+)\s*\n\s*rev:\s*(\S+)\s*$", text, flags=re.MULTILINE
+    )
+    return dict(pairs)
+
+
+def test_the_parsing_finds_something() -> None:
+    """
+    Guard the parsers, so a silent empty result cannot pass the checks below.
+    """
+    assert _pinned_dev_versions()
+    assert set(_hook_revisions()) >= set(HOOK_REPO_TO_PACKAGE)
+
+
+@pytest.mark.parametrize("repo,package", sorted(HOOK_REPO_TO_PACKAGE.items()))
+def test_linters_are_pinned_alike_in_both_files(repo: str, package: str) -> None:
+    """
+    A linter is the same version for pre-commit and for CI.
+
+    When the two drift, CI installs a different linter than the hooks do and
+    unrelated pull requests go red - a ruff release once failed main itself
+    this way. Dependabot now proposes each bump as two pull requests, one per
+    file, and this is what stops one of them landing alone.
+    """
+    revision = _hook_revisions()[repo]
+    pinned = _pinned_dev_versions().get(package)
+
+    assert pinned is not None, f"{package} is not pinned in pyproject.toml"
+    assert revision == f"v{pinned}", (
+        f"{package}: .pre-commit-config.yaml has {revision}, "
+        f"pyproject.toml pins {pinned}"
+    )


### PR DESCRIPTION
Two problems in `.github/dependabot.yml`, both visible in the open queue.

**Duplicate pull requests.** Two identical `pip` blocks pointed at the same directory, so every Python update opened twice — #58/#59 and #60/#61 are one bump each, not two.

**Hooks were never watched.** The second block was clearly meant for `.pre-commit-config.yaml`, but `package-ecosystem: "pip"` does not read it. Hook revisions have never been proposed. It is now `pre-commit`, which Dependabot supports.

## Why the test comes with it

`ruff`, `pyright` and `pyproject-fmt` are pinned in two places: `pyproject.toml` (what CI installs) and `.pre-commit-config.yaml` (what the hooks install). They have to stay equal — ruff 0.16 widening its default rules once failed `main` itself through that gap, which is why the pins exist.

Dependabot proposes the two files as two separate pull requests, so it is now easy to land one and forget the other. `tests/test_tooling_pins.py` fails when they disagree:

```
AssertionError: ruff: .pre-commit-config.yaml has v0.15.21, pyproject.toml pins 0.16.2
```

Verified by actually introducing the drift, not just by the test passing as written.

## Test plan

- [x] `pytest -q`
- [x] `ruff check`, `ruff format --check`
- [x] `dependabot.yml` parses, three ecosystems, no stray `target-branch`