### PR TITLE
Use zeroconf's async API for async discovery

### DIFF
--- a/src/busylib/devices.py
+++ b/src/busylib/devices.py
@@ -71,22 +71,39 @@ class BusyBarDevice:
 
 
 class BusyBarDeviceDiscoverer:
-    def __init__(self, zeroconf):
-        self._user_provided_zeroconf = bool(zeroconf)
+    """
+    Collects bars advertising themselves over mDNS.
+
+    Owns the `Zeroconf` instance it creates and closes it when done. One
+    supplied by the caller is left exactly as it was found: not reconfigured,
+    and not closed, because they may still be using it.
+    """
+
+    def __init__(self, zeroconf: Zeroconf | None) -> None:
+        self._user_provided_zeroconf = zeroconf is not None
+        # A bar plugged in over USB answers on a 10.0.4.x link, so every
+        # interface has to be listened on. That is already Zeroconf's own
+        # default, which is why a caller's instance needs no adjustment - and
+        # if they deliberately narrowed theirs, overriding it would be wrong.
         self._zeroconf = zeroconf or Zeroconf(InterfaceChoice.All)
-        self._devices_by_id = {}
+        self._devices_by_id: dict[str, BusyBarDevice] = {}
 
-    def sync_setup(self):
-        if self._user_provided_zeroconf:
-            self._zeroconf.update_interfaces(InterfaceChoice.All)
-
-    async def async_setup(self):
-        if self._user_provided_zeroconf:
-            await self._zeroconf.async_update_interfaces(InterfaceChoice.All)
-
-    def sync_teardown(self):
+    def sync_teardown(self) -> None:
+        """
+        Close the `Zeroconf` instance, if this discoverer created it.
+        """
         if not self._user_provided_zeroconf:
             self._zeroconf.close()
+
+    async def async_teardown(self) -> None:
+        """
+        Close it without blocking the event loop.
+
+        `Zeroconf.close()` joins its listener threads and has no async
+        counterpart in zeroconf 0.150, so it runs on a worker thread.
+        """
+        if not self._user_provided_zeroconf:
+            await asyncio.to_thread(self._zeroconf.close)
 
     @staticmethod
     def _address_affinity(address: str) -> BusyBarAddressAffinity:
@@ -156,17 +173,17 @@ class BusyBarDevices:
         timeout: float = TIMEOUT, zeroconf: Zeroconf | None = None
     ) -> list[BusyBarDevice]:
         discoverer = BusyBarDeviceDiscoverer(zeroconf)
-        await discoverer.async_setup()
-        devices = await discoverer.async_collect(timeout)
-        discoverer.sync_teardown()
-        return devices
+        try:
+            return await discoverer.async_collect(timeout)
+        finally:
+            await discoverer.async_teardown()
 
     @staticmethod
     def discover(
         timeout: float = TIMEOUT, zeroconf: Zeroconf | None = None
     ) -> list[BusyBarDevice]:
         discoverer = BusyBarDeviceDiscoverer(zeroconf)
-        discoverer.sync_setup()
-        devices = discoverer.sync_collect(timeout)
-        discoverer.sync_teardown()
-        return devices
+        try:
+            return discoverer.sync_collect(timeout)
+        finally:
+            discoverer.sync_teardown()

--- a/src/busylib/devices.py
+++ b/src/busylib/devices.py
@@ -10,15 +10,19 @@ from .client import AsyncBusyBar, BusyBar
 from zeroconf import (
     IPVersion,
     ServiceBrowser,
+    ServiceInfo,
     ServiceStateChange,
     Zeroconf,
     InterfaceChoice,
 )
+from zeroconf.asyncio import AsyncServiceBrowser, AsyncServiceInfo, AsyncZeroconf
 
 BUSYBAR_SERVICE = "_busybar._tcp.local."
 BUSYBAR_USB_SUBNET = "10.0.4."
 BUSYBAR_DEFAULT_NAME = b"BUSY Bar"
 TIMEOUT = 1.5
+# How long to wait for one bar to answer with its full record, in ms.
+RESOLVE_TIMEOUT_MS = 1500.0
 
 
 class BusyBarAddressAffinity(Enum):
@@ -70,40 +74,19 @@ class BusyBarDevice:
         return AsyncBusyBar(addr, **kwargs)
 
 
-class BusyBarDeviceDiscoverer:
+class _DeviceCollector:
     """
-    Collects bars advertising themselves over mDNS.
+    Turns resolved mDNS records into `BusyBarDevice` values.
 
-    Owns the `Zeroconf` instance it creates and closes it when done. One
-    supplied by the caller is left exactly as it was found: not reconfigured,
-    and not closed, because they may still be using it.
+    Shared by the sync and async discoverers, which differ only in how they
+    talk to zeroconf.
     """
 
-    def __init__(self, zeroconf: Zeroconf | None) -> None:
-        self._user_provided_zeroconf = zeroconf is not None
-        # A bar plugged in over USB answers on a 10.0.4.x link, so every
-        # interface has to be listened on. That is already Zeroconf's own
-        # default, which is why a caller's instance needs no adjustment - and
-        # if they deliberately narrowed theirs, overriding it would be wrong.
-        self._zeroconf = zeroconf or Zeroconf(InterfaceChoice.All)
+    def __init__(self) -> None:
         self._devices_by_id: dict[str, BusyBarDevice] = {}
 
-    def sync_teardown(self) -> None:
-        """
-        Close the `Zeroconf` instance, if this discoverer created it.
-        """
-        if not self._user_provided_zeroconf:
-            self._zeroconf.close()
-
-    async def async_teardown(self) -> None:
-        """
-        Close it without blocking the event loop.
-
-        `Zeroconf.close()` joins its listener threads and has no async
-        counterpart in zeroconf 0.150, so it runs on a worker thread.
-        """
-        if not self._user_provided_zeroconf:
-            await asyncio.to_thread(self._zeroconf.close)
+    def collected(self) -> list[BusyBarDevice]:
+        return list(self._devices_by_id.values())
 
     @staticmethod
     def _address_affinity(address: str) -> BusyBarAddressAffinity:
@@ -119,28 +102,21 @@ class BusyBarDeviceDiscoverer:
             affinity=BusyBarDeviceDiscoverer._address_affinity(address),
         )
 
-    def _on_service_state_change(
-        self,
-        zeroconf: Zeroconf,
-        service_type: str,
-        name: str,
-        state_change: ServiceStateChange,
-    ) -> None:
-        if state_change not in [
+    @staticmethod
+    def _is_interesting(state_change: ServiceStateChange) -> bool:
+        return state_change in (
             ServiceStateChange.Added,
             ServiceStateChange.Updated,
-        ]:
-            return
+        )
 
-        info = zeroconf.get_service_info(service_type, name)
-        if not info:
-            return
-
+    def _record(self, info: ServiceInfo) -> None:
+        """
+        Fold one resolved service record into the collected devices.
+        """
         device_id = info.name.split(".")[0]
-        addresses = info.ip_addresses_by_version(IPVersion.V4Only)
         addresses = (
             BusyBarDeviceDiscoverer._ip_address_to_our(addr.compressed)
-            for addr in addresses
+            for addr in info.ip_addresses_by_version(IPVersion.V4Only)
         )
 
         raw_name = info.properties.get(b"name") or BUSYBAR_DEFAULT_NAME
@@ -152,27 +128,126 @@ class BusyBarDeviceDiscoverer:
         device.addresses = device.addresses.union(addresses)
         self._devices_by_id[device_id] = device
 
+
+class BusyBarDeviceDiscoverer(_DeviceCollector):
+    """
+    Blocking mDNS discovery.
+
+    Owns the `Zeroconf` instance it creates and closes it when done. One
+    supplied by the caller is left exactly as it was found: not reconfigured,
+    and not closed, because they may still be using it.
+    """
+
+    def __init__(self, zeroconf: Zeroconf | None) -> None:
+        super().__init__()
+        self._user_provided_zeroconf = zeroconf is not None
+        # A bar plugged in over USB answers on a 10.0.4.x link, so every
+        # interface has to be listened on. That is already Zeroconf's own
+        # default, which is why a caller's instance needs no adjustment - and
+        # if they deliberately narrowed theirs, overriding it would be wrong.
+        self._zeroconf = zeroconf or Zeroconf(InterfaceChoice.All)
+
+    def sync_teardown(self) -> None:
+        """
+        Close the `Zeroconf` instance, if this discoverer created it.
+        """
+        if not self._user_provided_zeroconf:
+            self._zeroconf.close()
+
+    def _on_service_state_change(
+        self,
+        zeroconf: Zeroconf,
+        service_type: str,
+        name: str,
+        state_change: ServiceStateChange,
+    ) -> None:
+        if not self._is_interesting(state_change):
+            return
+        info = zeroconf.get_service_info(service_type, name)
+        if info:
+            self._record(info)
+
     def sync_collect(self, timeout: float) -> list[BusyBarDevice]:
         with ServiceBrowser(
             self._zeroconf, BUSYBAR_SERVICE, handlers=[self._on_service_state_change]
         ):
             time.sleep(timeout)
-        return list(self._devices_by_id.values())
+        return self.collected()
+
+
+class AsyncBusyBarDeviceDiscoverer(_DeviceCollector):
+    """
+    Non-blocking mDNS discovery, on zeroconf's own async API.
+
+    Nothing here reaches for a worker thread: `AsyncZeroconf` closes with
+    `async_close`, the browser cancels with `async_cancel`, and records are
+    resolved with `AsyncServiceInfo.async_request` instead of the blocking
+    `get_service_info`.
+    """
+
+    def __init__(self, zeroconf: AsyncZeroconf | None) -> None:
+        super().__init__()
+        self._user_provided_zeroconf = zeroconf is not None
+        self._aiozc = zeroconf or AsyncZeroconf(InterfaceChoice.All)
+        self._pending: set[asyncio.Task[None]] = set()
+
+    async def async_teardown(self) -> None:
+        """
+        Close the `AsyncZeroconf` instance, if this discoverer created it.
+        """
+        if not self._user_provided_zeroconf:
+            await self._aiozc.async_close()
+
+    def _on_service_state_change(
+        self,
+        zeroconf: Zeroconf,
+        service_type: str,
+        name: str,
+        state_change: ServiceStateChange,
+    ) -> None:
+        if not self._is_interesting(state_change):
+            return
+        # Handlers run on the event loop thread, so resolving has to be
+        # scheduled rather than awaited here. The task is kept referenced
+        # until it finishes, otherwise it can be garbage collected mid-flight.
+        task = asyncio.ensure_future(self._resolve(service_type, name))
+        self._pending.add(task)
+        task.add_done_callback(self._pending.discard)
+
+    async def _resolve(self, service_type: str, name: str) -> None:
+        info = AsyncServiceInfo(service_type, name)
+        if await info.async_request(self._aiozc.zeroconf, RESOLVE_TIMEOUT_MS):
+            self._record(info)
 
     async def async_collect(self, timeout: float) -> list[BusyBarDevice]:
-        with ServiceBrowser(
-            self._zeroconf, BUSYBAR_SERVICE, handlers=[self._on_service_state_change]
-        ):
+        browser = AsyncServiceBrowser(
+            self._aiozc.zeroconf,
+            BUSYBAR_SERVICE,
+            handlers=[self._on_service_state_change],
+        )
+        try:
             await asyncio.sleep(timeout)
-        return list(self._devices_by_id.values())
+        finally:
+            await browser.async_cancel()
+        # A record announced just before the deadline may still be resolving.
+        if self._pending:
+            await asyncio.gather(*self._pending, return_exceptions=True)
+        return self.collected()
 
 
 class BusyBarDevices:
     @staticmethod
     async def async_discover(
-        timeout: float = TIMEOUT, zeroconf: Zeroconf | None = None
+        timeout: float = TIMEOUT, zeroconf: AsyncZeroconf | None = None
     ) -> list[BusyBarDevice]:
-        discoverer = BusyBarDeviceDiscoverer(zeroconf)
+        """
+        Discover bars without blocking the event loop.
+
+        Takes an `AsyncZeroconf`, not a `Zeroconf`, mirroring zeroconf's own
+        split between the two APIs. Wrap an existing instance with
+        `AsyncZeroconf(zc=my_zeroconf)` if you already have one.
+        """
+        discoverer = AsyncBusyBarDeviceDiscoverer(zeroconf)
         try:
             return await discoverer.async_collect(timeout)
         finally:

--- a/tests/busylib/test_devices.py
+++ b/tests/busylib/test_devices.py
@@ -9,6 +9,7 @@ from busylib.devices import (
     BusyBarAddress,
     BusyBarAddressAffinity,
     BusyBarDevice,
+    AsyncBusyBarDeviceDiscoverer,
     BusyBarDeviceDiscoverer,
     BusyBarDevices,
 )
@@ -113,8 +114,18 @@ class RecordingZeroconf:
     def update_interfaces(self, *_args: object, **_kwargs: object) -> None:
         self.reconfigured = True
 
-    async def async_update_interfaces(self, *_args: object, **_kwargs: object) -> None:
-        self.reconfigured = True
+
+class RecordingAsyncZeroconf:
+    """
+    Stands in for an `AsyncZeroconf`, including the inner instance it wraps.
+    """
+
+    def __init__(self) -> None:
+        self.zeroconf = RecordingZeroconf()
+        self.closed_on_thread: int | None = None
+
+    async def async_close(self) -> None:
+        self.closed_on_thread = threading.get_ident()
 
 
 def test_discover_leaves_a_caller_supplied_zeroconf_alone(
@@ -127,9 +138,6 @@ def test_discover_leaves_a_caller_supplied_zeroconf_alone(
     Zeroconf's own default. Forcing `InterfaceChoice.All` onto a caller's
     instance only overrode a narrowing they had chosen on purpose, and left it
     that way after discovery had finished.
-
-    Driven through `discover()` rather than the discoverer, because that is
-    where the reconfiguration used to happen.
     """
     zeroconf = RecordingZeroconf()
     monkeypatch.setattr(BusyBarDeviceDiscoverer, "sync_collect", lambda *_: [])
@@ -145,19 +153,19 @@ async def test_async_discover_leaves_a_caller_supplied_zeroconf_alone(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """
-    The async path leaves it alone too.
+    The async path leaves the caller's `AsyncZeroconf` alone too.
     """
-    zeroconf = RecordingZeroconf()
+    zeroconf = RecordingAsyncZeroconf()
 
     async def no_devices(*_args: object) -> list[BusyBarDevice]:
         return []
 
-    monkeypatch.setattr(BusyBarDeviceDiscoverer, "async_collect", no_devices)
+    monkeypatch.setattr(AsyncBusyBarDeviceDiscoverer, "async_collect", no_devices)
 
     assert await BusyBarDevices.async_discover(zeroconf=zeroconf) == []  # type: ignore[arg-type]
 
     assert zeroconf.closed_on_thread is None
-    assert not zeroconf.reconfigured
+    assert not zeroconf.zeroconf.reconfigured
 
 
 def test_an_owned_zeroconf_is_closed() -> None:
@@ -174,20 +182,22 @@ def test_an_owned_zeroconf_is_closed() -> None:
 
 
 @pytest.mark.asyncio
-async def test_async_teardown_closes_off_the_event_loop() -> None:
+async def test_async_teardown_closes_without_leaving_the_event_loop() -> None:
     """
-    `Zeroconf.close()` joins listener threads and has no async form in
-    zeroconf 0.150, so awaiting it directly would stall the loop. It has to
-    run on a worker thread.
+    Closing is awaited, not handed to a worker thread.
+
+    `AsyncZeroconf.async_close()` is a coroutine, so the whole async path
+    stays on zeroconf's own async API - no `asyncio.to_thread` detour, which
+    is what an earlier version of this used because it held a plain
+    `Zeroconf`. Same-thread closing is the observable difference.
     """
-    discoverer = BusyBarDeviceDiscoverer(None)
-    owned = RecordingZeroconf()
-    discoverer._zeroconf = owned  # type: ignore[assignment]
+    discoverer = AsyncBusyBarDeviceDiscoverer(None)
+    owned = RecordingAsyncZeroconf()
+    discoverer._aiozc = owned  # type: ignore[assignment]
 
     await discoverer.async_teardown()
 
-    assert owned.closed_on_thread is not None
-    assert owned.closed_on_thread != threading.get_ident()
+    assert owned.closed_on_thread == threading.get_ident()
 
 
 def test_discover_closes_its_zeroconf_when_collection_fails(
@@ -199,9 +209,9 @@ def test_discover_closes_its_zeroconf_when_collection_fails(
     owned = RecordingZeroconf()
 
     def fake_init(self: BusyBarDeviceDiscoverer, zeroconf: object) -> None:
+        self._devices_by_id = {}
         self._user_provided_zeroconf = False
         self._zeroconf = owned  # type: ignore[assignment]
-        self._devices_by_id = {}
 
     def boom(_self: BusyBarDeviceDiscoverer, _timeout: float) -> list[BusyBarDevice]:
         raise TimeoutError("scan interrupted")
@@ -222,18 +232,19 @@ async def test_async_discover_closes_its_zeroconf_when_collection_fails(
     """
     Same for the async path, including cancellation.
     """
-    owned = RecordingZeroconf()
+    owned = RecordingAsyncZeroconf()
 
-    def fake_init(self: BusyBarDeviceDiscoverer, zeroconf: object) -> None:
-        self._user_provided_zeroconf = False
-        self._zeroconf = owned  # type: ignore[assignment]
+    def fake_init(self: AsyncBusyBarDeviceDiscoverer, zeroconf: object) -> None:
         self._devices_by_id = {}
+        self._user_provided_zeroconf = False
+        self._aiozc = owned  # type: ignore[assignment]
+        self._pending = set()
 
-    async def boom(_self: BusyBarDeviceDiscoverer, _timeout: float) -> None:
+    async def boom(_self: AsyncBusyBarDeviceDiscoverer, _timeout: float) -> None:
         raise TimeoutError("scan interrupted")
 
-    monkeypatch.setattr(BusyBarDeviceDiscoverer, "__init__", fake_init)
-    monkeypatch.setattr(BusyBarDeviceDiscoverer, "async_collect", boom)
+    monkeypatch.setattr(AsyncBusyBarDeviceDiscoverer, "__init__", fake_init)
+    monkeypatch.setattr(AsyncBusyBarDeviceDiscoverer, "async_collect", boom)
 
     with pytest.raises(TimeoutError):
         await BusyBarDevices.async_discover()

--- a/tests/busylib/test_devices.py
+++ b/tests/busylib/test_devices.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import threading
+
 import pytest
 
 from busylib import AsyncBusyBar, BusyBar
@@ -7,6 +9,8 @@ from busylib.devices import (
     BusyBarAddress,
     BusyBarAddressAffinity,
     BusyBarDevice,
+    BusyBarDeviceDiscoverer,
+    BusyBarDevices,
 )
 
 USB_IP = "10.0.4.20"
@@ -92,3 +96,146 @@ def test_client_factories_return_none_without_an_address() -> None:
 
     assert device.to_sync_client("over_usb") is None
     assert device.to_async_client("over_usb") is None
+
+
+class RecordingZeroconf:
+    """
+    Stands in for a caller-supplied `Zeroconf`, recording what is done to it.
+    """
+
+    def __init__(self) -> None:
+        self.closed_on_thread: int | None = None
+        self.reconfigured = False
+
+    def close(self) -> None:
+        self.closed_on_thread = threading.get_ident()
+
+    def update_interfaces(self, *_args: object, **_kwargs: object) -> None:
+        self.reconfigured = True
+
+    async def async_update_interfaces(self, *_args: object, **_kwargs: object) -> None:
+        self.reconfigured = True
+
+
+def test_discover_leaves_a_caller_supplied_zeroconf_alone(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    Neither closed nor reconfigured, because the caller still owns it.
+
+    Discovery needs every interface listened on, but that is already
+    Zeroconf's own default. Forcing `InterfaceChoice.All` onto a caller's
+    instance only overrode a narrowing they had chosen on purpose, and left it
+    that way after discovery had finished.
+
+    Driven through `discover()` rather than the discoverer, because that is
+    where the reconfiguration used to happen.
+    """
+    zeroconf = RecordingZeroconf()
+    monkeypatch.setattr(BusyBarDeviceDiscoverer, "sync_collect", lambda *_: [])
+
+    assert BusyBarDevices.discover(zeroconf=zeroconf) == []  # type: ignore[arg-type]
+
+    assert zeroconf.closed_on_thread is None
+    assert not zeroconf.reconfigured
+
+
+@pytest.mark.asyncio
+async def test_async_discover_leaves_a_caller_supplied_zeroconf_alone(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    The async path leaves it alone too.
+    """
+    zeroconf = RecordingZeroconf()
+
+    async def no_devices(*_args: object) -> list[BusyBarDevice]:
+        return []
+
+    monkeypatch.setattr(BusyBarDeviceDiscoverer, "async_collect", no_devices)
+
+    assert await BusyBarDevices.async_discover(zeroconf=zeroconf) == []  # type: ignore[arg-type]
+
+    assert zeroconf.closed_on_thread is None
+    assert not zeroconf.reconfigured
+
+
+def test_an_owned_zeroconf_is_closed() -> None:
+    """
+    The instance the discoverer created is its responsibility to close.
+    """
+    discoverer = BusyBarDeviceDiscoverer(None)
+    owned = RecordingZeroconf()
+    discoverer._zeroconf = owned  # type: ignore[assignment]
+
+    discoverer.sync_teardown()
+
+    assert owned.closed_on_thread == threading.get_ident()
+
+
+@pytest.mark.asyncio
+async def test_async_teardown_closes_off_the_event_loop() -> None:
+    """
+    `Zeroconf.close()` joins listener threads and has no async form in
+    zeroconf 0.150, so awaiting it directly would stall the loop. It has to
+    run on a worker thread.
+    """
+    discoverer = BusyBarDeviceDiscoverer(None)
+    owned = RecordingZeroconf()
+    discoverer._zeroconf = owned  # type: ignore[assignment]
+
+    await discoverer.async_teardown()
+
+    assert owned.closed_on_thread is not None
+    assert owned.closed_on_thread != threading.get_ident()
+
+
+def test_discover_closes_its_zeroconf_when_collection_fails(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    A timeout mid-scan must not leak the sockets.
+    """
+    owned = RecordingZeroconf()
+
+    def fake_init(self: BusyBarDeviceDiscoverer, zeroconf: object) -> None:
+        self._user_provided_zeroconf = False
+        self._zeroconf = owned  # type: ignore[assignment]
+        self._devices_by_id = {}
+
+    def boom(_self: BusyBarDeviceDiscoverer, _timeout: float) -> list[BusyBarDevice]:
+        raise TimeoutError("scan interrupted")
+
+    monkeypatch.setattr(BusyBarDeviceDiscoverer, "__init__", fake_init)
+    monkeypatch.setattr(BusyBarDeviceDiscoverer, "sync_collect", boom)
+
+    with pytest.raises(TimeoutError):
+        BusyBarDevices.discover()
+
+    assert owned.closed_on_thread is not None
+
+
+@pytest.mark.asyncio
+async def test_async_discover_closes_its_zeroconf_when_collection_fails(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    Same for the async path, including cancellation.
+    """
+    owned = RecordingZeroconf()
+
+    def fake_init(self: BusyBarDeviceDiscoverer, zeroconf: object) -> None:
+        self._user_provided_zeroconf = False
+        self._zeroconf = owned  # type: ignore[assignment]
+        self._devices_by_id = {}
+
+    async def boom(_self: BusyBarDeviceDiscoverer, _timeout: float) -> None:
+        raise TimeoutError("scan interrupted")
+
+    monkeypatch.setattr(BusyBarDeviceDiscoverer, "__init__", fake_init)
+    monkeypatch.setattr(BusyBarDeviceDiscoverer, "async_collect", boom)
+
+    with pytest.raises(TimeoutError):
+        await BusyBarDevices.async_discover()
+
+    assert owned.closed_on_thread is not None


### PR DESCRIPTION
The two review points left open on #50, done while async discovery is still unreleased. Discovery now uses zeroconf's own async API instead of driving the sync one from a coroutine, and a caller-supplied `Zeroconf` is used as given rather than being forced to `InterfaceChoice.All` — that is already zeroconf's default, so the override only overrode a deliberate narrowing.

Teardown moved into `finally`, so an interrupted scan no longer leaks sockets.