### PR TITLE
Let a cloud host be named instead of inferred

### DIFF
--- a/docs/api/cloud.md
+++ b/docs/api/cloud.md
@@ -10,8 +10,19 @@ interchangeable — a token for one is refused by the other.
 
 ## Choosing an environment
 
-A bar can be pointed at a non-production cloud, and a client has to follow it
-there. Name the host and say that it is a cloud:
+A bar can be pointed at a non-production cloud. Switching is rare and applies
+to everything a process talks to, so the normal way is the environment:
+
+```bash
+BUSYLIB_CLOUD_URL=https://api.dev.busy.app python your_script.py
+```
+
+Nothing in your code changes: `BusyBar(token=...)` picks that host up, and the
+default stays production when the variable is unset.
+
+For the cases where one process needs more than one environment — a test
+sweep, a tool comparing two clouds — the host can be named on the client
+instead:
 
 ```python
 bb = BusyBar(
@@ -21,11 +32,16 @@ bb = BusyBar(
 )
 ```
 
-`is_cloud` matters. Without it the address is taken for a device, so requests
-go to `/api` with the device's token header instead of `/busybar` with a
-bearer one, and fail without explaining themselves. Omitting `addr` still
-means the configured cloud host, so `BusyBar(token=...)` is unchanged; the
-default comes from `BUSYLIB_CLOUD_URL`.
+`is_cloud` is what makes that address a cloud. Without it the address is taken
+for a device, so requests go to `/api` with the device's token header instead
+of `/busybar` with a bearer one, and fail without explaining themselves.
+Omitting `addr` still means the configured cloud host, so existing calls are
+unchanged.
+
+Note that you cannot ask a bar which cloud it uses when you are reaching it
+*through* that cloud - you would need the answer to make the connection. In
+practice whoever points a bar at a non-production environment knows it, and
+everyone else wants the default.
 
 The helpers below follow the same host, so a bar on a development cloud gets
 that environment's documentation rather than production's. Both accept an

--- a/docs/api/cloud.md
+++ b/docs/api/cloud.md
@@ -8,6 +8,29 @@ interchangeable — a token for one is refused by the other.
 | Device API | [`/busybar`](https://api.busy.app/busybar/docs) | bar-scope | yes, as cloud mode |
 | Account API | [`/`](https://api.busy.app/docs) | account-scope | no |
 
+## Choosing an environment
+
+A bar can be pointed at a non-production cloud, and a client has to follow it
+there. Name the host and say that it is a cloud:
+
+```python
+bb = BusyBar(
+    addr="https://api.dev.busy.app",
+    token="<bar-scope token for that environment>",
+    is_cloud=True,
+)
+```
+
+`is_cloud` matters. Without it the address is taken for a device, so requests
+go to `/api` with the device's token header instead of `/busybar` with a
+bearer one, and fail without explaining themselves. Omitting `addr` still
+means the configured cloud host, so `BusyBar(token=...)` is unchanged; the
+default comes from `BUSYLIB_CLOUD_URL`.
+
+The helpers below follow the same host, so a bar on a development cloud gets
+that environment's documentation rather than production's. Both accept an
+explicit `host` if you need to ask about another one.
+
 Cloud mode talks to the device API. It is the same set of endpoints a bar
 serves locally, with `/api` replaced by `/busybar`, so every client method
 works unchanged:

--- a/src/busylib/client/__init__.py
+++ b/src/busylib/client/__init__.py
@@ -67,9 +67,9 @@ class BusyBar(
         Build a client for one bar.
 
         `addr` is a device address; leaving it out with a `token` reaches the
-        bar through the cloud. `is_cloud` states that outright, which is what
-        lets a cloud host be named - `addr="https://api.dev.busy.app",
-        is_cloud=True` - instead of being inferred from an omitted argument.
+        bar through the cloud, at the host `BUSYLIB_CLOUD_URL` names. Pass
+        `is_cloud=True` only to name a cloud host per client, which is what
+        stops an address like api.dev.busy.app being taken for a device.
         """
         super().__init__(
             addr,
@@ -157,9 +157,9 @@ class AsyncBusyBar(
         Build a client for one bar.
 
         `addr` is a device address; leaving it out with a `token` reaches the
-        bar through the cloud. `is_cloud` states that outright, which is what
-        lets a cloud host be named - `addr="https://api.dev.busy.app",
-        is_cloud=True` - instead of being inferred from an omitted argument.
+        bar through the cloud, at the host `BUSYLIB_CLOUD_URL` names. Pass
+        `is_cloud=True` only to name a cloud host per client, which is what
+        stops an address like api.dev.busy.app being taken for a device.
         """
         super().__init__(
             addr,

--- a/src/busylib/client/__init__.py
+++ b/src/busylib/client/__init__.py
@@ -2,6 +2,11 @@ from __future__ import annotations
 
 import logging
 
+import httpx
+
+from .. import versioning
+from .base import DEFAULT_BACKOFF
+
 from .access import AccessMixin, AsyncAccessMixin
 from .account import AccountMixin, AsyncAccountMixin
 from .busy import AsyncBusyMixin, BusyMixin
@@ -45,8 +50,38 @@ class BusyBar(
     HTTPX-based client for the BUSY Bar API.
     """
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
+    def __init__(
+        self,
+        addr: str | None = None,
+        *,
+        token: str | None = None,
+        timeout: float | httpx.Timeout | None = None,
+        max_retries: int = 2,
+        backoff: float = DEFAULT_BACKOFF,
+        transport: httpx.BaseTransport | None = None,
+        api_version: str | None = None,
+        compatibility_mode: versioning.CompatibilityMode = "warn",
+        is_cloud: bool | None = None,
+    ) -> None:
+        """
+        Build a client for one bar.
+
+        `addr` is a device address; leaving it out with a `token` reaches the
+        bar through the cloud. `is_cloud` states that outright, which is what
+        lets a cloud host be named - `addr="https://api.dev.busy.app",
+        is_cloud=True` - instead of being inferred from an omitted argument.
+        """
+        super().__init__(
+            addr,
+            token=token,
+            timeout=timeout,
+            max_retries=max_retries,
+            backoff=backoff,
+            transport=transport,
+            api_version=api_version,
+            compatibility_mode=compatibility_mode,
+            is_cloud=is_cloud,
+        )
         self._usb: UsbController | None = None
 
     @property
@@ -105,8 +140,38 @@ class AsyncBusyBar(
     Async HTTPX-based client for the BUSY Bar API.
     """
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
+    def __init__(
+        self,
+        addr: str | None = None,
+        *,
+        token: str | None = None,
+        timeout: float | httpx.Timeout | None = None,
+        max_retries: int = 2,
+        backoff: float = DEFAULT_BACKOFF,
+        transport: httpx.AsyncBaseTransport | None = None,
+        api_version: str | None = None,
+        compatibility_mode: versioning.CompatibilityMode = "warn",
+        is_cloud: bool | None = None,
+    ) -> None:
+        """
+        Build a client for one bar.
+
+        `addr` is a device address; leaving it out with a `token` reaches the
+        bar through the cloud. `is_cloud` states that outright, which is what
+        lets a cloud host be named - `addr="https://api.dev.busy.app",
+        is_cloud=True` - instead of being inferred from an omitted argument.
+        """
+        super().__init__(
+            addr,
+            token=token,
+            timeout=timeout,
+            max_retries=max_retries,
+            backoff=backoff,
+            transport=transport,
+            api_version=api_version,
+            compatibility_mode=compatibility_mode,
+            is_cloud=is_cloud,
+        )
         self._usb: AsyncUsbController | None = None
 
     @property

--- a/src/busylib/client/base.py
+++ b/src/busylib/client/base.py
@@ -365,6 +365,33 @@ def _decode_response_payload(
         return response.text
 
 
+def _resolve_connection(
+    addr: str | None,
+    token: str | None,
+    is_cloud: bool | None,
+) -> tuple[str, Literal["local", "cloud", "network"]]:
+    """
+    Decide the base URL and the connection type from the arguments.
+
+    Cloud mode used to be selected by *omitting* `addr`, which made it
+    impossible to name a cloud host - so pointing at api.dev.busy.app looked
+    like `addr=...` and quietly became an ordinary network connection, with
+    the device's token header and the device's `/api` paths. `is_cloud` says
+    it outright; left as None, the historical inference applies.
+    """
+    if is_cloud is None:
+        is_cloud = addr is None and token is not None
+
+    if is_cloud:
+        return (
+            _normalize_addr(addr) if addr else settings.cloud_base_url,
+            "cloud",
+        )
+    if addr is not None:
+        return _normalize_addr(addr), "network"
+    return settings.base_url, "local"
+
+
 class SyncClientBase:
     """
     Sync foundation: connection setup, retries, and low-level HTTP requests.
@@ -383,16 +410,9 @@ class SyncClientBase:
         transport: httpx.BaseTransport | None = None,
         api_version: str | None = None,
         compatibility_mode: versioning.CompatibilityMode = "warn",
+        is_cloud: bool | None = None,
     ) -> None:
-        if addr is None and token is None:
-            self.base_url = settings.base_url
-            self.connection_type = "local"
-        elif addr is None:
-            self.base_url = settings.cloud_base_url
-            self.connection_type = "cloud"
-        else:
-            self.base_url = _normalize_addr(addr)
-            self.connection_type = "network"
+        self.base_url, self.connection_type = _resolve_connection(addr, token, is_cloud)
 
         self._token = token
         self.max_retries = max(0, int(max_retries))
@@ -664,16 +684,9 @@ class AsyncClientBase:
         transport: httpx.AsyncBaseTransport | None = None,
         api_version: str | None = None,
         compatibility_mode: versioning.CompatibilityMode = "warn",
+        is_cloud: bool | None = None,
     ) -> None:
-        if addr is None and token is None:
-            self.base_url = settings.base_url
-            self.connection_type = "local"
-        elif addr is None:
-            self.base_url = settings.cloud_base_url
-            self.connection_type = "cloud"
-        else:
-            self.base_url = _normalize_addr(addr)
-            self.connection_type = "network"
+        self.base_url, self.connection_type = _resolve_connection(addr, token, is_cloud)
 
         self._token = token
         self.max_retries = max(0, int(max_retries))

--- a/src/busylib/client/base.py
+++ b/src/busylib/client/base.py
@@ -373,11 +373,12 @@ def _resolve_connection(
     """
     Decide the base URL and the connection type from the arguments.
 
-    Cloud mode used to be selected by *omitting* `addr`, which made it
-    impossible to name a cloud host - so pointing at api.dev.busy.app looked
-    like `addr=...` and quietly became an ordinary network connection, with
-    the device's token header and the device's `/api` paths. `is_cloud` says
-    it outright; left as None, the historical inference applies.
+    `BUSYLIB_CLOUD_URL` is the usual way to reach a non-production cloud, and
+    it needs nothing here. `is_cloud` exists because the address alone cannot
+    say what it is: pointing at api.dev.busy.app looked like `addr=...` and
+    quietly became an ordinary network connection, with the device's token
+    header and the device's `/api` paths. Left as None, the historical
+    inference applies, so existing calls are unaffected.
     """
     if is_cloud is None:
         is_cloud = addr is None and token is not None

--- a/src/busylib/cloud.py
+++ b/src/busylib/cloud.py
@@ -9,6 +9,8 @@ old name for months.
 
 from __future__ import annotations
 
+from .settings import settings
+
 CLOUD_HOST = "https://api.busy.app"
 
 # Two separate surfaces share the host. The account API sits at the root and
@@ -20,7 +22,20 @@ DEVICE_API_DOCS_URL = f"{CLOUD_HOST}/busybar/docs"
 DEVICE_API_SPEC_URL = f"{CLOUD_HOST}/busybar/openapi.yaml"
 
 
-def device_docs_url(firmware_version: str | None = None) -> str:
+def _host(host: str | None) -> str:
+    """
+    Return the host to build a URL against.
+
+    Defaults to the configured cloud base URL rather than the constant, so a
+    client pointed at a non-production environment gets that environment's
+    documentation instead of production's.
+    """
+    return (host or settings.cloud_base_url).rstrip("/")
+
+
+def device_docs_url(
+    firmware_version: str | None = None, *, host: str | None = None
+) -> str:
     """
     Return the device API documentation, optionally for one firmware version.
 
@@ -34,12 +49,15 @@ def device_docs_url(firmware_version: str | None = None) -> str:
     >>> device_docs_url("1.0.2")
     'https://api.busy.app/busybar/docs?urls.primaryName=1.0.2'
     """
+    base = f"{_host(host)}/busybar/docs"
     if not firmware_version:
-        return DEVICE_API_DOCS_URL
-    return f"{DEVICE_API_DOCS_URL}?urls.primaryName={firmware_version}"
+        return base
+    return f"{base}?urls.primaryName={firmware_version}"
 
 
-def device_spec_url(firmware_version: str | None = None) -> str:
+def device_spec_url(
+    firmware_version: str | None = None, *, host: str | None = None
+) -> str:
     """
     Return the machine-readable OpenAPI document for a firmware version.
 
@@ -50,6 +68,7 @@ def device_spec_url(firmware_version: str | None = None) -> str:
     >>> device_spec_url("1.0.2")
     'https://api.busy.app/busybar/openapi.yaml?Name=1.0.2'
     """
+    base = f"{_host(host)}/busybar/openapi.yaml"
     if not firmware_version:
-        return DEVICE_API_SPEC_URL
-    return f"{DEVICE_API_SPEC_URL}?Name={firmware_version}"
+        return base
+    return f"{base}?Name={firmware_version}"

--- a/tests/busylib/test_connection_mode.py
+++ b/tests/busylib/test_connection_mode.py
@@ -1,0 +1,121 @@
+"""
+How the connection mode is chosen.
+
+Cloud mode used to be selected by *omitting* `addr`, so a cloud host could
+not be named: pointing at a non-production environment looked like an
+ordinary `addr=...` and quietly became a device connection, with the device's
+token header and the device's `/api` paths. `is_cloud` states it instead.
+"""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+
+from busylib import AsyncBusyBar, BusyBar
+
+
+def _client(**kwargs) -> BusyBar:
+    return BusyBar(
+        transport=httpx.MockTransport(lambda _r: httpx.Response(200)), **kwargs
+    )
+
+
+@pytest.mark.parametrize(
+    "kwargs,mode",
+    [
+        ({}, "local"),
+        ({"token": "s"}, "cloud"),
+        ({"addr": "10.0.4.20"}, "network"),
+        ({"addr": "192.168.1.5", "token": "1234"}, "network"),
+    ],
+)
+def test_inference_is_unchanged(kwargs: dict, mode: str) -> None:
+    """
+    Without the flag, every existing call resolves exactly as before.
+    """
+    client = _client(**kwargs)
+
+    assert client.connection_type == mode
+
+    client.close()
+
+
+def test_a_cloud_host_can_be_named() -> None:
+    """
+    An explicit cloud address gets cloud paths and the bearer header.
+
+    This is the case that used to be impossible: the address was taken as a
+    device, so requests went to /api with the wrong credential and failed
+    without saying why.
+    """
+    client = _client(addr="https://api.dev.busy.app", token="s", is_cloud=True)
+
+    assert client.connection_type == "cloud"
+    assert client.base_url == "https://api.dev.busy.app"
+    assert client.prepare_request("GET", "/api/version").path == "/busybar/version"
+    assert client.client.headers["authorization"] == "Bearer s"
+
+    client.close()
+
+
+def test_cloud_without_an_address_uses_the_configured_host() -> None:
+    """
+    `is_cloud=True` alone still means the default cloud host.
+    """
+    client = _client(token="s", is_cloud=True)
+
+    assert client.base_url == "https://api.busy.app"
+
+    client.close()
+
+
+def test_a_token_can_be_kept_local() -> None:
+    """
+    `is_cloud=False` keeps a tokened client on the device.
+
+    That is a bar with an access key, which takes the device header rather
+    than a bearer token.
+    """
+    client = _client(token="1234", is_cloud=False)
+
+    assert client.connection_type == "local"
+    assert client.prepare_request("GET", "/api/version").path == "/api/version"
+    assert client.client.headers["x-api-token"] == "1234"
+
+    client.close()
+
+
+@pytest.mark.asyncio
+async def test_the_async_client_agrees() -> None:
+    """
+    Both clients resolve the mode the same way.
+    """
+    client = AsyncBusyBar(
+        addr="https://api.stage.busy.app",
+        token="s",
+        is_cloud=True,
+        transport=httpx.MockTransport(lambda _r: httpx.Response(200)),
+    )
+
+    assert client.connection_type == "cloud"
+    assert client.base_url == "https://api.stage.busy.app"
+    assert client.prepare_request("GET", "/api/status").path == "/busybar/status"
+
+    await client.aclose()
+
+
+@pytest.mark.parametrize("cls", [BusyBar, AsyncBusyBar])
+def test_the_parameters_are_visible_on_the_public_client(cls: type) -> None:
+    """
+    The public clients spell their arguments out.
+
+    They forwarded `*args, **kwargs`, so editors and the generated reference
+    showed no parameters at all - including `addr` and `token`.
+    """
+    import inspect
+
+    params = inspect.signature(cls).parameters
+
+    for name in ("addr", "token", "is_cloud", "timeout", "transport"):
+        assert name in params, f"{cls.__name__} hides {name}"


### PR DESCRIPTION
Cloud mode was selected by *omitting* `addr`, so an address like `https://api.dev.busy.app` was silently taken for a device — device token header, `/api` paths instead of `/busybar` — and failed without explaining itself. `is_cloud=True` says what the address is; unset, the existing inference applies, so nothing breaks. `BUSYLIB_CLOUD_URL` remains the normal way to switch environments.

Also: the docs helpers follow the configured host, and the public clients spell their arguments out — forwarding `*args/**kwargs` hid every parameter, `addr` and `token` included, from editors and the generated reference.