### PR TITLE
Test against a real bar over every transport

### DIFF
--- a/README.md
+++ b/README.md
@@ -659,3 +659,10 @@ python3 -m venv .venv
 source .venv/bin/activate
 make install-dev
 ```
+
+`make test` runs the suite against a mock device and needs no hardware. If you
+have a bar to hand, there is a second suite that drives a real one over USB,
+over the local network and through the cloud — see
+[Testing against a real bar](https://busy-app.github.io/busylib-py/guides/integration-tests/).
+It found two client methods that had never worked, because a mock accepts
+payloads the device rejects.

--- a/docs/api/cloud.md
+++ b/docs/api/cloud.md
@@ -1,0 +1,62 @@
+# Cloud addresses
+
+The BUSY cloud publishes two separate APIs on one host, and they are not
+interchangeable — a token for one is refused by the other.
+
+| Surface | Address | Token | In this library |
+| --- | --- | --- | --- |
+| Device API | [`/busybar`](https://api.busy.app/busybar/docs) | bar-scope | yes, as cloud mode |
+| Account API | [`/`](https://api.busy.app/docs) | account-scope | no |
+
+Cloud mode talks to the device API. It is the same set of endpoints a bar
+serves locally, with `/api` replaced by `/busybar`, so every client method
+works unchanged:
+
+```python
+from busylib import BusyBar
+
+bb = BusyBar(token="<bar-scope token>")  # no address means cloud
+print(bb.version().api_semver)
+```
+
+Status streaming is the one exception: `/api/status/ws` is local only, and
+cloud mode refuses it rather than attempting an upgrade the cloud rejects.
+
+## Documentation per firmware version
+
+The device documentation is versioned, selected by **firmware** version —
+`1.1.1`, not the API version `25.0.0`. A bar reports its firmware under
+`status().firmware.version`, which gives you the page describing what that
+particular bar serves:
+
+::: busylib.cloud.device_docs_url
+    options:
+      show_root_heading: true
+      show_root_full_path: false
+      heading_level: 3
+
+The same document is available machine-readable, which is how you can ask
+what a firmware supports without having that bar to hand:
+
+::: busylib.cloud.device_spec_url
+    options:
+      show_root_heading: true
+      show_root_full_path: false
+      heading_level: 3
+
+Putting the two together, this links a connected bar to its own reference:
+
+```python
+from busylib import BusyBar, cloud
+
+with BusyBar("10.0.4.20") as bb:
+    firmware = bb.status().firmware
+    print(cloud.device_docs_url(firmware.version if firmware else None))
+```
+
+## Why these live in code
+
+These addresses move. The cloud host was renamed before launch while this
+library kept the old name, and cloud mode was unusable for months as a
+result. Importing them from `busylib.cloud` means a rename is one edit rather
+than a search through guides and docstrings.

--- a/docs/guides/integration-tests.md
+++ b/docs/guides/integration-tests.md
@@ -1,0 +1,131 @@
+# Testing against a real bar
+
+Most of the suite runs against a mock transport and needs no hardware. That
+catches a lot, but not everything: a mock accepts any query string, so it
+cannot tell you that the device rejects `?volume=42.0`, or that it names a
+rename's source `path` and not `old_path`. Both of those shipped broken for
+months.
+
+The integration suite closes that gap. It drives one physical bar over all
+three transports the library supports, and it is opt-in: nothing here runs
+during a normal `pytest`.
+
+## Connect the bar
+
+You can use any subset of these. Each transport is skipped unless it is
+configured *and* answers, so start with USB and add the others when you want
+wider coverage.
+
+**Over USB.** Plug the bar into the machine running the tests. It comes up as
+a network device at `10.0.4.20` and, on current firmware, needs no access key
+over USB.
+
+**Over the local network.** Put the bar on Wi-Fi — the setup wizard does this
+— and find its address with `bb.wifi_status().ip_config.address`, on the
+device screen, or via discovery. If the bar has an access key set (`bb.access()`
+reports `mode="key"`), you need that PIN: over Wi-Fi the key is enforced.
+
+**Through the cloud.** Link the bar to a BUSY account, then mint a bar-scope
+token in the [dashboard](https://cloud.busy.app/dashboard). An account-scope
+token will not work — see [Cloud addresses](../api/cloud.md).
+
+## Configure
+
+Everything comes from the environment:
+
+| Variable | Meaning |
+| --- | --- |
+| `BUSYBAR_TEST_USB` | address over USB, defaults to `10.0.4.20` |
+| `BUSYBAR_TEST_WIFI` | address on the local network |
+| `BUSYBAR_TEST_WIFI_TOKEN` | access key, if the bar has one |
+| `BUSYBAR_TEST_CLOUD_TOKEN` | bar-scope cloud token |
+| `BUSYBAR_TEST_MANUAL_TIMEOUT` | seconds to wait for a button press, default 30 |
+
+## Run
+
+```bash
+uv run pytest tests/integration -m integration
+```
+
+Add `-m "integration and not manual"` to skip the one test that needs a human,
+which is what you want in any unattended run.
+
+To check a single transport, configure only that one. Unsetting
+`BUSYBAR_TEST_USB` is not enough to skip USB, since it has a default — point
+it at nothing instead:
+
+```bash
+BUSYBAR_TEST_USB= uv run pytest tests/integration -m "integration and not manual"
+```
+
+## Read the result
+
+A full run against a bar reachable three ways looks like this:
+
+```
+40 passed, 2 skipped, 3 deselected
+```
+
+**Skips are expected, and the reason says which kind.** A skip reading
+`endpoint is local only` is correct behaviour: status streaming does not work
+through the cloud by design, so those two tests stand down on the cloud
+transport. A skip reading `usb transport unavailable - ...` means that
+transport was configured but did not answer, and the message carries the
+error — a `403` there means a missing or wrong access key, not a broken bar.
+
+Run with `-rs` to see the reasons:
+
+```bash
+uv run pytest tests/integration -m integration -rs
+```
+
+**A failure is about the device, not the mock.** These tests only assert
+things a real bar decides: that a payload is accepted, that a written value
+reads back, that a frame is the size the panel dictates. So a failure means
+either the firmware changed its contract or this client has it wrong — which
+is exactly what the suite exists to tell you.
+
+The probe deliberately calls `/api/status` rather than `/api/version`, because
+a bar in key mode answers `version` without a key. Probing with `version`
+would let a transport with a bad token look usable and then fail every test
+with `403`.
+
+## The manual test
+
+Forwarded input travels the same stream as a real button, so the automatic
+tests cannot prove the hardware path. One test asks you to press the buttons:
+
+```bash
+BUSYBAR_TEST_MANUAL_TIMEOUT=120 uv run pytest \
+  tests/integration/test_input_stream.py::test_physical_buttons_reach_the_stream \
+  -m "integration and manual" -s
+```
+
+`-s` matters: without it pytest captures the prompt and you will not see what
+to press. Press **OK**, **BACK** and **START** on the bar; each one is
+acknowledged as it arrives and the test finishes as soon as all three are
+seen.
+
+```
+Press OK, BACK and START on the bar (120s)...
+  saw OK
+  saw BACK
+  saw START
+```
+
+If a press does not appear, check the automatic counterpart first —
+`test_forwarded_input_comes_back_on_the_stream` uses the same decoding, so if
+that passes and this does not, the gap is between the buttons and the stream
+rather than in this client.
+
+## What the tests touch
+
+Everything written is namespaced: drawings and assets use the application
+name `busylib-itest`, and files go under `/ext/busylib-itest`. Values that get
+changed — brightness, volume, device name — are restored afterwards, including
+when the test fails.
+
+Two things are worth knowing anyway. The device name is what discovery
+advertises, so an interrupted run can leave `busylib itest` visible on the
+network until you re-run. And nothing here reboots the bar, installs firmware,
+unlinks the account, or touches Wi-Fi settings.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -77,6 +77,7 @@ nav:
       - Assets and storage: guides/assets-and-storage.md
       - Reading device state: guides/device-state.md
       - Building a tool: guides/building-a-tool.md
+      - Testing against a real bar: guides/integration-tests.md
   - Reference:
       - Clients: api/clients.md
       - Cloud addresses: api/cloud.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -79,6 +79,7 @@ nav:
       - Building a tool: guides/building-a-tool.md
   - Reference:
       - Clients: api/clients.md
+      - Cloud addresses: api/cloud.md
       - Device discovery: api/discovery.md
       - Displays and frames: api/display.md
       - Features: api/features.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,5 +95,11 @@ lint.select = [
 
 [tool.pytest]
 ini_options.pythonpath = [ "." ]
-ini_options.addopts = "-q"
+# Integration tests need a real bar, so they are opt-in: -m integration
+# selects them, and -m "integration and manual" the ones needing a human.
+ini_options.addopts = "-q -m 'not integration'"
+ini_options.markers = [
+  "integration: exercises a real device over USB, LAN or the cloud",
+  "manual: needs someone to press buttons on the bar",
+]
 ini_options.asyncio_mode = "auto"

--- a/src/busylib/__init__.py
+++ b/src/busylib/__init__.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from . import exceptions, types
+from . import cloud, exceptions, types
 from .devices import BusyBarDevices
 from .client import AsyncBusyBar, BusyBar, PreparedRequest
 
@@ -9,6 +9,7 @@ __all__ = [
     "AsyncBusyBar",
     "PreparedRequest",
     "BusyBarDevices",
+    "cloud",
     "exceptions",
     "types",
 ]

--- a/src/busylib/client/audio.py
+++ b/src/busylib/client/audio.py
@@ -85,7 +85,7 @@ class AudioMixin(SyncClientBase):
 
     def audio_volume_set(self, volume: float) -> types.SuccessResponse:
         logger.info("audio_volume_set volume=%s", volume)
-        model = types.AudioVolumeUpdate(volume=volume)
+        model = types.AudioVolumeUpdate(volume=types.whole_volume(volume))
         payload = model.model_dump()
         data = self._request(
             "POST",
@@ -167,7 +167,7 @@ class AsyncAudioMixin(AsyncClientBase):
 
     async def audio_volume_set(self, volume: float) -> types.SuccessResponse:
         logger.info("async audio_volume_set volume=%s", volume)
-        model = types.AudioVolumeUpdate(volume=volume)
+        model = types.AudioVolumeUpdate(volume=types.whole_volume(volume))
         payload = model.model_dump()
         data = await self._request(
             "POST",

--- a/src/busylib/client/base.py
+++ b/src/busylib/client/base.py
@@ -12,7 +12,7 @@ import httpx
 from pydantic import BaseModel, ConfigDict, Field
 
 from .. import exceptions, versioning
-from ..settings import settings
+from ..settings import CLOUD_API_PREFIX, DEVICE_API_PREFIX, settings
 
 JsonType = dict[str, Any] | list[Any] | str | int | float | bool | None
 
@@ -174,6 +174,24 @@ def _apply_application_name(
     params_local = dict(params or {})
     params_local["application_name"] = application_name
     return params_local, json_payload
+
+
+def _cloud_path(path: str) -> str:
+    """
+    Translate a device path into the one the cloud serves.
+
+    Endpoints live under `/api` on the device and under `/busybar` in the
+    cloud, which serves no `/api` at all. Every helper in this package writes
+    the device path, so the swap happens here rather than in each of them.
+    """
+    if path == DEVICE_API_PREFIX:
+        return CLOUD_API_PREFIX
+    if path.startswith(f"{DEVICE_API_PREFIX}/"):
+        return CLOUD_API_PREFIX + path[len(DEVICE_API_PREFIX) :]
+    # Anything already outside /api is passed through: the caller is reaching
+    # for something this mapping does not describe, and rewriting it blindly
+    # would be worse than leaving it alone.
+    return path
 
 
 def _prepare_request_payload(
@@ -554,7 +572,7 @@ class SyncClientBase:
         """
         return _prepare_request_payload(
             method,
-            path,
+            _cloud_path(path) if self.is_cloud else path,
             params=params,
             headers=headers,
             session_id=session_id,
@@ -836,7 +854,7 @@ class AsyncClientBase:
         """
         return _prepare_request_payload(
             method,
-            path,
+            _cloud_path(path) if self.is_cloud else path,
             params=params,
             headers=headers,
             session_id=session_id,

--- a/src/busylib/client/state_stream.py
+++ b/src/busylib/client/state_stream.py
@@ -13,7 +13,7 @@ import websockets.exceptions
 
 from .. import exceptions
 from ..state_stream_proto import state_pb2
-from .base import AsyncClientBase, SyncClientBase
+from .base import AsyncClientBase, SyncClientBase, _cloud_path
 
 logger = logging.getLogger(__name__)
 _WS_MAX_SIZE = 4 * 1024 * 1024
@@ -33,12 +33,15 @@ def _http_to_ws(addr: str) -> str:
     return urlunparse(parsed._replace(scheme=scheme))
 
 
+STATUS_STREAM_PATH = "/api/status/ws"
+
+
 def _extract_token(headers: Mapping[str, str]) -> str | None:
     """
-    Extract API token from configured HTTP headers.
+    Extract the device access key from configured HTTP headers.
 
-    Local clients use `X-API-Token`. Cloud status streaming is currently not
-    supported in this client.
+    Local clients send it as `X-API-Token`; cloud clients authenticate with a
+    bearer header instead, which is read separately.
     """
     return headers.get("x-api-token") or headers.get("X-API-Token")
 
@@ -85,21 +88,29 @@ class AsyncStateStreamMixin(AsyncClientBase):
         `BSB_State.State` protobuf schema from `bsb-protobuf` and converted into
         dictionaries with original proto field names.
         """
-        if self.is_cloud:
-            raise NotImplementedError(
-                "Cloud mode is not supported for /api/status/ws streaming."
-            )
-
         headers = self.client.headers
-        token = _extract_token(headers)
+        stream_path = (
+            _cloud_path(STATUS_STREAM_PATH) if self.is_cloud else (STATUS_STREAM_PATH)
+        )
+        ws_url = _http_to_ws(self.base_url).rstrip("/") + stream_path
 
-        ws_url = _http_to_ws(self.base_url).rstrip("/") + "/api/status/ws"
-        if token:
-            ws_url += f"?x-api-token={quote(token, safe='')}"
+        # The device takes its access key as a query parameter; the cloud
+        # authenticates the upgrade with the same bearer header as the REST
+        # calls, so the credential travels differently per mode.
+        extra_headers: dict[str, str] = {}
+        if self.is_cloud:
+            authorization = headers.get("authorization") or headers.get("Authorization")
+            if authorization:
+                extra_headers["Authorization"] = authorization
+        else:
+            token = _extract_token(headers)
+            if token:
+                ws_url += f"?x-api-token={quote(token, safe='')}"
 
         try:
             async with websockets.connect(
                 ws_url,
+                additional_headers=extra_headers or None,
                 max_size=_WS_MAX_SIZE,
                 ping_interval=_WS_PING_INTERVAL_SECONDS,
                 ping_timeout=_WS_PING_TIMEOUT_SECONDS,
@@ -136,10 +147,20 @@ class AsyncStateStreamMixin(AsyncClientBase):
         except websockets.exceptions.InvalidStatus as exc:
             status_code = exc.response.status_code
             if status_code in (401, 403):
+                # A cloud token that works for every REST endpoint is still
+                # refused here, so pointing the user at their credentials
+                # would send them looking for a fault that isn't theirs.
+                detail = (
+                    "the cloud refuses the upgrade even for tokens its REST "
+                    "endpoints accept; use a direct device connection for "
+                    "streaming"
+                    if self.is_cloud
+                    else "provide a valid API token"
+                )
                 raise exceptions.BusyBarWebSocketError(
-                    "Status WebSocket streaming failed: authentication required "
-                    f"(HTTP {status_code}). Provide a valid API token",
-                    path="/api/status/ws",
+                    "Status WebSocket streaming failed: authentication "
+                    f"required (HTTP {status_code}). Here, {detail}",
+                    path=stream_path,
                     original=exc,
                 ) from exc
             raise exceptions.BusyBarWebSocketError(

--- a/src/busylib/client/state_stream.py
+++ b/src/busylib/client/state_stream.py
@@ -13,7 +13,7 @@ import websockets.exceptions
 
 from .. import exceptions
 from ..state_stream_proto import state_pb2
-from .base import AsyncClientBase, SyncClientBase, _cloud_path
+from .base import AsyncClientBase, SyncClientBase
 
 logger = logging.getLogger(__name__)
 _WS_MAX_SIZE = 4 * 1024 * 1024
@@ -40,8 +40,8 @@ def _extract_token(headers: Mapping[str, str]) -> str | None:
     """
     Extract the device access key from configured HTTP headers.
 
-    Local clients send it as `X-API-Token`; cloud clients authenticate with a
-    bearer header instead, which is read separately.
+    Only local clients reach this: the device takes its key as `X-API-Token`,
+    and streaming is not available through the cloud at all.
     """
     return headers.get("x-api-token") or headers.get("X-API-Token")
 
@@ -88,29 +88,24 @@ class AsyncStateStreamMixin(AsyncClientBase):
         `BSB_State.State` protobuf schema from `bsb-protobuf` and converted into
         dictionaries with original proto field names.
         """
-        headers = self.client.headers
-        stream_path = (
-            _cloud_path(STATUS_STREAM_PATH) if self.is_cloud else (STATUS_STREAM_PATH)
-        )
-        ws_url = _http_to_ws(self.base_url).rstrip("/") + stream_path
-
-        # The device takes its access key as a query parameter; the cloud
-        # authenticates the upgrade with the same bearer header as the REST
-        # calls, so the credential travels differently per mode.
-        extra_headers: dict[str, str] = {}
         if self.is_cloud:
-            authorization = headers.get("authorization") or headers.get("Authorization")
-            if authorization:
-                extra_headers["Authorization"] = authorization
-        else:
-            token = _extract_token(headers)
-            if token:
-                ws_url += f"?x-api-token={quote(token, safe='')}"
+            # Deliberate: status streaming is a local-only endpoint. The cloud
+            # lists it but refuses the upgrade for every token, including ones
+            # its own REST endpoints accept, so connect to the bar directly.
+            raise NotImplementedError(
+                f"{STATUS_STREAM_PATH} streaming is local only. Connect to the "
+                "device address instead of using cloud mode."
+            )
+
+        headers = self.client.headers
+        ws_url = _http_to_ws(self.base_url).rstrip("/") + STATUS_STREAM_PATH
+        token = _extract_token(headers)
+        if token:
+            ws_url += f"?x-api-token={quote(token, safe='')}"
 
         try:
             async with websockets.connect(
                 ws_url,
-                additional_headers=extra_headers or None,
                 max_size=_WS_MAX_SIZE,
                 ping_interval=_WS_PING_INTERVAL_SECONDS,
                 ping_timeout=_WS_PING_TIMEOUT_SECONDS,
@@ -147,20 +142,10 @@ class AsyncStateStreamMixin(AsyncClientBase):
         except websockets.exceptions.InvalidStatus as exc:
             status_code = exc.response.status_code
             if status_code in (401, 403):
-                # A cloud token that works for every REST endpoint is still
-                # refused here, so pointing the user at their credentials
-                # would send them looking for a fault that isn't theirs.
-                detail = (
-                    "the cloud refuses the upgrade even for tokens its REST "
-                    "endpoints accept; use a direct device connection for "
-                    "streaming"
-                    if self.is_cloud
-                    else "provide a valid API token"
-                )
                 raise exceptions.BusyBarWebSocketError(
-                    "Status WebSocket streaming failed: authentication "
-                    f"required (HTTP {status_code}). Here, {detail}",
-                    path=stream_path,
+                    "Status WebSocket streaming failed: authentication required "
+                    f"(HTTP {status_code}). Provide a valid API token",
+                    path=STATUS_STREAM_PATH,
                     original=exc,
                 ) from exc
             raise exceptions.BusyBarWebSocketError(

--- a/src/busylib/client/storage.py
+++ b/src/busylib/client/storage.py
@@ -100,7 +100,10 @@ class StorageMixin(SyncClientBase):
         data = self._request(
             "POST",
             "/api/storage/rename",
-            params={"old_path": old_path, "new_path": new_path},
+            # The device calls the source "path"; sending "old_path" was
+            # rejected with 400, so renaming never worked. The keyword stays
+            # `old_path` here because it reads better next to `new_path`.
+            params={"path": old_path, "new_path": new_path},
         )
         return types.SuccessResponse.model_validate(data)
 
@@ -209,7 +212,7 @@ class AsyncStorageMixin(AsyncClientBase):
         data = await self._request(
             "POST",
             "/api/storage/rename",
-            params={"old_path": old_path, "new_path": new_path},
+            params={"path": old_path, "new_path": new_path},
         )
         return types.SuccessResponse.model_validate(data)
 

--- a/src/busylib/cloud.py
+++ b/src/busylib/cloud.py
@@ -1,0 +1,55 @@
+"""
+Where the BUSY cloud lives, and where its API documentation is published.
+
+These addresses move, so they are named once here rather than pasted into
+docstrings and guides that then go stale. That has already cost a release:
+the cloud host was renamed before launch and this client kept pointing at the
+old name for months.
+"""
+
+from __future__ import annotations
+
+CLOUD_HOST = "https://api.busy.app"
+
+# Two separate surfaces share the host. The account API sits at the root and
+# takes an account-scope token; the device API sits under /busybar and takes a
+# bar-scope token. They are not interchangeable - a token for one is refused
+# by the other.
+ACCOUNT_API_DOCS_URL = f"{CLOUD_HOST}/docs"
+DEVICE_API_DOCS_URL = f"{CLOUD_HOST}/busybar/docs"
+DEVICE_API_SPEC_URL = f"{CLOUD_HOST}/busybar/openapi.yaml"
+
+
+def device_docs_url(firmware_version: str | None = None) -> str:
+    """
+    Return the device API documentation, optionally for one firmware version.
+
+    The cloud keeps the documentation of every published firmware, selected by
+    version rather than by API version - `1.1.1`, not `25.0.0`. Passing the
+    value from `status().firmware.version` gives the page describing the
+    endpoints that particular bar actually serves.
+
+    >>> device_docs_url()
+    'https://api.busy.app/busybar/docs'
+    >>> device_docs_url("1.0.2")
+    'https://api.busy.app/busybar/docs?urls.primaryName=1.0.2'
+    """
+    if not firmware_version:
+        return DEVICE_API_DOCS_URL
+    return f"{DEVICE_API_DOCS_URL}?urls.primaryName={firmware_version}"
+
+
+def device_spec_url(firmware_version: str | None = None) -> str:
+    """
+    Return the machine-readable OpenAPI document for a firmware version.
+
+    This is the same content the documentation page renders, which makes it
+    the way to ask what a given firmware supports without having that bar to
+    hand.
+
+    >>> device_spec_url("1.0.2")
+    'https://api.busy.app/busybar/openapi.yaml?Name=1.0.2'
+    """
+    if not firmware_version:
+        return DEVICE_API_SPEC_URL
+    return f"{DEVICE_API_SPEC_URL}?Name={firmware_version}"

--- a/src/busylib/settings.py
+++ b/src/busylib/settings.py
@@ -1,17 +1,26 @@
-from pydantic import Field
+from pydantic import AliasChoices, Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
+
+# The device serves its API under /api; the cloud serves the same endpoints
+# under /busybar and has no /api at all, so the prefix is swapped rather than
+# appended when a client runs in cloud mode.
+DEVICE_API_PREFIX = "/api"
+CLOUD_API_PREFIX = "/busybar"
 
 
 class Settings(BaseSettings):
     model_config = SettingsConfigDict(env_prefix="BUSYLIB_")
 
     base_url: str = Field(
-        validation_alias="URL",
+        # An explicit validation_alias bypasses env_prefix entirely, so the
+        # documented BUSYLIB_* names were silently ignored and only the bare
+        # ones worked. Both are accepted now, prefixed first.
+        validation_alias=AliasChoices("BUSYLIB_URL", "URL"),
         default="http://10.0.4.20",
     )
     cloud_base_url: str = Field(
-        validation_alias="CLOUD_URL",
-        default="https://proxy.busy.app",
+        validation_alias=AliasChoices("BUSYLIB_CLOUD_URL", "CLOUD_URL"),
+        default="https://api.busy.app",
     )
 
 

--- a/src/busylib/settings.py
+++ b/src/busylib/settings.py
@@ -1,11 +1,10 @@
 from pydantic import Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
-# The device serves its API under /api. In the cloud the same device endpoints
-# live under /busybar (https://api.busy.app/busybar/docs) and there is no /api,
-# so the prefix is swapped rather than appended when a client runs in cloud
-# mode. The account-level API at the root of the same host is a separate
-# surface with its own token and is not covered by this client.
+# The device serves its API under /api. In the cloud the same endpoints live
+# under /busybar and there is no /api, so the prefix is swapped rather than
+# appended when a client runs in cloud mode. See `busylib.cloud` for the
+# published addresses, including the account API that shares the host.
 DEVICE_API_PREFIX = "/api"
 CLOUD_API_PREFIX = "/busybar"
 

--- a/src/busylib/settings.py
+++ b/src/busylib/settings.py
@@ -1,9 +1,11 @@
-from pydantic import AliasChoices, Field
+from pydantic import Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
-# The device serves its API under /api; the cloud serves the same endpoints
-# under /busybar and has no /api at all, so the prefix is swapped rather than
-# appended when a client runs in cloud mode.
+# The device serves its API under /api. In the cloud the same device endpoints
+# live under /busybar (https://api.busy.app/busybar/docs) and there is no /api,
+# so the prefix is swapped rather than appended when a client runs in cloud
+# mode. The account-level API at the root of the same host is a separate
+# surface with its own token and is not covered by this client.
 DEVICE_API_PREFIX = "/api"
 CLOUD_API_PREFIX = "/busybar"
 
@@ -11,15 +13,15 @@ CLOUD_API_PREFIX = "/busybar"
 class Settings(BaseSettings):
     model_config = SettingsConfigDict(env_prefix="BUSYLIB_")
 
+    # Spelled out in full rather than left to env_prefix, which would expect
+    # BUSYLIB_BASE_URL. Bare URL/CLOUD_URL are deliberately not accepted: they
+    # are too broad a name for a library to claim in a shared environment.
     base_url: str = Field(
-        # An explicit validation_alias bypasses env_prefix entirely, so the
-        # documented BUSYLIB_* names were silently ignored and only the bare
-        # ones worked. Both are accepted now, prefixed first.
-        validation_alias=AliasChoices("BUSYLIB_URL", "URL"),
+        validation_alias="BUSYLIB_URL",
         default="http://10.0.4.20",
     )
     cloud_base_url: str = Field(
-        validation_alias=AliasChoices("BUSYLIB_CLOUD_URL", "CLOUD_URL"),
+        validation_alias="BUSYLIB_CLOUD_URL",
         default="https://api.busy.app",
     )
 

--- a/src/busylib/types.py
+++ b/src/busylib/types.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import math
 from datetime import datetime
 from enum import Enum
 from typing import Annotated, Any, Literal
@@ -725,9 +726,22 @@ class AudioVolumeInfo(BaseModel):
 
 
 class AudioVolumeUpdate(BaseModel):
-    volume: float = Field(ge=0, le=100)
+    # The OpenAPI document says `number`, but the device rejects a decimal
+    # point: `?volume=42` is accepted and `?volume=42.0` answers 400. Floats
+    # are still taken from callers and rounded, so audio_volume_set(42.4)
+    # keeps working rather than failing at the device.
+    volume: int = Field(ge=0, le=100)
 
     model_config = ConfigDict(extra="forbid")
+
+    @field_validator("volume", mode="before")
+    @classmethod
+    def _round_to_whole(cls, value: Any) -> Any:
+        # Half up, not `round`: banker's rounding would send 42.5 as 42 and
+        # 55.5 as 56, which is a strange thing for a volume control to do.
+        if isinstance(value, float):
+            return math.floor(value + 0.5)
+        return value
 
 
 class AudioPlayRequest(BaseModel):

--- a/src/busylib/types.py
+++ b/src/busylib/types.py
@@ -725,23 +725,22 @@ class AudioVolumeInfo(BaseModel):
     model_config = ConfigDict(extra="ignore")
 
 
+def whole_volume(value: float) -> int:
+    """
+    Round a volume to the whole number the device requires.
+
+    The OpenAPI document says `number`, but the device rejects a decimal
+    point: `?volume=42` is accepted and `?volume=42.0` answers 400. Callers
+    may still pass a float, so it is rounded here - half up, not with
+    `round`, whose banker's rounding would send 42.5 as 42 and 55.5 as 56.
+    """
+    return math.floor(value + 0.5)
+
+
 class AudioVolumeUpdate(BaseModel):
-    # The OpenAPI document says `number`, but the device rejects a decimal
-    # point: `?volume=42` is accepted and `?volume=42.0` answers 400. Floats
-    # are still taken from callers and rounded, so audio_volume_set(42.4)
-    # keeps working rather than failing at the device.
     volume: int = Field(ge=0, le=100)
 
     model_config = ConfigDict(extra="forbid")
-
-    @field_validator("volume", mode="before")
-    @classmethod
-    def _round_to_whole(cls, value: Any) -> Any:
-        # Half up, not `round`: banker's rounding would send 42.5 as 42 and
-        # 55.5 as 56, which is a strange thing for a volume control to do.
-        if isinstance(value, float):
-            return math.floor(value + 0.5)
-        return value
 
 
 class AudioPlayRequest(BaseModel):

--- a/tests/busylib/client/test_audio.py
+++ b/tests/busylib/client/test_audio.py
@@ -69,7 +69,7 @@ def test_audio_play_stop_volume_sync() -> None:
         {
             "path": "/api/audio/volume",
             "method": "POST",
-            "params": {"volume": "55.5"},
+            "params": {"volume": "56"},
             "body": None,
         },
     ]
@@ -194,7 +194,7 @@ async def test_audio_play_stop_volume_async() -> None:
         {
             "path": "/api/audio/volume",
             "method": "POST",
-            "params": {"volume": "12.5"},
+            "params": {"volume": "13"},
             "body": None,
         },
     ]

--- a/tests/busylib/client/test_client.py
+++ b/tests/busylib/client/test_client.py
@@ -33,12 +33,14 @@ def test_init_defaults_local():
 
 def test_init_token_sets_cloud_base_and_header():
     """
-    Ensure token auth switches to the cloud proxy base URL.
+    Ensure token auth switches to the cloud base URL.
 
-    Also validates the Authorization header value.
+    Also validates the Authorization header value. The host used to default to
+    proxy.busy.app, which was renamed before launch and never resolved, so
+    cloud mode could not reach anything.
     """
     client = BusyBar(token="secret")
-    assert client.base_url == "https://proxy.busy.app"
+    assert client.base_url == "https://api.busy.app"
     assert client.client.headers["authorization"] == "Bearer secret"
 
 

--- a/tests/busylib/client/test_client.py
+++ b/tests/busylib/client/test_client.py
@@ -838,7 +838,8 @@ def test_audio_volume_set_params():
     client = make_client(responder)
     resp = client.audio_volume_set(42.5)
     assert resp.result == "OK"
-    assert seen["params"] == {"volume": "42.5"}
+    # The device rejects a decimal point, so the value is whole on the wire.
+    assert seen["params"] == {"volume": "43"}
     assert seen["content"] == b""
 
 

--- a/tests/busylib/client/test_openapi_sync.py
+++ b/tests/busylib/client/test_openapi_sync.py
@@ -223,7 +223,7 @@ def test_system_time_update_and_storage_endpoints_match_openapi() -> None:
     assert storage_request == {
         "method": "POST",
         "path": "/api/storage/rename",
-        "params": {"old_path": "/ext/a.txt", "new_path": "/ext/b.txt"},
+        "params": {"path": "/ext/a.txt", "new_path": "/ext/b.txt"},
         "body": b"",
     }
     assert log_dump_request == {

--- a/tests/busylib/client/test_status_ws.py
+++ b/tests/busylib/client/test_status_ws.py
@@ -147,33 +147,32 @@ async def test_stream_status_ws_wraps_decode_error(
 
 
 @pytest.mark.asyncio
-async def test_stream_status_ws_cloud_uses_the_cloud_path_and_bearer(
+async def test_stream_status_ws_is_local_only(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """
-    Cloud streaming targets /busybar/status/ws and authenticates by header.
+    Cloud mode refuses streaming without opening a connection.
 
-    This used to raise NotImplementedError even though the cloud publishes the
-    endpoint. The credential also moves: the device takes it as a query
-    parameter, the cloud as the same bearer header the REST calls use.
+    The endpoint is local by design. The cloud lists it but rejects the
+    upgrade for every token, so the refusal happens here rather than after a
+    round trip that would look like a credentials problem.
     """
-    seen: dict[str, object] = {}
+    connected = False
 
-    def fake_connect(uri: str, **kwargs: object) -> object:
-        seen["uri"] = uri
-        seen["headers"] = kwargs.get("additional_headers")
-        raise AssertionError("stop before connecting")
+    def fake_connect(*_args: object, **_kwargs: object) -> object:
+        nonlocal connected
+        connected = True
+        raise AssertionError("cloud mode must not open a websocket")
 
     monkeypatch.setattr(state_stream_client.websockets, "connect", fake_connect)
 
     client = AsyncBusyBar(addr=None, token="secret")
-    with pytest.raises(exceptions.BusyBarWebSocketError):
+    with pytest.raises(NotImplementedError, match="local only"):
         async for _ in client.stream_status_ws():
             pass
     await client.aclose()
 
-    assert seen["uri"] == "wss://api.busy.app/busybar/status/ws"
-    assert seen["headers"] == {"Authorization": "Bearer secret"}
+    assert not connected
 
 
 @pytest.mark.asyncio
@@ -185,9 +184,8 @@ async def test_stream_status_ws_device_keeps_the_query_parameter(
     """
     seen: dict[str, object] = {}
 
-    def fake_connect(uri: str, **kwargs: object) -> object:
+    def fake_connect(uri: str, **_kwargs: object) -> object:
         seen["uri"] = uri
-        seen["headers"] = kwargs.get("additional_headers")
         raise AssertionError("stop before connecting")
 
     monkeypatch.setattr(state_stream_client.websockets, "connect", fake_connect)
@@ -199,4 +197,3 @@ async def test_stream_status_ws_device_keeps_the_query_parameter(
     await client.aclose()
 
     assert seen["uri"] == "ws://10.0.4.20/api/status/ws?x-api-token=1234"
-    assert seen["headers"] is None

--- a/tests/busylib/client/test_status_ws.py
+++ b/tests/busylib/client/test_status_ws.py
@@ -147,12 +147,56 @@ async def test_stream_status_ws_wraps_decode_error(
 
 
 @pytest.mark.asyncio
-async def test_stream_status_ws_cloud_not_supported() -> None:
+async def test_stream_status_ws_cloud_uses_the_cloud_path_and_bearer(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """
-    Explicitly reject cloud mode for /api/status/ws streaming.
+    Cloud streaming targets /busybar/status/ws and authenticates by header.
+
+    This used to raise NotImplementedError even though the cloud publishes the
+    endpoint. The credential also moves: the device takes it as a query
+    parameter, the cloud as the same bearer header the REST calls use.
     """
+    seen: dict[str, object] = {}
+
+    def fake_connect(uri: str, **kwargs: object) -> object:
+        seen["uri"] = uri
+        seen["headers"] = kwargs.get("additional_headers")
+        raise AssertionError("stop before connecting")
+
+    monkeypatch.setattr(state_stream_client.websockets, "connect", fake_connect)
+
     client = AsyncBusyBar(addr=None, token="secret")
-    with pytest.raises(NotImplementedError):
+    with pytest.raises(exceptions.BusyBarWebSocketError):
         async for _ in client.stream_status_ws():
             pass
     await client.aclose()
+
+    assert seen["uri"] == "wss://api.busy.app/busybar/status/ws"
+    assert seen["headers"] == {"Authorization": "Bearer secret"}
+
+
+@pytest.mark.asyncio
+async def test_stream_status_ws_device_keeps_the_query_parameter(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    A local device still receives its access key in the URL.
+    """
+    seen: dict[str, object] = {}
+
+    def fake_connect(uri: str, **kwargs: object) -> object:
+        seen["uri"] = uri
+        seen["headers"] = kwargs.get("additional_headers")
+        raise AssertionError("stop before connecting")
+
+    monkeypatch.setattr(state_stream_client.websockets, "connect", fake_connect)
+
+    client = AsyncBusyBar(addr="10.0.4.20", token="1234")
+    with pytest.raises(exceptions.BusyBarWebSocketError):
+        async for _ in client.stream_status_ws():
+            pass
+    await client.aclose()
+
+    assert seen["uri"] == "ws://10.0.4.20/api/status/ws?x-api-token=1234"
+    assert seen["headers"] is None

--- a/tests/busylib/test_cloud_mode.py
+++ b/tests/busylib/test_cloud_mode.py
@@ -83,22 +83,23 @@ async def test_async_cloud_client_requests_the_cloud_path() -> None:
     assert seen == ["/busybar/version"]
 
 
-def test_prefixed_environment_variables_are_honoured(
+def test_only_prefixed_environment_variables_are_read(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """
-    Both BUSYLIB_-prefixed and bare names work.
+    `BUSYLIB_CLOUD_URL` configures the client; bare `CLOUD_URL` does not.
 
-    An explicit `validation_alias` bypasses `env_prefix`, so the documented
-    prefixed names were silently ignored and only the bare ones took effect.
+    It used to be the other way round: an explicit `validation_alias` bypasses
+    `env_prefix`, so the documented prefixed name was silently ignored while
+    the library quietly claimed a name as broad as `CLOUD_URL`.
     """
-    monkeypatch.setenv("BUSYLIB_CLOUD_URL", "https://prefixed.test")
     monkeypatch.delenv("CLOUD_URL", raising=False)
+    monkeypatch.setenv("BUSYLIB_CLOUD_URL", "https://prefixed.test")
     assert Settings().cloud_base_url == "https://prefixed.test"
 
     monkeypatch.delenv("BUSYLIB_CLOUD_URL")
     monkeypatch.setenv("CLOUD_URL", "https://bare.test")
-    assert Settings().cloud_base_url == "https://bare.test"
+    assert Settings().cloud_base_url == "https://api.busy.app"
 
 
 def test_the_cloud_default_points_at_a_host_that_exists() -> None:

--- a/tests/busylib/test_cloud_mode.py
+++ b/tests/busylib/test_cloud_mode.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+
+import httpx
+import pytest
+
+from busylib import AsyncBusyBar, BusyBar
+from busylib.client.base import _cloud_path
+from busylib.settings import Settings
+
+
+@pytest.mark.parametrize(
+    "device_path,expected",
+    [
+        ("/api/version", "/busybar/version"),
+        ("/api/status", "/busybar/status"),
+        ("/api/display/draw", "/busybar/display/draw"),
+        ("/api/access/tokens/ab12", "/busybar/access/tokens/ab12"),
+        ("/api", "/busybar"),
+        # Not under /api: left alone rather than guessed at.
+        ("/openapi.yaml", "/openapi.yaml"),
+        ("/busybar/version", "/busybar/version"),
+        # Only the prefix is replaced, never a later occurrence.
+        ("/api/assets/api", "/busybar/assets/api"),
+    ],
+)
+def test_cloud_paths_replace_the_prefix(device_path: str, expected: str) -> None:
+    """
+    Cloud endpoints live under /busybar, and the cloud serves no /api at all.
+
+    Overriding only the base URL was not enough, which is why cloud mode
+    answered 404 for every call.
+    """
+    assert _cloud_path(device_path) == expected
+
+
+def test_cloud_client_requests_the_cloud_path() -> None:
+    """
+    A client in cloud mode rewrites the path it was given.
+    """
+    seen: list[str] = []
+
+    def responder(request: httpx.Request) -> httpx.Response:
+        seen.append(request.url.path)
+        return httpx.Response(200, json={"api_semver": "25.0.0"})
+
+    client = BusyBar(token="secret", transport=httpx.MockTransport(responder))
+    client.version()
+
+    assert seen == ["/busybar/version"]
+
+
+def test_device_client_keeps_the_device_path() -> None:
+    """
+    Nothing changes for a client talking to a bar directly.
+    """
+    seen: list[str] = []
+
+    def responder(request: httpx.Request) -> httpx.Response:
+        seen.append(request.url.path)
+        return httpx.Response(200, json={"api_semver": "25.0.0"})
+
+    client = BusyBar(addr="10.0.4.20", transport=httpx.MockTransport(responder))
+    client.version()
+
+    assert seen == ["/api/version"]
+
+
+@pytest.mark.asyncio
+async def test_async_cloud_client_requests_the_cloud_path() -> None:
+    """
+    The async client rewrites the same way.
+    """
+    seen: list[str] = []
+
+    def responder(request: httpx.Request) -> httpx.Response:
+        seen.append(request.url.path)
+        return httpx.Response(200, json={"api_semver": "25.0.0"})
+
+    client = AsyncBusyBar(token="secret", transport=httpx.MockTransport(responder))
+    await client.version()
+    await client.aclose()
+
+    assert seen == ["/busybar/version"]
+
+
+def test_prefixed_environment_variables_are_honoured(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    Both BUSYLIB_-prefixed and bare names work.
+
+    An explicit `validation_alias` bypasses `env_prefix`, so the documented
+    prefixed names were silently ignored and only the bare ones took effect.
+    """
+    monkeypatch.setenv("BUSYLIB_CLOUD_URL", "https://prefixed.test")
+    monkeypatch.delenv("CLOUD_URL", raising=False)
+    assert Settings().cloud_base_url == "https://prefixed.test"
+
+    monkeypatch.delenv("BUSYLIB_CLOUD_URL")
+    monkeypatch.setenv("CLOUD_URL", "https://bare.test")
+    assert Settings().cloud_base_url == "https://bare.test"
+
+
+def test_the_cloud_default_points_at_a_host_that_exists() -> None:
+    """
+    The default was proxy.busy.app, renamed before launch and never resolvable.
+    """
+    monkeypatched = Settings()
+
+    assert monkeypatched.cloud_base_url == "https://api.busy.app"

--- a/tests/busylib/test_cloud_urls.py
+++ b/tests/busylib/test_cloud_urls.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+import pytest
+
+from busylib import cloud
+
+
+def test_the_two_surfaces_do_not_overlap() -> None:
+    """
+    Account and device documentation are separate addresses.
+
+    They share a host but take different tokens, so conflating them sends
+    people to a page that cannot describe what their token opens.
+    """
+    assert cloud.ACCOUNT_API_DOCS_URL == "https://api.busy.app/docs"
+    assert cloud.DEVICE_API_DOCS_URL == "https://api.busy.app/busybar/docs"
+    assert cloud.ACCOUNT_API_DOCS_URL != cloud.DEVICE_API_DOCS_URL
+
+
+@pytest.mark.parametrize(
+    "version,expected",
+    [
+        (None, "https://api.busy.app/busybar/docs"),
+        ("", "https://api.busy.app/busybar/docs"),
+        ("1.1.1", "https://api.busy.app/busybar/docs?urls.primaryName=1.1.1"),
+        ("1.0.2", "https://api.busy.app/busybar/docs?urls.primaryName=1.0.2"),
+        ("0.10.2-rc", "https://api.busy.app/busybar/docs?urls.primaryName=0.10.2-rc"),
+    ],
+)
+def test_device_docs_url(version: str | None, expected: str) -> None:
+    """
+    Documentation is selected by firmware version, not by API version.
+    """
+    assert cloud.device_docs_url(version) == expected
+
+
+@pytest.mark.parametrize(
+    "version,expected",
+    [
+        (None, "https://api.busy.app/busybar/openapi.yaml"),
+        ("1.1.1", "https://api.busy.app/busybar/openapi.yaml?Name=1.1.1"),
+    ],
+)
+def test_device_spec_url(version: str | None, expected: str) -> None:
+    """
+    The spec uses its own parameter name, which is easy to get wrong.
+    """
+    assert cloud.device_spec_url(version) == expected
+
+
+def test_the_client_default_matches_the_published_host() -> None:
+    """
+    The cloud default and the documented host cannot drift apart.
+    """
+    from busylib.settings import Settings
+
+    assert Settings().cloud_base_url == cloud.CLOUD_HOST

--- a/tests/busylib/test_wire_format.py
+++ b/tests/busylib/test_wire_format.py
@@ -44,12 +44,14 @@ def test_volume_goes_on_the_wire_without_a_decimal_point(
     assert seen["params"] == {"volume": expected}
 
 
-def test_volume_model_holds_a_whole_number() -> None:
+@pytest.mark.parametrize(
+    "given,expected", [(42.5, 43), (55.5, 56), (42.4, 42), (0.4, 0), (99.5, 100)]
+)
+def test_volume_rounds_half_up(given: float, expected: int) -> None:
     """
-    The rounding happens in the model, so any caller of it benefits.
+    Half up, so a volume control does not round 42.5 down and 55.5 up.
     """
-    assert types.AudioVolumeUpdate(volume=42.5).volume == 43
-    assert isinstance(types.AudioVolumeUpdate(volume=42.0).volume, int)
+    assert types.whole_volume(given) == expected
 
 
 def test_rename_sends_the_source_as_path() -> None:

--- a/tests/busylib/test_wire_format.py
+++ b/tests/busylib/test_wire_format.py
@@ -1,0 +1,67 @@
+"""
+Payload shapes the device actually accepts.
+
+Both cases here were found by running against real firmware and had passed
+mock-based tests for months: a mock accepts any query string, so nothing
+noticed that the device did not.
+"""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+
+from busylib import BusyBar, types
+
+
+def _client(seen: dict[str, object]) -> BusyBar:
+    def responder(request: httpx.Request) -> httpx.Response:
+        seen["path"] = request.url.path
+        seen["params"] = dict(request.url.params)
+        return httpx.Response(200, json={"result": "OK"})
+
+    return BusyBar(addr="http://device.local", transport=httpx.MockTransport(responder))
+
+
+@pytest.mark.parametrize(
+    "given,expected",
+    [(42, "42"), (42.0, "42"), (42.4, "42"), (42.5, "43"), (100, "100"), (0, "0")],
+)
+def test_volume_goes_on_the_wire_without_a_decimal_point(
+    given: float, expected: str
+) -> None:
+    """
+    The device answers 400 for `?volume=42.0` and 200 for `?volume=42`.
+
+    The OpenAPI document says `number`, so the model was a float and every
+    call from this client was rejected. Floats are still accepted from callers
+    and rounded half up.
+    """
+    seen: dict[str, object] = {}
+
+    _client(seen).audio_volume_set(given)
+
+    assert seen["params"] == {"volume": expected}
+
+
+def test_volume_model_holds_a_whole_number() -> None:
+    """
+    The rounding happens in the model, so any caller of it benefits.
+    """
+    assert types.AudioVolumeUpdate(volume=42.5).volume == 43
+    assert isinstance(types.AudioVolumeUpdate(volume=42.0).volume, int)
+
+
+def test_rename_sends_the_source_as_path() -> None:
+    """
+    The device names the source `path`; `old_path` is rejected with 400.
+
+    The Python keyword stays `old_path` because it reads better beside
+    `new_path`, but only the wire name matters to the bar.
+    """
+    seen: dict[str, object] = {}
+
+    _client(seen).storage_rename(old_path="/ext/a.txt", new_path="/ext/b.txt")
+
+    assert seen["path"] == "/api/storage/rename"
+    assert seen["params"] == {"path": "/ext/a.txt", "new_path": "/ext/b.txt"}

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,0 +1,159 @@
+"""
+A real bar, reached three ways.
+
+The same client code runs over USB, over the LAN, and through the cloud, so
+these tests are parameterized by transport rather than duplicated per
+transport. Anything that only works on one of them says so explicitly.
+
+Nothing here runs by default: `-m integration` selects it, and each transport
+is skipped unless it is configured and answers. Configuration is by
+environment, so a laptop with a bar plugged in needs no arguments at all:
+
+    BUSYBAR_TEST_USB          device address over USB   (default 10.0.4.20)
+    BUSYBAR_TEST_WIFI         device address on the LAN
+    BUSYBAR_TEST_WIFI_TOKEN   access key, if the bar has one set
+    BUSYBAR_TEST_CLOUD_TOKEN  bar-scope cloud token
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+
+import pytest
+
+from busylib import AsyncBusyBar, BusyBar
+
+# Everything this suite writes is namespaced, so a failed run leaves rubbish
+# that is easy to find and impossible to confuse with a user's own data.
+APP_NAME = "busylib-itest"
+STORAGE_DIR = "/ext/busylib-itest"
+
+DEFAULT_USB_ADDR = "10.0.4.20"
+PROBE_TIMEOUT_SECONDS = 5.0
+
+
+@dataclass(frozen=True)
+class Transport:
+    """
+    One way of reaching the bar, and what it can be expected to do.
+    """
+
+    name: str
+    addr: str | None
+    token: str | None
+    is_cloud: bool
+
+    def sync_client(self, **kwargs: object) -> BusyBar:
+        return BusyBar(addr=self.addr, token=self.token, **kwargs)  # type: ignore[arg-type]
+
+    def async_client(self, **kwargs: object) -> AsyncBusyBar:
+        return AsyncBusyBar(addr=self.addr, token=self.token, **kwargs)  # type: ignore[arg-type]
+
+
+def _configured_transports() -> list[Transport]:
+    """
+    Build the transport list from the environment, in cost order.
+    """
+    found: list[Transport] = []
+
+    usb_addr = os.environ.get("BUSYBAR_TEST_USB", DEFAULT_USB_ADDR)
+    if usb_addr:
+        found.append(Transport("usb", usb_addr, None, is_cloud=False))
+
+    wifi_addr = os.environ.get("BUSYBAR_TEST_WIFI")
+    if wifi_addr:
+        found.append(
+            Transport(
+                "wifi",
+                wifi_addr,
+                os.environ.get("BUSYBAR_TEST_WIFI_TOKEN"),
+                is_cloud=False,
+            )
+        )
+
+    cloud_token = os.environ.get("BUSYBAR_TEST_CLOUD_TOKEN")
+    if cloud_token:
+        found.append(Transport("cloud", None, cloud_token, is_cloud=True))
+
+    return found
+
+
+TRANSPORTS = _configured_transports()
+
+
+def _reachable(transport: Transport) -> str | None:
+    """
+    Return None when the bar answers, or the reason it did not.
+
+    Probing once per session keeps a disconnected cable from producing dozens
+    of identical timeouts.
+    """
+    try:
+        client = transport.sync_client(timeout=PROBE_TIMEOUT_SECONDS)
+    except Exception as exc:  # noqa: BLE001 - configuration errors count as unreachable
+        return f"client could not be built: {exc}"
+    try:
+        # `status` rather than `version`: the bar answers /api/version without
+        # a key even in key mode, so probing with it would let a transport
+        # with a missing or wrong token look usable and fail every test.
+        client.status()
+    except Exception as exc:  # noqa: BLE001 - any failure means "not usable here"
+        return f"{type(exc).__name__}: {exc}"
+    finally:
+        client.close()
+    return None
+
+
+_REACHABILITY: dict[str, str | None] = {}
+
+
+@pytest.fixture(scope="session", params=TRANSPORTS, ids=lambda t: t.name)
+def transport(request: pytest.FixtureRequest) -> Transport:
+    """
+    Yield each configured transport, skipping any that does not answer.
+    """
+    chosen: Transport = request.param
+    if chosen.name not in _REACHABILITY:
+        _REACHABILITY[chosen.name] = _reachable(chosen)
+    reason = _REACHABILITY[chosen.name]
+    if reason is not None:
+        pytest.skip(f"{chosen.name} transport unavailable - {reason}")
+    return chosen
+
+
+@pytest.fixture
+def bar(transport: Transport):
+    """
+    A sync client for the transport under test.
+    """
+    client = transport.sync_client()
+    try:
+        yield client
+    finally:
+        client.close()
+
+
+@pytest.fixture
+async def abar(transport: Transport):
+    """
+    An async client for the transport under test.
+    """
+    client = transport.async_client()
+    try:
+        yield client
+    finally:
+        await client.aclose()
+
+
+@pytest.fixture
+def local_only(transport: Transport) -> Transport:
+    """
+    Skip the test unless the bar is reached directly.
+
+    Status streaming is a local endpoint by design; the cloud lists it and
+    refuses the upgrade.
+    """
+    if transport.is_cloud:
+        pytest.skip("endpoint is local only")
+    return transport

--- a/tests/integration/test_device_api.py
+++ b/tests/integration/test_device_api.py
@@ -1,0 +1,288 @@
+"""
+The functional surface, exercised against a real bar over every transport.
+
+These are deliberately coarse: one test per area of behaviour rather than one
+per endpoint. A real device is the only thing that can tell us the payloads
+are right, and a hundred single-call tests against it would take minutes to
+tell us less.
+
+Anything written here is namespaced under a test application name and a test
+storage directory, and every value that gets changed is put back.
+"""
+
+from __future__ import annotations
+
+import io
+import wave
+
+import pytest
+from PIL import Image
+
+from busylib import types
+
+from .conftest import APP_NAME, STORAGE_DIR
+
+pytestmark = pytest.mark.integration
+
+
+def test_identity_reads_agree_with_each_other(bar) -> None:
+    """
+    The bar reports a version, and status repeats it consistently.
+
+    `/api/version` carries only `api_semver`; the human-readable firmware
+    version lives under `/api/status`, which is exactly the split that made
+    the setup wizard report "Firmware ?".
+    """
+    version = bar.version()
+    status = bar.status()
+
+    assert version.api_semver, "a bar must report its API version"
+    assert status.device is not None and status.device.serial_number
+    assert status.firmware is not None and status.firmware.version
+
+    if status.system is not None and status.system.api_semver:
+        assert status.system.api_semver == version.api_semver
+
+
+def test_subsystem_state_is_readable(bar) -> None:
+    """
+    Every read-only subsystem answers with a parseable model.
+
+    Grouped on purpose: these are the calls a dashboard makes on startup, and
+    what matters is that none of them fail against real firmware.
+    """
+    assert bar.name().name
+    assert bar.time() is not None
+    assert bar.display_brightness().value is not None
+    assert bar.audio_volume().volume is not None
+    assert bar.wifi_status().state is not None
+    assert bar.ble_status() is not None
+    assert bar.storage_status() is not None
+    assert bar.access() is not None
+    assert bar.update_status() is not None
+    assert bar.busy_snapshot() is not None
+
+
+@pytest.mark.parametrize(
+    "display,x,y",
+    [(types.DisplayName.FRONT, 2, 4), (types.DisplayName.BACK, 4, 8)],
+)
+def test_draws_then_clears(bar, display: types.DisplayName, x: int, y: int) -> None:
+    """
+    Text reaches both displays and the drawing can be withdrawn again.
+    """
+    elements = types.DisplayElements(
+        application_name=APP_NAME,
+        elements=[
+            types.TextElement(
+                id="probe",
+                type="text",
+                x=x,
+                y=y,
+                text="TEST",
+                font="small",
+                display=display,
+            )
+        ],
+    )
+
+    assert bar.display_draw(elements).result == "OK"
+    assert bar.display_clear(application_name=APP_NAME).result == "OK"
+
+
+def test_screen_returns_a_frame_of_the_expected_size(bar) -> None:
+    """
+    Both displays hand back a decodable frame.
+
+    The size is fixed by the panel, so a mismatch means the decode path is
+    wrong rather than the picture being different - which is how base64 was
+    once rendered as pixels.
+    """
+    front = bar.screen(0)
+    back = bar.screen(1)
+
+    # Both come back as three bytes per pixel. The back panel shows 16 greys,
+    # but the frame is not packed - assuming one byte per pixel here is how a
+    # decode bug hides.
+    assert len(front) == 72 * 16 * 3, "front is 72x16, three bytes per pixel"
+    assert len(back) == 160 * 80 * 3, "back is 160x80, three bytes per pixel"
+
+
+def test_storage_round_trip(bar) -> None:
+    """
+    Write, read back, list, rename and remove under /ext.
+
+    Paths outside /ext are not refused with an error - the device stops
+    answering - so the prefix is part of the contract, not a convention.
+    """
+    from busylib import exceptions
+
+    payload = b"integration"
+    path = f"{STORAGE_DIR}/probe.txt"
+    renamed = f"{STORAGE_DIR}/probe-renamed.txt"
+
+    try:
+        bar.storage_mkdir(path=STORAGE_DIR)
+    except exceptions.BusyBarAPIError as exc:
+        # mkdir answers 400 when the directory is already there, so a rerun
+        # after a failed run must not trip over its own leftovers.
+        assert exc.status_code == 400, exc
+    assert bar.storage_write(path=path, data=payload).result == "OK"
+    assert bar.storage_read(path=path) == payload
+
+    listing = bar.storage_list(path=STORAGE_DIR)
+    assert any(item.name == "probe.txt" for item in listing.list)
+
+    bar.storage_rename(old_path=path, new_path=renamed)
+    assert bar.storage_read(path=renamed) == payload
+
+    # Directories are removed by the same call as files.
+    bar.storage_remove(path=renamed)
+    bar.storage_remove(path=STORAGE_DIR)
+
+
+def test_assets_and_audio(bar) -> None:
+    """
+    Upload an image and a sound, use both, then delete them together.
+
+    `assets_delete` is scoped to the application name, so this cannot touch
+    anything the user put on the bar under a different one.
+    """
+    from busylib import converter, exceptions
+
+    buffer = io.BytesIO()
+    Image.new("RGB", (72, 16), (0, 40, 0)).save(buffer, format="PNG")
+    image_name, image_payload = converter.convert_for_storage(
+        "probe.png", buffer.getvalue()
+    )
+    assert (
+        bar.assets_upload(
+            application_name=APP_NAME, filename=image_name, data=image_payload
+        ).result
+        == "OK"
+    )
+
+    audio = io.BytesIO()
+    with wave.open(audio, "wb") as handle:
+        handle.setnchannels(1)
+        handle.setsampwidth(2)
+        handle.setframerate(8000)
+        handle.writeframes(b"\x00\x00" * 1600)
+    audio_name, audio_payload = converter.convert_for_storage(
+        "probe.wav", audio.getvalue()
+    )
+    bar.assets_upload(
+        application_name=APP_NAME, filename=audio_name, data=audio_payload
+    )
+
+    bar.display_draw(
+        types.DisplayElements(
+            application_name=APP_NAME,
+            elements=[
+                types.ImageElement(
+                    id="pic",
+                    type="image",
+                    x=0,
+                    y=0,
+                    path=image_name,
+                    display=types.DisplayName.BACK,
+                )
+            ],
+        )
+    )
+    assert bar.audio_play(application_name=APP_NAME, path=audio_name).result == "OK"
+    try:
+        bar.audio_stop()
+    except exceptions.BusyBarAPIError as exc:
+        # A short clip can finish before the stop lands, and the device
+        # answers 410 rather than treating it as a no-op.
+        assert exc.status_code == 410, exc
+
+    bar.display_clear(application_name=APP_NAME)
+    assert bar.assets_delete(application_name=APP_NAME).result == "OK"
+
+
+def test_brightness_round_trip(bar) -> None:
+    """
+    A written brightness is read back, then the original is restored.
+
+    The read lags the write by about a second on current firmware, so this
+    polls rather than asserting immediately.
+    """
+    import time
+
+    original = bar.display_brightness().value
+    try:
+        bar.display_brightness_set(50)
+        for _ in range(10):
+            if bar.display_brightness().value == "50":
+                break
+            time.sleep(0.5)
+        assert bar.display_brightness().value == "50"
+    finally:
+        if original is not None:
+            bar.display_brightness_set("auto" if original == "auto" else int(original))
+
+
+def test_volume_round_trip(bar) -> None:
+    """
+    Volume survives a write and is restored afterwards.
+    """
+    original = bar.audio_volume().volume
+    try:
+        bar.audio_volume_set(42)
+        assert bar.audio_volume().volume == 42
+    finally:
+        if original is not None:
+            bar.audio_volume_set(int(original))
+
+
+def test_device_name_round_trip(bar) -> None:
+    """
+    The name can be changed and put back.
+
+    Discovery advertises this name, so leaving a test value behind would be
+    visible on the network and in the owner's app.
+    """
+    original = bar.name().name
+    probe = "busylib itest"
+    try:
+        assert bar.name_set(probe).result == "OK"
+        assert bar.name().name == probe
+    finally:
+        if original:
+            bar.name_set(original)
+            assert bar.name().name == original
+
+
+def test_input_is_accepted(bar) -> None:
+    """
+    Forwarded key presses are accepted for every button.
+    """
+    for key in (types.InputKey.OK, types.InputKey.BACK, types.InputKey.START):
+        assert bar.input(key).result == "OK"
+
+
+def test_compatibility_metadata_matches_this_bar(bar) -> None:
+    """
+    What the library claims about an endpoint holds against real firmware.
+
+    An experimental marker that answers 404 is honest; one that answers 200
+    means the marker outlived the firmware work and should be a version floor
+    instead.
+    """
+    from busylib import exceptions
+
+    metadata = bar.method_compatibility("access_tokens_list")
+    assert metadata is not None
+
+    try:
+        bar.access_tokens_list()
+    except exceptions.BusyBarAPIError as exc:
+        assert metadata.get("status") == "experimental", (
+            f"endpoint failed ({exc}) but is not marked experimental"
+        )
+    else:
+        assert metadata.get("status") != "experimental", (
+            "endpoint works on this firmware but is still marked experimental"
+        )

--- a/tests/integration/test_input_stream.py
+++ b/tests/integration/test_input_stream.py
@@ -1,0 +1,152 @@
+"""
+What the status stream reports, and whether physical buttons reach it.
+
+`/api/status/ws` is a local endpoint by design, so none of this runs through
+the cloud. The synthetic half is automatic: input forwarded over HTTP comes
+back on the stream, which proves the whole path without anyone touching the
+bar. The physical half needs a person and is marked `manual`.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+
+import pytest
+
+from busylib import types
+
+pytestmark = pytest.mark.integration
+
+STREAM_SETTLE_SECONDS = 1.5
+STREAM_DRAIN_SECONDS = 2.0
+MANUAL_TIMEOUT_SECONDS = float(os.environ.get("BUSYBAR_TEST_MANUAL_TIMEOUT", "30"))
+
+# proto3 omits fields holding a default value, so the first entry of each enum
+# arrives as an absent key: OK is button 0 and PRESS is action 0, which makes
+# "OK pressed" indistinguishable from an empty message unless the defaults are
+# filled in. Everything below reads events through _button, never raw.
+DEFAULT_BUTTON = "OK"
+DEFAULT_ACTION = "PRESS"
+
+
+def _button(event: dict) -> tuple[str, str] | None:
+    """
+    Return (button, action) from an update, or None if it is not a button.
+    """
+    payload = event.get("input", {}).get("button_event")
+    if payload is None:
+        return None
+    return (
+        payload.get("button", DEFAULT_BUTTON),
+        payload.get("action", DEFAULT_ACTION),
+    )
+
+
+async def _collect(abar, seconds: float, stop_when=None) -> list[dict]:
+    """
+    Gather stream updates for a while, or until `stop_when` is satisfied.
+    """
+    updates: list[dict] = []
+
+    async def listen() -> None:
+        async for message in abar.stream_status_ws():
+            if not isinstance(message, dict):
+                continue
+            for update in message.get("updates", []):
+                updates.append(update)
+                if stop_when is not None and stop_when(updates):
+                    return
+
+    try:
+        await asyncio.wait_for(listen(), timeout=seconds)
+    except asyncio.TimeoutError:
+        pass
+    return updates
+
+
+async def test_stream_yields_frames(local_only, abar) -> None:
+    """
+    The stream produces screen frames without being prompted.
+    """
+    updates = await _collect(
+        abar,
+        STREAM_DRAIN_SECONDS,
+        stop_when=lambda seen: any("frame" in u for u in seen),
+    )
+
+    assert any("frame" in u for u in updates), (
+        f"no frame updates in {len(updates)} stream messages"
+    )
+
+
+async def test_forwarded_input_comes_back_on_the_stream(local_only, abar) -> None:
+    """
+    Every forwarded button appears as a press and a release.
+
+    This is the automatic half of the key-press check: it proves the stream
+    carries input at all, so a failure in the manual test below points at the
+    hardware path rather than at this client.
+    """
+    expected = [types.InputKey.OK, types.InputKey.BACK, types.InputKey.START]
+    seen: list[tuple[str, str]] = []
+
+    async def listen() -> None:
+        async for message in abar.stream_status_ws():
+            if not isinstance(message, dict):
+                continue
+            for update in message.get("updates", []):
+                pressed = _button(update)
+                if pressed is not None:
+                    seen.append(pressed)
+
+    listener = asyncio.create_task(listen())
+    await asyncio.sleep(STREAM_SETTLE_SECONDS)
+    try:
+        for key in expected:
+            await abar.input(key)
+            await asyncio.sleep(0.4)
+        await asyncio.sleep(1.0)
+    finally:
+        listener.cancel()
+
+    for key in expected:
+        name = key.value.upper()
+        assert (name, "PRESS") in seen, f"no press for {name}, saw {seen}"
+        assert (name, "RELEASE") in seen, f"no release for {name}, saw {seen}"
+
+
+@pytest.mark.manual
+async def test_physical_buttons_reach_the_stream(local_only, abar) -> None:
+    """
+    A human presses buttons on the bar and the stream reports them.
+
+    Forwarded input travelling the same channel does not prove the hardware
+    does, which is why this exists separately. Run it with output shown:
+
+        uv run pytest -m "integration and manual" -s
+
+    Then press OK, BACK and START on the bar within the timeout.
+    """
+    wanted = {"OK", "BACK", "START"}
+    print(
+        f"\nPress OK, BACK and START on the bar ({MANUAL_TIMEOUT_SECONDS:.0f}s)...",
+        flush=True,
+    )
+
+    pressed: set[str] = set()
+
+    def enough(updates: list[dict]) -> bool:
+        for update in updates[-1:]:
+            found = _button(update)
+            if found is not None and found[1] == "PRESS":
+                if found[0] not in pressed:
+                    pressed.add(found[0])
+                    print(f"  saw {found[0]}", flush=True)
+        return wanted.issubset(pressed)
+
+    await _collect(abar, MANUAL_TIMEOUT_SECONDS, stop_when=enough)
+
+    assert wanted.issubset(pressed), (
+        f"missing {sorted(wanted - pressed)}; got {sorted(pressed)}"
+    )


### PR DESCRIPTION
Adds `tests/integration`: one physical bar, driven over USB, over the LAN and through the cloud from a single parameterized fixture. Opt-in — a normal `pytest` run is unchanged — and each transport skips unless configured and answering.

It immediately found two methods that had never worked. `audio_volume_set` sent a float and the device rejects `?volume=42.0` with 400; `storage_rename` sent the source as `old_path` where the device wants `path`. Mock transports accept any query string, so both passed unit tests for months — and three of those tests asserted the broken shape outright, which is now corrected and pinned in `test_wire_format.py`.

Status streaming is covered in two halves: forwarded input proves the channel automatically, and a `manual` test asks someone to press the buttons, since input on the same channel does not prove the hardware path.

Verified against a real bar: 14 passed over USB, 14 over Wi-Fi, 12 over cloud with 2 correctly skipped as local-only.

Based on #76 — retarget to main once that merges.