### PR TITLE
Make cloud mode reach the cloud

### DIFF
--- a/docs/api/cloud.md
+++ b/docs/api/cloud.md
@@ -1,0 +1,62 @@
+# Cloud addresses
+
+The BUSY cloud publishes two separate APIs on one host, and they are not
+interchangeable — a token for one is refused by the other.
+
+| Surface | Address | Token | In this library |
+| --- | --- | --- | --- |
+| Device API | [`/busybar`](https://api.busy.app/busybar/docs) | bar-scope | yes, as cloud mode |
+| Account API | [`/`](https://api.busy.app/docs) | account-scope | no |
+
+Cloud mode talks to the device API. It is the same set of endpoints a bar
+serves locally, with `/api` replaced by `/busybar`, so every client method
+works unchanged:
+
+```python
+from busylib import BusyBar
+
+bb = BusyBar(token="<bar-scope token>")  # no address means cloud
+print(bb.version().api_semver)
+```
+
+Status streaming is the one exception: `/api/status/ws` is local only, and
+cloud mode refuses it rather than attempting an upgrade the cloud rejects.
+
+## Documentation per firmware version
+
+The device documentation is versioned, selected by **firmware** version —
+`1.1.1`, not the API version `25.0.0`. A bar reports its firmware under
+`status().firmware.version`, which gives you the page describing what that
+particular bar serves:
+
+::: busylib.cloud.device_docs_url
+    options:
+      show_root_heading: true
+      show_root_full_path: false
+      heading_level: 3
+
+The same document is available machine-readable, which is how you can ask
+what a firmware supports without having that bar to hand:
+
+::: busylib.cloud.device_spec_url
+    options:
+      show_root_heading: true
+      show_root_full_path: false
+      heading_level: 3
+
+Putting the two together, this links a connected bar to its own reference:
+
+```python
+from busylib import BusyBar, cloud
+
+with BusyBar("10.0.4.20") as bb:
+    firmware = bb.status().firmware
+    print(cloud.device_docs_url(firmware.version if firmware else None))
+```
+
+## Why these live in code
+
+These addresses move. The cloud host was renamed before launch while this
+library kept the old name, and cloud mode was unusable for months as a
+result. Importing them from `busylib.cloud` means a rename is one edit rather
+than a search through guides and docstrings.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -79,6 +79,7 @@ nav:
       - Building a tool: guides/building-a-tool.md
   - Reference:
       - Clients: api/clients.md
+      - Cloud addresses: api/cloud.md
       - Device discovery: api/discovery.md
       - Displays and frames: api/display.md
       - Features: api/features.md

--- a/src/busylib/__init__.py
+++ b/src/busylib/__init__.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from . import exceptions, types
+from . import cloud, exceptions, types
 from .devices import BusyBarDevices
 from .client import AsyncBusyBar, BusyBar, PreparedRequest
 
@@ -9,6 +9,7 @@ __all__ = [
     "AsyncBusyBar",
     "PreparedRequest",
     "BusyBarDevices",
+    "cloud",
     "exceptions",
     "types",
 ]

--- a/src/busylib/client/base.py
+++ b/src/busylib/client/base.py
@@ -12,7 +12,7 @@ import httpx
 from pydantic import BaseModel, ConfigDict, Field
 
 from .. import exceptions, versioning
-from ..settings import settings
+from ..settings import CLOUD_API_PREFIX, DEVICE_API_PREFIX, settings
 
 JsonType = dict[str, Any] | list[Any] | str | int | float | bool | None
 
@@ -174,6 +174,24 @@ def _apply_application_name(
     params_local = dict(params or {})
     params_local["application_name"] = application_name
     return params_local, json_payload
+
+
+def _cloud_path(path: str) -> str:
+    """
+    Translate a device path into the one the cloud serves.
+
+    Endpoints live under `/api` on the device and under `/busybar` in the
+    cloud, which serves no `/api` at all. Every helper in this package writes
+    the device path, so the swap happens here rather than in each of them.
+    """
+    if path == DEVICE_API_PREFIX:
+        return CLOUD_API_PREFIX
+    if path.startswith(f"{DEVICE_API_PREFIX}/"):
+        return CLOUD_API_PREFIX + path[len(DEVICE_API_PREFIX) :]
+    # Anything already outside /api is passed through: the caller is reaching
+    # for something this mapping does not describe, and rewriting it blindly
+    # would be worse than leaving it alone.
+    return path
 
 
 def _prepare_request_payload(
@@ -554,7 +572,7 @@ class SyncClientBase:
         """
         return _prepare_request_payload(
             method,
-            path,
+            _cloud_path(path) if self.is_cloud else path,
             params=params,
             headers=headers,
             session_id=session_id,
@@ -836,7 +854,7 @@ class AsyncClientBase:
         """
         return _prepare_request_payload(
             method,
-            path,
+            _cloud_path(path) if self.is_cloud else path,
             params=params,
             headers=headers,
             session_id=session_id,

--- a/src/busylib/client/state_stream.py
+++ b/src/busylib/client/state_stream.py
@@ -13,7 +13,7 @@ import websockets.exceptions
 
 from .. import exceptions
 from ..state_stream_proto import state_pb2
-from .base import AsyncClientBase, SyncClientBase
+from .base import AsyncClientBase, SyncClientBase, _cloud_path
 
 logger = logging.getLogger(__name__)
 _WS_MAX_SIZE = 4 * 1024 * 1024
@@ -33,12 +33,15 @@ def _http_to_ws(addr: str) -> str:
     return urlunparse(parsed._replace(scheme=scheme))
 
 
+STATUS_STREAM_PATH = "/api/status/ws"
+
+
 def _extract_token(headers: Mapping[str, str]) -> str | None:
     """
-    Extract API token from configured HTTP headers.
+    Extract the device access key from configured HTTP headers.
 
-    Local clients use `X-API-Token`. Cloud status streaming is currently not
-    supported in this client.
+    Local clients send it as `X-API-Token`; cloud clients authenticate with a
+    bearer header instead, which is read separately.
     """
     return headers.get("x-api-token") or headers.get("X-API-Token")
 
@@ -85,21 +88,29 @@ class AsyncStateStreamMixin(AsyncClientBase):
         `BSB_State.State` protobuf schema from `bsb-protobuf` and converted into
         dictionaries with original proto field names.
         """
-        if self.is_cloud:
-            raise NotImplementedError(
-                "Cloud mode is not supported for /api/status/ws streaming."
-            )
-
         headers = self.client.headers
-        token = _extract_token(headers)
+        stream_path = (
+            _cloud_path(STATUS_STREAM_PATH) if self.is_cloud else (STATUS_STREAM_PATH)
+        )
+        ws_url = _http_to_ws(self.base_url).rstrip("/") + stream_path
 
-        ws_url = _http_to_ws(self.base_url).rstrip("/") + "/api/status/ws"
-        if token:
-            ws_url += f"?x-api-token={quote(token, safe='')}"
+        # The device takes its access key as a query parameter; the cloud
+        # authenticates the upgrade with the same bearer header as the REST
+        # calls, so the credential travels differently per mode.
+        extra_headers: dict[str, str] = {}
+        if self.is_cloud:
+            authorization = headers.get("authorization") or headers.get("Authorization")
+            if authorization:
+                extra_headers["Authorization"] = authorization
+        else:
+            token = _extract_token(headers)
+            if token:
+                ws_url += f"?x-api-token={quote(token, safe='')}"
 
         try:
             async with websockets.connect(
                 ws_url,
+                additional_headers=extra_headers or None,
                 max_size=_WS_MAX_SIZE,
                 ping_interval=_WS_PING_INTERVAL_SECONDS,
                 ping_timeout=_WS_PING_TIMEOUT_SECONDS,
@@ -136,10 +147,20 @@ class AsyncStateStreamMixin(AsyncClientBase):
         except websockets.exceptions.InvalidStatus as exc:
             status_code = exc.response.status_code
             if status_code in (401, 403):
+                # A cloud token that works for every REST endpoint is still
+                # refused here, so pointing the user at their credentials
+                # would send them looking for a fault that isn't theirs.
+                detail = (
+                    "the cloud refuses the upgrade even for tokens its REST "
+                    "endpoints accept; use a direct device connection for "
+                    "streaming"
+                    if self.is_cloud
+                    else "provide a valid API token"
+                )
                 raise exceptions.BusyBarWebSocketError(
-                    "Status WebSocket streaming failed: authentication required "
-                    f"(HTTP {status_code}). Provide a valid API token",
-                    path="/api/status/ws",
+                    "Status WebSocket streaming failed: authentication "
+                    f"required (HTTP {status_code}). Here, {detail}",
+                    path=stream_path,
                     original=exc,
                 ) from exc
             raise exceptions.BusyBarWebSocketError(

--- a/src/busylib/client/state_stream.py
+++ b/src/busylib/client/state_stream.py
@@ -13,7 +13,7 @@ import websockets.exceptions
 
 from .. import exceptions
 from ..state_stream_proto import state_pb2
-from .base import AsyncClientBase, SyncClientBase, _cloud_path
+from .base import AsyncClientBase, SyncClientBase
 
 logger = logging.getLogger(__name__)
 _WS_MAX_SIZE = 4 * 1024 * 1024
@@ -40,8 +40,8 @@ def _extract_token(headers: Mapping[str, str]) -> str | None:
     """
     Extract the device access key from configured HTTP headers.
 
-    Local clients send it as `X-API-Token`; cloud clients authenticate with a
-    bearer header instead, which is read separately.
+    Only local clients reach this: the device takes its key as `X-API-Token`,
+    and streaming is not available through the cloud at all.
     """
     return headers.get("x-api-token") or headers.get("X-API-Token")
 
@@ -88,29 +88,24 @@ class AsyncStateStreamMixin(AsyncClientBase):
         `BSB_State.State` protobuf schema from `bsb-protobuf` and converted into
         dictionaries with original proto field names.
         """
-        headers = self.client.headers
-        stream_path = (
-            _cloud_path(STATUS_STREAM_PATH) if self.is_cloud else (STATUS_STREAM_PATH)
-        )
-        ws_url = _http_to_ws(self.base_url).rstrip("/") + stream_path
-
-        # The device takes its access key as a query parameter; the cloud
-        # authenticates the upgrade with the same bearer header as the REST
-        # calls, so the credential travels differently per mode.
-        extra_headers: dict[str, str] = {}
         if self.is_cloud:
-            authorization = headers.get("authorization") or headers.get("Authorization")
-            if authorization:
-                extra_headers["Authorization"] = authorization
-        else:
-            token = _extract_token(headers)
-            if token:
-                ws_url += f"?x-api-token={quote(token, safe='')}"
+            # Deliberate: status streaming is a local-only endpoint. The cloud
+            # lists it but refuses the upgrade for every token, including ones
+            # its own REST endpoints accept, so connect to the bar directly.
+            raise NotImplementedError(
+                f"{STATUS_STREAM_PATH} streaming is local only. Connect to the "
+                "device address instead of using cloud mode."
+            )
+
+        headers = self.client.headers
+        ws_url = _http_to_ws(self.base_url).rstrip("/") + STATUS_STREAM_PATH
+        token = _extract_token(headers)
+        if token:
+            ws_url += f"?x-api-token={quote(token, safe='')}"
 
         try:
             async with websockets.connect(
                 ws_url,
-                additional_headers=extra_headers or None,
                 max_size=_WS_MAX_SIZE,
                 ping_interval=_WS_PING_INTERVAL_SECONDS,
                 ping_timeout=_WS_PING_TIMEOUT_SECONDS,
@@ -147,20 +142,10 @@ class AsyncStateStreamMixin(AsyncClientBase):
         except websockets.exceptions.InvalidStatus as exc:
             status_code = exc.response.status_code
             if status_code in (401, 403):
-                # A cloud token that works for every REST endpoint is still
-                # refused here, so pointing the user at their credentials
-                # would send them looking for a fault that isn't theirs.
-                detail = (
-                    "the cloud refuses the upgrade even for tokens its REST "
-                    "endpoints accept; use a direct device connection for "
-                    "streaming"
-                    if self.is_cloud
-                    else "provide a valid API token"
-                )
                 raise exceptions.BusyBarWebSocketError(
-                    "Status WebSocket streaming failed: authentication "
-                    f"required (HTTP {status_code}). Here, {detail}",
-                    path=stream_path,
+                    "Status WebSocket streaming failed: authentication required "
+                    f"(HTTP {status_code}). Provide a valid API token",
+                    path=STATUS_STREAM_PATH,
                     original=exc,
                 ) from exc
             raise exceptions.BusyBarWebSocketError(

--- a/src/busylib/cloud.py
+++ b/src/busylib/cloud.py
@@ -1,0 +1,55 @@
+"""
+Where the BUSY cloud lives, and where its API documentation is published.
+
+These addresses move, so they are named once here rather than pasted into
+docstrings and guides that then go stale. That has already cost a release:
+the cloud host was renamed before launch and this client kept pointing at the
+old name for months.
+"""
+
+from __future__ import annotations
+
+CLOUD_HOST = "https://api.busy.app"
+
+# Two separate surfaces share the host. The account API sits at the root and
+# takes an account-scope token; the device API sits under /busybar and takes a
+# bar-scope token. They are not interchangeable - a token for one is refused
+# by the other.
+ACCOUNT_API_DOCS_URL = f"{CLOUD_HOST}/docs"
+DEVICE_API_DOCS_URL = f"{CLOUD_HOST}/busybar/docs"
+DEVICE_API_SPEC_URL = f"{CLOUD_HOST}/busybar/openapi.yaml"
+
+
+def device_docs_url(firmware_version: str | None = None) -> str:
+    """
+    Return the device API documentation, optionally for one firmware version.
+
+    The cloud keeps the documentation of every published firmware, selected by
+    version rather than by API version - `1.1.1`, not `25.0.0`. Passing the
+    value from `status().firmware.version` gives the page describing the
+    endpoints that particular bar actually serves.
+
+    >>> device_docs_url()
+    'https://api.busy.app/busybar/docs'
+    >>> device_docs_url("1.0.2")
+    'https://api.busy.app/busybar/docs?urls.primaryName=1.0.2'
+    """
+    if not firmware_version:
+        return DEVICE_API_DOCS_URL
+    return f"{DEVICE_API_DOCS_URL}?urls.primaryName={firmware_version}"
+
+
+def device_spec_url(firmware_version: str | None = None) -> str:
+    """
+    Return the machine-readable OpenAPI document for a firmware version.
+
+    This is the same content the documentation page renders, which makes it
+    the way to ask what a given firmware supports without having that bar to
+    hand.
+
+    >>> device_spec_url("1.0.2")
+    'https://api.busy.app/busybar/openapi.yaml?Name=1.0.2'
+    """
+    if not firmware_version:
+        return DEVICE_API_SPEC_URL
+    return f"{DEVICE_API_SPEC_URL}?Name={firmware_version}"

--- a/src/busylib/settings.py
+++ b/src/busylib/settings.py
@@ -1,17 +1,26 @@
-from pydantic import Field
+from pydantic import AliasChoices, Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
+
+# The device serves its API under /api; the cloud serves the same endpoints
+# under /busybar and has no /api at all, so the prefix is swapped rather than
+# appended when a client runs in cloud mode.
+DEVICE_API_PREFIX = "/api"
+CLOUD_API_PREFIX = "/busybar"
 
 
 class Settings(BaseSettings):
     model_config = SettingsConfigDict(env_prefix="BUSYLIB_")
 
     base_url: str = Field(
-        validation_alias="URL",
+        # An explicit validation_alias bypasses env_prefix entirely, so the
+        # documented BUSYLIB_* names were silently ignored and only the bare
+        # ones worked. Both are accepted now, prefixed first.
+        validation_alias=AliasChoices("BUSYLIB_URL", "URL"),
         default="http://10.0.4.20",
     )
     cloud_base_url: str = Field(
-        validation_alias="CLOUD_URL",
-        default="https://proxy.busy.app",
+        validation_alias=AliasChoices("BUSYLIB_CLOUD_URL", "CLOUD_URL"),
+        default="https://api.busy.app",
     )
 
 

--- a/src/busylib/settings.py
+++ b/src/busylib/settings.py
@@ -1,11 +1,10 @@
 from pydantic import Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
-# The device serves its API under /api. In the cloud the same device endpoints
-# live under /busybar (https://api.busy.app/busybar/docs) and there is no /api,
-# so the prefix is swapped rather than appended when a client runs in cloud
-# mode. The account-level API at the root of the same host is a separate
-# surface with its own token and is not covered by this client.
+# The device serves its API under /api. In the cloud the same endpoints live
+# under /busybar and there is no /api, so the prefix is swapped rather than
+# appended when a client runs in cloud mode. See `busylib.cloud` for the
+# published addresses, including the account API that shares the host.
 DEVICE_API_PREFIX = "/api"
 CLOUD_API_PREFIX = "/busybar"
 

--- a/src/busylib/settings.py
+++ b/src/busylib/settings.py
@@ -1,9 +1,11 @@
-from pydantic import AliasChoices, Field
+from pydantic import Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
-# The device serves its API under /api; the cloud serves the same endpoints
-# under /busybar and has no /api at all, so the prefix is swapped rather than
-# appended when a client runs in cloud mode.
+# The device serves its API under /api. In the cloud the same device endpoints
+# live under /busybar (https://api.busy.app/busybar/docs) and there is no /api,
+# so the prefix is swapped rather than appended when a client runs in cloud
+# mode. The account-level API at the root of the same host is a separate
+# surface with its own token and is not covered by this client.
 DEVICE_API_PREFIX = "/api"
 CLOUD_API_PREFIX = "/busybar"
 
@@ -11,15 +13,15 @@ CLOUD_API_PREFIX = "/busybar"
 class Settings(BaseSettings):
     model_config = SettingsConfigDict(env_prefix="BUSYLIB_")
 
+    # Spelled out in full rather than left to env_prefix, which would expect
+    # BUSYLIB_BASE_URL. Bare URL/CLOUD_URL are deliberately not accepted: they
+    # are too broad a name for a library to claim in a shared environment.
     base_url: str = Field(
-        # An explicit validation_alias bypasses env_prefix entirely, so the
-        # documented BUSYLIB_* names were silently ignored and only the bare
-        # ones worked. Both are accepted now, prefixed first.
-        validation_alias=AliasChoices("BUSYLIB_URL", "URL"),
+        validation_alias="BUSYLIB_URL",
         default="http://10.0.4.20",
     )
     cloud_base_url: str = Field(
-        validation_alias=AliasChoices("BUSYLIB_CLOUD_URL", "CLOUD_URL"),
+        validation_alias="BUSYLIB_CLOUD_URL",
         default="https://api.busy.app",
     )
 

--- a/tests/busylib/client/test_client.py
+++ b/tests/busylib/client/test_client.py
@@ -33,12 +33,14 @@ def test_init_defaults_local():
 
 def test_init_token_sets_cloud_base_and_header():
     """
-    Ensure token auth switches to the cloud proxy base URL.
+    Ensure token auth switches to the cloud base URL.
 
-    Also validates the Authorization header value.
+    Also validates the Authorization header value. The host used to default to
+    proxy.busy.app, which was renamed before launch and never resolved, so
+    cloud mode could not reach anything.
     """
     client = BusyBar(token="secret")
-    assert client.base_url == "https://proxy.busy.app"
+    assert client.base_url == "https://api.busy.app"
     assert client.client.headers["authorization"] == "Bearer secret"
 
 

--- a/tests/busylib/client/test_status_ws.py
+++ b/tests/busylib/client/test_status_ws.py
@@ -147,33 +147,32 @@ async def test_stream_status_ws_wraps_decode_error(
 
 
 @pytest.mark.asyncio
-async def test_stream_status_ws_cloud_uses_the_cloud_path_and_bearer(
+async def test_stream_status_ws_is_local_only(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """
-    Cloud streaming targets /busybar/status/ws and authenticates by header.
+    Cloud mode refuses streaming without opening a connection.
 
-    This used to raise NotImplementedError even though the cloud publishes the
-    endpoint. The credential also moves: the device takes it as a query
-    parameter, the cloud as the same bearer header the REST calls use.
+    The endpoint is local by design. The cloud lists it but rejects the
+    upgrade for every token, so the refusal happens here rather than after a
+    round trip that would look like a credentials problem.
     """
-    seen: dict[str, object] = {}
+    connected = False
 
-    def fake_connect(uri: str, **kwargs: object) -> object:
-        seen["uri"] = uri
-        seen["headers"] = kwargs.get("additional_headers")
-        raise AssertionError("stop before connecting")
+    def fake_connect(*_args: object, **_kwargs: object) -> object:
+        nonlocal connected
+        connected = True
+        raise AssertionError("cloud mode must not open a websocket")
 
     monkeypatch.setattr(state_stream_client.websockets, "connect", fake_connect)
 
     client = AsyncBusyBar(addr=None, token="secret")
-    with pytest.raises(exceptions.BusyBarWebSocketError):
+    with pytest.raises(NotImplementedError, match="local only"):
         async for _ in client.stream_status_ws():
             pass
     await client.aclose()
 
-    assert seen["uri"] == "wss://api.busy.app/busybar/status/ws"
-    assert seen["headers"] == {"Authorization": "Bearer secret"}
+    assert not connected
 
 
 @pytest.mark.asyncio
@@ -185,9 +184,8 @@ async def test_stream_status_ws_device_keeps_the_query_parameter(
     """
     seen: dict[str, object] = {}
 
-    def fake_connect(uri: str, **kwargs: object) -> object:
+    def fake_connect(uri: str, **_kwargs: object) -> object:
         seen["uri"] = uri
-        seen["headers"] = kwargs.get("additional_headers")
         raise AssertionError("stop before connecting")
 
     monkeypatch.setattr(state_stream_client.websockets, "connect", fake_connect)
@@ -199,4 +197,3 @@ async def test_stream_status_ws_device_keeps_the_query_parameter(
     await client.aclose()
 
     assert seen["uri"] == "ws://10.0.4.20/api/status/ws?x-api-token=1234"
-    assert seen["headers"] is None

--- a/tests/busylib/client/test_status_ws.py
+++ b/tests/busylib/client/test_status_ws.py
@@ -147,12 +147,56 @@ async def test_stream_status_ws_wraps_decode_error(
 
 
 @pytest.mark.asyncio
-async def test_stream_status_ws_cloud_not_supported() -> None:
+async def test_stream_status_ws_cloud_uses_the_cloud_path_and_bearer(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """
-    Explicitly reject cloud mode for /api/status/ws streaming.
+    Cloud streaming targets /busybar/status/ws and authenticates by header.
+
+    This used to raise NotImplementedError even though the cloud publishes the
+    endpoint. The credential also moves: the device takes it as a query
+    parameter, the cloud as the same bearer header the REST calls use.
     """
+    seen: dict[str, object] = {}
+
+    def fake_connect(uri: str, **kwargs: object) -> object:
+        seen["uri"] = uri
+        seen["headers"] = kwargs.get("additional_headers")
+        raise AssertionError("stop before connecting")
+
+    monkeypatch.setattr(state_stream_client.websockets, "connect", fake_connect)
+
     client = AsyncBusyBar(addr=None, token="secret")
-    with pytest.raises(NotImplementedError):
+    with pytest.raises(exceptions.BusyBarWebSocketError):
         async for _ in client.stream_status_ws():
             pass
     await client.aclose()
+
+    assert seen["uri"] == "wss://api.busy.app/busybar/status/ws"
+    assert seen["headers"] == {"Authorization": "Bearer secret"}
+
+
+@pytest.mark.asyncio
+async def test_stream_status_ws_device_keeps_the_query_parameter(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    A local device still receives its access key in the URL.
+    """
+    seen: dict[str, object] = {}
+
+    def fake_connect(uri: str, **kwargs: object) -> object:
+        seen["uri"] = uri
+        seen["headers"] = kwargs.get("additional_headers")
+        raise AssertionError("stop before connecting")
+
+    monkeypatch.setattr(state_stream_client.websockets, "connect", fake_connect)
+
+    client = AsyncBusyBar(addr="10.0.4.20", token="1234")
+    with pytest.raises(exceptions.BusyBarWebSocketError):
+        async for _ in client.stream_status_ws():
+            pass
+    await client.aclose()
+
+    assert seen["uri"] == "ws://10.0.4.20/api/status/ws?x-api-token=1234"
+    assert seen["headers"] is None

--- a/tests/busylib/test_cloud_mode.py
+++ b/tests/busylib/test_cloud_mode.py
@@ -83,22 +83,23 @@ async def test_async_cloud_client_requests_the_cloud_path() -> None:
     assert seen == ["/busybar/version"]
 
 
-def test_prefixed_environment_variables_are_honoured(
+def test_only_prefixed_environment_variables_are_read(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """
-    Both BUSYLIB_-prefixed and bare names work.
+    `BUSYLIB_CLOUD_URL` configures the client; bare `CLOUD_URL` does not.
 
-    An explicit `validation_alias` bypasses `env_prefix`, so the documented
-    prefixed names were silently ignored and only the bare ones took effect.
+    It used to be the other way round: an explicit `validation_alias` bypasses
+    `env_prefix`, so the documented prefixed name was silently ignored while
+    the library quietly claimed a name as broad as `CLOUD_URL`.
     """
-    monkeypatch.setenv("BUSYLIB_CLOUD_URL", "https://prefixed.test")
     monkeypatch.delenv("CLOUD_URL", raising=False)
+    monkeypatch.setenv("BUSYLIB_CLOUD_URL", "https://prefixed.test")
     assert Settings().cloud_base_url == "https://prefixed.test"
 
     monkeypatch.delenv("BUSYLIB_CLOUD_URL")
     monkeypatch.setenv("CLOUD_URL", "https://bare.test")
-    assert Settings().cloud_base_url == "https://bare.test"
+    assert Settings().cloud_base_url == "https://api.busy.app"
 
 
 def test_the_cloud_default_points_at_a_host_that_exists() -> None:

--- a/tests/busylib/test_cloud_mode.py
+++ b/tests/busylib/test_cloud_mode.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+
+import httpx
+import pytest
+
+from busylib import AsyncBusyBar, BusyBar
+from busylib.client.base import _cloud_path
+from busylib.settings import Settings
+
+
+@pytest.mark.parametrize(
+    "device_path,expected",
+    [
+        ("/api/version", "/busybar/version"),
+        ("/api/status", "/busybar/status"),
+        ("/api/display/draw", "/busybar/display/draw"),
+        ("/api/access/tokens/ab12", "/busybar/access/tokens/ab12"),
+        ("/api", "/busybar"),
+        # Not under /api: left alone rather than guessed at.
+        ("/openapi.yaml", "/openapi.yaml"),
+        ("/busybar/version", "/busybar/version"),
+        # Only the prefix is replaced, never a later occurrence.
+        ("/api/assets/api", "/busybar/assets/api"),
+    ],
+)
+def test_cloud_paths_replace_the_prefix(device_path: str, expected: str) -> None:
+    """
+    Cloud endpoints live under /busybar, and the cloud serves no /api at all.
+
+    Overriding only the base URL was not enough, which is why cloud mode
+    answered 404 for every call.
+    """
+    assert _cloud_path(device_path) == expected
+
+
+def test_cloud_client_requests_the_cloud_path() -> None:
+    """
+    A client in cloud mode rewrites the path it was given.
+    """
+    seen: list[str] = []
+
+    def responder(request: httpx.Request) -> httpx.Response:
+        seen.append(request.url.path)
+        return httpx.Response(200, json={"api_semver": "25.0.0"})
+
+    client = BusyBar(token="secret", transport=httpx.MockTransport(responder))
+    client.version()
+
+    assert seen == ["/busybar/version"]
+
+
+def test_device_client_keeps_the_device_path() -> None:
+    """
+    Nothing changes for a client talking to a bar directly.
+    """
+    seen: list[str] = []
+
+    def responder(request: httpx.Request) -> httpx.Response:
+        seen.append(request.url.path)
+        return httpx.Response(200, json={"api_semver": "25.0.0"})
+
+    client = BusyBar(addr="10.0.4.20", transport=httpx.MockTransport(responder))
+    client.version()
+
+    assert seen == ["/api/version"]
+
+
+@pytest.mark.asyncio
+async def test_async_cloud_client_requests_the_cloud_path() -> None:
+    """
+    The async client rewrites the same way.
+    """
+    seen: list[str] = []
+
+    def responder(request: httpx.Request) -> httpx.Response:
+        seen.append(request.url.path)
+        return httpx.Response(200, json={"api_semver": "25.0.0"})
+
+    client = AsyncBusyBar(token="secret", transport=httpx.MockTransport(responder))
+    await client.version()
+    await client.aclose()
+
+    assert seen == ["/busybar/version"]
+
+
+def test_prefixed_environment_variables_are_honoured(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    Both BUSYLIB_-prefixed and bare names work.
+
+    An explicit `validation_alias` bypasses `env_prefix`, so the documented
+    prefixed names were silently ignored and only the bare ones took effect.
+    """
+    monkeypatch.setenv("BUSYLIB_CLOUD_URL", "https://prefixed.test")
+    monkeypatch.delenv("CLOUD_URL", raising=False)
+    assert Settings().cloud_base_url == "https://prefixed.test"
+
+    monkeypatch.delenv("BUSYLIB_CLOUD_URL")
+    monkeypatch.setenv("CLOUD_URL", "https://bare.test")
+    assert Settings().cloud_base_url == "https://bare.test"
+
+
+def test_the_cloud_default_points_at_a_host_that_exists() -> None:
+    """
+    The default was proxy.busy.app, renamed before launch and never resolvable.
+    """
+    monkeypatched = Settings()
+
+    assert monkeypatched.cloud_base_url == "https://api.busy.app"

--- a/tests/busylib/test_cloud_urls.py
+++ b/tests/busylib/test_cloud_urls.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+import pytest
+
+from busylib import cloud
+
+
+def test_the_two_surfaces_do_not_overlap() -> None:
+    """
+    Account and device documentation are separate addresses.
+
+    They share a host but take different tokens, so conflating them sends
+    people to a page that cannot describe what their token opens.
+    """
+    assert cloud.ACCOUNT_API_DOCS_URL == "https://api.busy.app/docs"
+    assert cloud.DEVICE_API_DOCS_URL == "https://api.busy.app/busybar/docs"
+    assert cloud.ACCOUNT_API_DOCS_URL != cloud.DEVICE_API_DOCS_URL
+
+
+@pytest.mark.parametrize(
+    "version,expected",
+    [
+        (None, "https://api.busy.app/busybar/docs"),
+        ("", "https://api.busy.app/busybar/docs"),
+        ("1.1.1", "https://api.busy.app/busybar/docs?urls.primaryName=1.1.1"),
+        ("1.0.2", "https://api.busy.app/busybar/docs?urls.primaryName=1.0.2"),
+        ("0.10.2-rc", "https://api.busy.app/busybar/docs?urls.primaryName=0.10.2-rc"),
+    ],
+)
+def test_device_docs_url(version: str | None, expected: str) -> None:
+    """
+    Documentation is selected by firmware version, not by API version.
+    """
+    assert cloud.device_docs_url(version) == expected
+
+
+@pytest.mark.parametrize(
+    "version,expected",
+    [
+        (None, "https://api.busy.app/busybar/openapi.yaml"),
+        ("1.1.1", "https://api.busy.app/busybar/openapi.yaml?Name=1.1.1"),
+    ],
+)
+def test_device_spec_url(version: str | None, expected: str) -> None:
+    """
+    The spec uses its own parameter name, which is easy to get wrong.
+    """
+    assert cloud.device_spec_url(version) == expected
+
+
+def test_the_client_default_matches_the_published_host() -> None:
+    """
+    The cloud default and the documented host cannot drift apart.
+    """
+    from busylib.settings import Settings
+
+    assert Settings().cloud_base_url == cloud.CLOUD_HOST


### PR DESCRIPTION
Fixes #53, reported by @unixengineer.

The cloud default host `proxy.busy.app` was renamed before launch and never resolved, and requests kept the device `/api` prefix although the cloud serves device endpoints under `/busybar`. Cloud mode had therefore never worked — `git log -S` shows `busybar/` was never in `src/`. Prefixed environment variables were ignored too, because an explicit `validation_alias` bypasses `env_prefix`; bare `URL`/`CLOUD_URL` are now dropped rather than kept, since that is too broad a name for a library to claim.

Verified against `api.busy.app` with a bar-scope token: version, status, brightness, volume, screen, storage list and display draw all work.

Status streaming stays refused in cloud mode — it is local by design, so the client says so up front instead of attempting an upgrade the cloud always rejects.