### PR TITLE
Bump ruff to 0.16.3, and pin the rule set instead of the version

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.21
+    rev: v0.16.3
     hooks:
       - id: ruff-check
         args: ["--fix"]

--- a/README.md
+++ b/README.md
@@ -480,7 +480,7 @@ Instead of hardcoding an IP address, you can discover devices like so:
 from busylib import BusyBarDevices
 
 for device in BusyBarDevices.discover():
-    print(f"Device: \"{device.name}\" (id \"{device.device_id}\")")
+    print(f'Device: "{device.name}" (id "{device.device_id}")')
     print(f"  Over USB: {device.get_address('over_usb')}")
     print(f"  Over Wi-Fi: {device.get_address('over_wifi')}")
 ```
@@ -513,7 +513,7 @@ file_data = b"Hello, world!"
 response = bb.storage_write(path="/my-app/data.txt", data=file_data)
 
 file_content = bb.storage_read(path="/my-app/data.txt")
-print(file_content.decode('utf-8'))
+print(file_content.decode("utf-8"))
 
 storage_list = bb.storage_list(path="/my-app")
 for item in storage_list.list:

--- a/docs/guides/connecting.md
+++ b/docs/guides/connecting.md
@@ -9,8 +9,8 @@ network it also gets a normal address on that network, and either works:
 ```python
 from busylib import BusyBar
 
-bb = BusyBar("10.0.4.20")          # over USB
-bb = BusyBar("192.168.1.20")       # over Wi-Fi
+bb = BusyBar("10.0.4.20")  # over USB
+bb = BusyBar("192.168.1.20")  # over Wi-Fi
 ```
 
 Constructing a client produces no output and does not make a network request.

--- a/docs/guides/device-state.md
+++ b/docs/guides/device-state.md
@@ -105,6 +105,7 @@ def on_diff(changed, snapshot):
     if "screen_front" in changed and snapshot.screen_front is not None:
         render(snapshot.screen_front)
 
+
 store.on_diff(on_diff)
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,7 +55,7 @@ dev = [
   "pytest>=8.4.1",
   "pytest-asyncio>=0.24",
   "pytest-cov>=7",
-  "ruff==0.15.21",
+  "ruff==0.16.3",
   "tomli>=2.2",
 ]
 
@@ -77,7 +77,18 @@ extend-exclude = [
   # reformatting it only creates churn that the next sync undoes.
   "src/busylib/state_stream_proto",
 ]
-lint.extend-select = [
+# Selected explicitly rather than extending ruff's defaults. Those defaults
+# widen between releases - 0.16 added enough rules to fail this repository,
+# including main - which turned every ruff bump into unrelated work and is
+# why the version is pinned. Listing them means a bump changes only the
+# implementation of these rules, and adopting new ones stays a decision.
+lint.select = [
+  # pycodestyle errors: the subset ruff enables by default.
+  "E4",
+  "E7",
+  "E9",
+  # https://docs.astral.sh/ruff/rules/#pyflakes-f
+  "F",
   # https://docs.astral.sh/ruff/rules/#pyupgrade-up
   "UP",
 ]


### PR DESCRIPTION
Combines #67 (`pyproject.toml`) and #69 (`.pre-commit-config.yaml`) — `tests/test_tooling_pins.py` fails unless both move together.

## Why this is more than a bump

0.16.3 reported **103 new violations**, none caused by a code change. The config said `lint.extend-select = ["UP"]`, so the enforced set was *ruff’s defaults plus UP* — and those defaults widen between releases. That is exactly what made an unrelated ruff release fail `main`, and what pinning the version was working around.

Pinning treated the symptom. This lists the rules explicitly — `E4`, `E7`, `E9`, `F` (the defaults ruff had) plus `UP` — so the enforced set no longer moves on its own. Future bumps change only how these rules are implemented, and adopting new ones becomes a decision instead of a side effect.

Lint is clean on 0.16.3 with no code changes.

## The documentation files

0.16 also formats Python inside markdown, which is the whole of the README, `connecting.md` and `device-state.md` diff: quote style, comment spacing, one blank line. The examples produce the same output, and `tests/test_readme_examples.py` still passes.

## Worth a follow-up

Some of the rules 0.16 would have added look genuinely useful here — 13 `BLE001` blind excepts, 13 stale `RUF100` noqa comments, 3 `S110` silent `try/except/pass`. Adopting them is real work with judgement calls, so it belongs in its own PR rather than riding along with a version bump.

Closes #67, closes #69