### PR TITLE
Keep the hero image proportional on narrow screens

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,10 @@
   <picture>
     <source media="(prefers-color-scheme: light)" srcset="assets/brand/busylib-py-hero-light.png">
     <source media="(prefers-color-scheme: dark)" srcset="assets/brand/busylib-py-hero-dark.png">
-    <img alt="BUSY Bar: official Python library for connecting, controlling, and automating." width="830" height="218" src="assets/brand/busylib-py-hero-light.png">
+    <!-- Width only: GitHub constrains images with max-width and no height:auto,
+         so an explicit height attribute stays fixed while the width shrinks and
+         squashes the image on a phone. -->
+    <img alt="BUSY Bar: official Python library for connecting, controlling, and automating." width="830" src="assets/brand/busylib-py-hero-light.png">
   </picture>
 </p>
 


### PR DESCRIPTION
GitHub constrains images with `max-width` and no `height: auto`, so the explicit `height` attribute stayed fixed while the width shrank — squashing the README hero to a 1.61 ratio instead of 3.81 on a phone. Dropping the attribute lets it scale proportionally; the docs site was unaffected, it draws the hero as a CSS background with an explicit aspect-ratio.