### PR TITLE
Bump pyproject-fmt to 2.27.1 in both places

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ repos:
       - id: ruff-format
         exclude: ^src/busylib/state_stream_proto/.*_pb2\.py$
   - repo: https://github.com/tox-dev/pyproject-fmt
-    rev: v2.25.3
+    rev: v2.27.1
     hooks:
       - id: pyproject-fmt
   - repo: https://github.com/RobertCraigie/pyright-python

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,7 @@ urls.Repository = "https://github.com/busy-app/busylib-py"
 dev = [
   "grpcio-tools>=1.74",
   "pre-commit>=3.8",
-  "pyproject-fmt==2.25.3",
+  "pyproject-fmt==2.27.1",
   "pyright==1.1.411",
   "pytest>=8.4.1",
   "pytest-asyncio>=0.24",


### PR DESCRIPTION
Combines #66 (pyproject.toml) and #68 (.pre-commit-config.yaml). Dependabot now opens one per ecosystem, and `tests/test_tooling_pins.py` fails unless both move together — which is why neither half is mergeable on its own.

Verified 2.27.1 reformats nothing in this `pyproject.toml`.

Closes #66, closes #68