### PR TITLE
State that everything in the repository is written in English

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,8 @@
 
 ## Core Rules
 
-- Answer in the language the user uses for the request.
+- Everything written into this repository or onto GitHub is in English: code, comments, docstrings, README and docs, commit messages, pull request titles and bodies, issue and review comments. This is a public library with external contributors, so nothing else is acceptable.
+- Answer in the language the user uses for the request. That applies to chat replies only, and never overrides the rule above.
 - Inspect the installed/local `busylib` before using unfamiliar APIs: client methods, `busylib.types`, README, and examples.
 - Do not invent `busylib` methods, enum values, element fields, or payload shapes.
 - Prefer public `busylib` methods over direct HTTP calls. Use `prepare_request()` only for batching, diagnostics, custom transports, or tests.


### PR DESCRIPTION
The only language line in AGENTS.md was "Answer in the language the user uses for the request", which reads as covering written output as well — and did, letting Russian into the bodies of #72, #73 and #74 before it was caught.

Now stated explicitly, with the chat-reply rule scoped so it cannot be read that way again.