### PR TITLE
Bump pyproject-fmt to 2.28.0 in both places

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ repos:
       - id: ruff-format
         exclude: ^src/busylib/state_stream_proto/.*_pb2\.py$
   - repo: https://github.com/tox-dev/pyproject-fmt
-    rev: v2.27.1
+    rev: v2.28.0
     hooks:
       - id: pyproject-fmt
   - repo: https://github.com/RobertCraigie/pyright-python

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,7 +55,7 @@ dev = [
   "grpcio-tools>=1.74",
   "pillow>=12",
   "pre-commit>=3.8",
-  "pyproject-fmt==2.27.1",
+  "pyproject-fmt==2.28",
   "pyright==1.1.411",
   "pytest>=8.4.1",
   "pytest-asyncio>=0.24",

--- a/tests/test_tooling_pins.py
+++ b/tests/test_tooling_pins.py
@@ -74,7 +74,22 @@ def test_linters_are_pinned_alike_in_both_files(repo: str, package: str) -> None
     pinned = _pinned_dev_versions().get(package)
 
     assert pinned is not None, f"{package} is not pinned in pyproject.toml"
-    assert revision == f"v{pinned}", (
+    # Compared as version numbers, not strings: pyproject-fmt normalizes the
+    # specifiers it writes, so 2.28.0 becomes ==2.28 in pyproject.toml while
+    # the hook revision stays at the release tag v2.28.0.
+    assert _release_parts(revision.lstrip("v")) == _release_parts(pinned), (
         f"{package}: .pre-commit-config.yaml has {revision}, "
         f"pyproject.toml pins {pinned}"
     )
+
+
+def _release_parts(version: str) -> tuple[int, ...]:
+    """
+    Split a version into numbers, ignoring trailing zeros.
+
+    `2.28` and `2.28.0` are the same release written two ways.
+    """
+    parts = [int(part) for part in version.split(".") if part.isdigit()]
+    while parts and parts[-1] == 0:
+        parts.pop()
+    return tuple(parts)


### PR DESCRIPTION
Combines #83 and #84 — Dependabot proposes one file each, and `tests/test_tooling_pins.py` fails unless both move together, so merging either alone would turn `main` red.

2.28.0 also normalizes the specifier it writes, rewriting `==2.28.0` as `==2.28`, so the guard now compares version numbers instead of strings.