### PR TITLE
Keep input events whole when decoding the state stream

### DIFF
--- a/docs/guides/integration-tests.md
+++ b/docs/guides/integration-tests.md
@@ -66,12 +66,18 @@ A full run against a bar reachable three ways looks like this:
 40 passed, 2 skipped, 3 deselected
 ```
 
-**Skips are expected, and the reason says which kind.** A skip reading
-`endpoint is local only` is correct behaviour: status streaming does not work
-through the cloud by design, so those two tests stand down on the cloud
-transport. A skip reading `usb transport unavailable - ...` means that
-transport was configured but did not answer, and the message carries the
-error — a `403` there means a missing or wrong access key, not a broken bar.
+**Skips are expected, and the reason says which kind.** There are three:
+
+- `endpoint is local only` — correct behaviour. Status streaming does not work
+  through the cloud by design, so those tests stand down on that transport.
+- `a Busy session owns the display (INTERVAL)` — the bar is mid-session.
+  `display_draw` competes for the screen and a running session outranks
+  everything, priority 100 included, so drawing is refused with `409`. Stopping
+  the session would take the bar away from whoever is using it, so the drawing
+  tests stand down instead. Stop the session on the bar to run them.
+- `usb transport unavailable - ...` — the transport was configured but did not
+  answer, and the message carries the error. A `403` there means a missing or
+  wrong access key, not a broken bar.
 
 Run with `-rs` to see the reasons:
 
@@ -92,31 +98,50 @@ with `403`.
 
 ## The manual test
 
-Forwarded input travels the same stream as a real button, so the automatic
-tests cannot prove the hardware path. One test asks you to press the buttons:
+Forwarded input travels the same stream as real hardware, so the automatic
+tests cannot prove the buttons, wheel and switch are wired to it. One test
+asks you to use the bar:
 
 ```bash
 BUSYBAR_TEST_MANUAL_TIMEOUT=120 uv run pytest \
-  tests/integration/test_input_stream.py::test_physical_buttons_reach_the_stream \
+  tests/integration/test_input_stream.py::test_physical_input_reaches_the_stream \
   -m "integration and manual" -s
 ```
 
 `-s` matters: without it pytest captures the prompt and you will not see what
-to press. Press **OK**, **BACK** and **START** on the bar; each one is
-acknowledged as it arrives and the test finishes as soon as all three are
-seen.
+to do. Each input is acknowledged as it arrives, and the test finishes as soon
+as it has seen all three buttons, both wheel directions and one switch move.
 
 ```
-Press OK, BACK and START on the bar (120s)...
-  saw OK
-  saw BACK
-  saw START
+On the bar, within 120s:
+  press OK, BACK and START
+  turn the wheel one way and back
+  move the switch to any other position
+  button OK
+  wheel forward (delta 1)
+  switch APPS
 ```
 
-If a press does not appear, check the automatic counterpart first —
-`test_forwarded_input_comes_back_on_the_stream` uses the same decoding, so if
-that passes and this does not, the gap is between the buttons and the stream
+If something does not appear, check the automatic counterparts first:
+`test_forwarded_buttons_come_back_on_the_stream` and
+`test_forwarded_wheel_movement_comes_back` use the same decoding, so if
+they pass and this does not, the gap is between the hardware and the stream
 rather than in this client.
+
+### Reading input yourself
+
+Worth knowing if you consume this stream in your own code: protobuf omits
+fields holding a default value, and the first entry of every input enum is a
+default. `OK` is button 0, `PRESS` is action 0, and `BUSY` is switch position
+0 — so "OK pressed" and "moved to BUSY" both arrive as an empty payload:
+
+```python
+{"input": {"button_event": {}}}  # OK, pressed
+{"input": {"switch_event": {}}}  # switch moved to BUSY
+```
+
+Treat a missing key as the enum's first value rather than as no data. The
+wheel is safe from this, since the firmware sends `+1` and `-1` and never `0`.
 
 ## What the tests touch
 

--- a/src/busylib/client/state_stream.py
+++ b/src/busylib/client/state_stream.py
@@ -46,6 +46,44 @@ def _extract_token(headers: Mapping[str, str]) -> str | None:
     return headers.get("x-api-token") or headers.get("X-API-Token")
 
 
+def _decode_state(state_message: Any) -> dict[str, Any]:
+    """
+    Convert a decoded `State` into a dictionary, keeping input events whole.
+
+    protobuf omits every field holding its default, and the first entry of an
+    enum *is* the default - so a press of OK (button 0, action 0) arrives as an
+    empty `button_event`, indistinguishable from no data. Reported as #77 with
+    the wire bytes to prove it.
+
+    Only the input subtree is re-converted with defaults filled in. Doing that
+    for the whole state would pad every update with zeroes for fields the
+    device never sent, which is a much bigger change than the problem needs.
+    """
+    decoded: dict[str, Any] = MessageToDict(
+        state_message,
+        preserving_proto_field_name=True,
+    )
+
+    updates = decoded.get("updates")
+    if not isinstance(updates, list):
+        return decoded
+
+    # The dictionary preserves order, so an update lines up with the message it
+    # came from by index.
+    for index, update in enumerate(updates):
+        if not isinstance(update, dict) or "input" not in update:
+            continue
+        if index >= len(state_message.updates):
+            continue
+        update["input"] = MessageToDict(
+            state_message.updates[index].input,
+            preserving_proto_field_name=True,
+            always_print_fields_with_no_presence=True,
+        )
+
+    return decoded
+
+
 class StateStreamMixin(SyncClientBase):
     """
     Sync API for status streaming endpoints.
@@ -126,10 +164,7 @@ class AsyncStateStreamMixin(AsyncClientBase):
                         state_schema = cast(Any, state_pb2)
                         state_message = state_schema.State()
                         state_message.ParseFromString(message)
-                        yield MessageToDict(
-                            state_message,
-                            preserving_proto_field_name=True,
-                        )
+                        yield _decode_state(state_message)
                     except Exception as exc:
                         raise exceptions.BusyBarProtocolError(
                             "Failed to decode /api/status/ws protobuf message",

--- a/tests/busylib/client/test_state_decoding.py
+++ b/tests/busylib/client/test_state_decoding.py
@@ -1,0 +1,98 @@
+"""
+Input events survive the protobuf-to-dictionary conversion.
+
+protobuf omits any field holding its default, and the first entry of an enum
+is the default, so a press of OK - button 0, action 0 - used to arrive as an
+empty `button_event`. The payloads below are the wire bytes from issue #77.
+"""
+
+from __future__ import annotations
+
+from typing import Any, cast
+
+import pytest
+
+from busylib.client.state_stream import _decode_state
+from busylib.state_stream_proto import state_pb2
+
+# Captured from /api/status/ws while pressing and releasing the encoder.
+PRESS = bytes.fromhex("12045a020a00")
+RELEASE = bytes.fromhex("12065a040a0210 01".replace(" ", ""))
+
+
+def _state(payload: bytes) -> Any:
+    schema = cast(Any, state_pb2)
+    message = schema.State()
+    message.ParseFromString(payload)
+    return message
+
+
+def test_a_zero_valued_button_event_keeps_both_fields() -> None:
+    """
+    OK pressed is reported as OK pressed, not as an empty message.
+    """
+    decoded = _decode_state(_state(PRESS))
+
+    assert decoded["updates"][0]["input"]["button_event"] == {
+        "button": "OK",
+        "action": "PRESS",
+    }
+
+
+def test_a_partially_defaulted_event_is_completed() -> None:
+    """
+    Release carries an action but not the button, which is still OK.
+    """
+    decoded = _decode_state(_state(RELEASE))
+
+    assert decoded["updates"][0]["input"]["button_event"] == {
+        "button": "OK",
+        "action": "RELEASE",
+    }
+
+
+@pytest.mark.parametrize(
+    "position,expected",
+    [(0, "BUSY"), (1, "CUSTOM"), (2, "OFF"), (3, "APPS"), (4, "SETTINGS")],
+)
+def test_switch_positions_are_named_including_the_zero_one(
+    position: int, expected: str
+) -> None:
+    """
+    BUSY is position 0, so it hit the same problem as OK.
+    """
+    schema = cast(Any, state_pb2)
+    message = schema.State()
+    message.updates.add().input.switch_event.position = position
+
+    decoded = _decode_state(message)
+
+    assert decoded["updates"][0]["input"]["switch_event"] == {"position": expected}
+
+
+def test_other_updates_are_not_padded_with_defaults() -> None:
+    """
+    Only the input subtree is completed.
+
+    Filling defaults across the whole state would add zeroes for everything the
+    device chose not to send, which is a far larger change than this needs.
+    """
+    schema = cast(Any, state_pb2)
+    message = schema.State()
+    message.updates.add().device_name.name = "bar"
+
+    decoded = _decode_state(message)
+
+    assert decoded["updates"][0]["device_name"] == {"name": "bar"}
+
+
+def test_a_state_without_updates_is_untouched() -> None:
+    """
+    The normalization must not invent an updates list.
+    """
+    schema = cast(Any, state_pb2)
+    message = schema.State(timestamp=7)
+
+    decoded = _decode_state(message)
+
+    assert decoded == {"timestamp": "7"}

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -147,6 +147,28 @@ async def abar(transport: Transport):
 
 
 @pytest.fixture
+def free_display(bar) -> None:
+    """
+    Skip the test while a Busy session owns the display.
+
+    `display_draw` competes for the screen and answers `409 Not drawn due to
+    low priority` while a session is running - and no priority wins, 100
+    included. Stopping the session would take the bar away from whoever is
+    using it, so the honest move is to stand down and say why.
+    """
+    try:
+        snapshot = bar.busy_snapshot().snapshot
+    except Exception as exc:  # noqa: BLE001 - unreadable state is not a reason to fail
+        pytest.skip(f"could not read the Busy session state - {exc}")
+
+    kind = getattr(snapshot, "type", None)
+    if kind is not None and kind != "NOT_STARTED":
+        paused = getattr(snapshot, "is_paused", None)
+        if paused is not True:
+            pytest.skip(f"a Busy session owns the display ({kind})")
+
+
+@pytest.fixture
 def local_only(transport: Transport) -> Transport:
     """
     Skip the test unless the bar is reached directly.

--- a/tests/integration/test_device_api.py
+++ b/tests/integration/test_device_api.py
@@ -67,7 +67,9 @@ def test_subsystem_state_is_readable(bar) -> None:
     "display,x,y",
     [(types.DisplayName.FRONT, 2, 4), (types.DisplayName.BACK, 4, 8)],
 )
-def test_draws_then_clears(bar, display: types.DisplayName, x: int, y: int) -> None:
+def test_draws_then_clears(
+    free_display, bar, display: types.DisplayName, x: int, y: int
+) -> None:
     """
     Text reaches both displays and the drawing can be withdrawn again.
     """
@@ -141,7 +143,7 @@ def test_storage_round_trip(bar) -> None:
     bar.storage_remove(path=STORAGE_DIR)
 
 
-def test_assets_and_audio(bar) -> None:
+def test_assets_and_audio(free_display, bar) -> None:
     """
     Upload an image and a sound, use both, then delete them together.
 

--- a/tests/integration/test_input_stream.py
+++ b/tests/integration/test_input_stream.py
@@ -1,5 +1,5 @@
 """
-What the status stream reports, and whether physical buttons reach it.
+What the status stream reports, and whether the hardware reaches it.
 
 `/api/status/ws` is a local endpoint by design, so none of this runs through
 the cloud. The synthetic half is automatic: input forwarded over HTTP comes
@@ -22,12 +22,10 @@ STREAM_SETTLE_SECONDS = 1.5
 STREAM_DRAIN_SECONDS = 2.0
 MANUAL_TIMEOUT_SECONDS = float(os.environ.get("BUSYBAR_TEST_MANUAL_TIMEOUT", "30"))
 
-# proto3 omits fields holding a default value, so the first entry of each enum
-# arrives as an absent key: OK is button 0 and PRESS is action 0, which makes
-# "OK pressed" indistinguishable from an empty message unless the defaults are
-# filled in. Everything below reads events through _button, never raw.
-DEFAULT_BUTTON = "OK"
-DEFAULT_ACTION = "PRESS"
+# The client fills the protobuf defaults that a plain conversion drops, so a
+# press of OK arrives complete rather than as an empty payload (#77). These
+# helpers read the fields directly rather than with a fallback, which makes
+# them fail if that normalization is ever lost.
 
 
 def _button(event: dict) -> tuple[str, str] | None:
@@ -37,10 +35,30 @@ def _button(event: dict) -> tuple[str, str] | None:
     payload = event.get("input", {}).get("button_event")
     if payload is None:
         return None
-    return (
-        payload.get("button", DEFAULT_BUTTON),
-        payload.get("action", DEFAULT_ACTION),
-    )
+    return (payload["button"], payload["action"])
+
+
+def _switch(event: dict) -> str | None:
+    """
+    Return the switch position from an update, or None if it is not a switch.
+    """
+    payload = event.get("input", {}).get("switch_event")
+    if payload is None:
+        return None
+    return payload["position"]
+
+
+def _encoder(event: dict) -> int | None:
+    """
+    Return the encoder delta from an update, or None if it is not an encoder.
+
+    The firmware sends +1 and -1 and never 0, so a missing delta would mean a
+    contract change rather than "no movement".
+    """
+    payload = event.get("input", {}).get("encoder_event")
+    if payload is None:
+        return None
+    return payload["delta"]
 
 
 async def _collect(abar, seconds: float, stop_when=None) -> list[dict]:
@@ -65,6 +83,33 @@ async def _collect(abar, seconds: float, stop_when=None) -> list[dict]:
     return updates
 
 
+async def _forward_and_watch(abar, keys, extract) -> list:
+    """
+    Forward input while listening, and return whatever `extract` recognised.
+    """
+    seen: list = []
+
+    async def listen() -> None:
+        async for message in abar.stream_status_ws():
+            if not isinstance(message, dict):
+                continue
+            for update in message.get("updates", []):
+                found = extract(update)
+                if found is not None:
+                    seen.append(found)
+
+    listener = asyncio.create_task(listen())
+    await asyncio.sleep(STREAM_SETTLE_SECONDS)
+    try:
+        for key in keys:
+            await abar.input(types.InputKey(key))
+            await asyncio.sleep(0.35)
+        await asyncio.sleep(1.0)
+    finally:
+        listener.cancel()
+    return seen
+
+
 async def test_stream_yields_frames(local_only, abar) -> None:
     """
     The stream produces screen frames without being prompted.
@@ -80,73 +125,103 @@ async def test_stream_yields_frames(local_only, abar) -> None:
     )
 
 
-async def test_forwarded_input_comes_back_on_the_stream(local_only, abar) -> None:
+async def test_forwarded_buttons_come_back_on_the_stream(local_only, abar) -> None:
     """
     Every forwarded button appears as a press and a release.
 
     This is the automatic half of the key-press check: it proves the stream
-    carries input at all, so a failure in the manual test below points at the
+    carries input at all, so a failure in the manual test points at the
     hardware path rather than at this client.
     """
-    expected = [types.InputKey.OK, types.InputKey.BACK, types.InputKey.START]
-    seen: list[tuple[str, str]] = []
+    expected = ["ok", "back", "start"]
 
-    async def listen() -> None:
-        async for message in abar.stream_status_ws():
-            if not isinstance(message, dict):
-                continue
-            for update in message.get("updates", []):
-                pressed = _button(update)
-                if pressed is not None:
-                    seen.append(pressed)
-
-    listener = asyncio.create_task(listen())
-    await asyncio.sleep(STREAM_SETTLE_SECONDS)
-    try:
-        for key in expected:
-            await abar.input(key)
-            await asyncio.sleep(0.4)
-        await asyncio.sleep(1.0)
-    finally:
-        listener.cancel()
+    seen = await _forward_and_watch(abar, expected, _button)
 
     for key in expected:
-        name = key.value.upper()
+        name = key.upper()
         assert (name, "PRESS") in seen, f"no press for {name}, saw {seen}"
         assert (name, "RELEASE") in seen, f"no release for {name}, saw {seen}"
 
 
-@pytest.mark.manual
-async def test_physical_buttons_reach_the_stream(local_only, abar) -> None:
+async def test_forwarded_wheel_movement_comes_back(local_only, abar) -> None:
     """
-    A human presses buttons on the bar and the stream reports them.
+    The stream carries wheel movement, not only buttons.
+
+    Only buttons were checked at first, which made scrolling look as though it
+    were never reported. It is, as an encoder delta of +1 or -1.
+
+    Switch positions are deliberately not forwarded here. They change the
+    bar's operating mode - sending `off` stops a running Busy session, and a
+    session owns the display, so a draw afterwards is refused with `409 Not
+    drawn due to low priority`. That cost three unexplained failures elsewhere
+    in this suite. Switch decoding is covered without a device in
+    tests/busylib/client/test_state_decoding.py, and the physical switch by the
+    manual test below.
+    """
+    deltas = await _forward_and_watch(abar, ["up", "down"], _encoder)
+
+    assert 1 in deltas, f"no forward wheel movement, saw {deltas}"
+    assert -1 in deltas, f"no backward wheel movement, saw {deltas}"
+
+
+@pytest.mark.manual
+async def test_physical_input_reaches_the_stream(local_only, abar) -> None:
+    """
+    A human uses the bar and the stream reports every kind of input.
 
     Forwarded input travelling the same channel does not prove the hardware
     does, which is why this exists separately. Run it with output shown:
 
         uv run pytest -m "integration and manual" -s
 
-    Then press OK, BACK and START on the bar within the timeout.
+    Then press the buttons, turn the wheel both ways, and move the switch.
     """
-    wanted = {"OK", "BACK", "START"}
+    wanted_buttons = {"OK", "BACK", "START"}
+    buttons: set[str] = set()
+    directions: set[str] = set()
+    positions: set[str] = set()
+
     print(
-        f"\nPress OK, BACK and START on the bar ({MANUAL_TIMEOUT_SECONDS:.0f}s)...",
+        f"\nOn the bar, within {MANUAL_TIMEOUT_SECONDS:.0f}s:"
+        "\n  press OK, BACK and START"
+        "\n  turn the wheel one way and back"
+        "\n  move the switch to any other position",
         flush=True,
     )
-
-    pressed: set[str] = set()
 
     def enough(updates: list[dict]) -> bool:
         for update in updates[-1:]:
             found = _button(update)
-            if found is not None and found[1] == "PRESS":
-                if found[0] not in pressed:
-                    pressed.add(found[0])
-                    print(f"  saw {found[0]}", flush=True)
-        return wanted.issubset(pressed)
+            if found is not None and found[1] == "PRESS" and found[0] not in buttons:
+                buttons.add(found[0])
+                print(f"  button {found[0]}", flush=True)
+
+            delta = _encoder(update)
+            if delta is not None:
+                direction = "forward" if delta > 0 else "backward"
+                if direction not in directions:
+                    directions.add(direction)
+                    print(f"  wheel {direction} (delta {delta})", flush=True)
+
+            position = _switch(update)
+            if position is not None and position not in positions:
+                positions.add(position)
+                print(f"  switch {position}", flush=True)
+
+        return (
+            wanted_buttons.issubset(buttons)
+            and len(directions) == 2
+            and bool(positions)
+        )
 
     await _collect(abar, MANUAL_TIMEOUT_SECONDS, stop_when=enough)
 
-    assert wanted.issubset(pressed), (
-        f"missing {sorted(wanted - pressed)}; got {sorted(pressed)}"
-    )
+    missing: list[str] = []
+    if not wanted_buttons.issubset(buttons):
+        missing.append(f"buttons {sorted(wanted_buttons - buttons)}")
+    if len(directions) < 2:
+        missing.append(f"wheel directions (saw {sorted(directions) or 'none'})")
+    if not positions:
+        missing.append("any switch movement")
+
+    assert not missing, "; ".join(missing)


### PR DESCRIPTION
Fixes #77, reported by @pimlock with the wire bytes.

protobuf omits any field holding its default and the first entry of an enum *is* the default, so a press of OK — button 0, action 0 — arrived as an empty `button_event`. Switch position `BUSY` is 0 and vanished the same way.

Only the input subtree is re-converted with defaults filled in, since padding the whole state with zeroes for fields the device never sent is the larger change @pimlock flagged. Verified against the exact bytes from the issue and against a live bar.

The integration tests also cover the wheel now, which was never checked — that is why scrolling looked unreported. Switch forwarding is deliberately dropped: moving the switch changes the bar operating mode, and a running Busy session owns the display, so a later draw is refused with `409` at any priority, 100 included. That had produced three unexplained failures. The drawing tests now skip with that reason rather than stopping someone else's timer.