### PR TITLE
Switch from httpx to httpx2

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -142,7 +142,7 @@ if __name__ == "__main__":
 ## Tests And Checks
 
 - Add tests for parsing, scheduling, retries, payload generation, and error handling.
-- Test display/audio payloads with `httpx.MockTransport` before hitting a real device.
+- Test display/audio payloads with `httpx2.MockTransport` before hitting a real device.
 - Test repeated failures and recovery paths for watchers.
 - Run checks available in the current project. In this repository, prefer:
 

--- a/README.md
+++ b/README.md
@@ -572,7 +572,7 @@ result = bb.execute_prepared_request(prepared)
 print(result)
 
 # or execute with an external client
-# with httpx.Client(base_url="http://10.0.4.20") as ext:
+# with httpx2.Client(base_url="http://10.0.4.20") as ext:
 #     result = bb.execute_prepared_request(prepared, client=ext)
 ```
 

--- a/examples/remote/terminal_utils.py
+++ b/examples/remote/terminal_utils.py
@@ -5,7 +5,7 @@ import logging
 import sys
 from logging.handlers import RotatingFileHandler
 
-import httpx
+import httpx2
 
 from examples.remote.constants import TEXT_ERR_CONNECT, TEXT_ERR_TIMEOUT, TEXT_STOPPED
 
@@ -102,7 +102,7 @@ def _format_error_message(exc: BaseException) -> tuple[str | None, str]:
         return "Error", f"{TEXT_ERR_TIMEOUT} (WebSocket)"
     if isinstance(exc, (asyncio.TimeoutError, TimeoutError)):
         return "Error", TEXT_ERR_TIMEOUT
-    if isinstance(exc, httpx.RequestError):
+    if isinstance(exc, httpx2.RequestError):
         return "Error", TEXT_ERR_CONNECT.format(details=message)
     if isinstance(exc, OSError):
         details = exc.strerror or message

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
 ]
 dynamic = [ "version" ]
 dependencies = [
-  "httpx>=0.28.1",
+  "httpx2>=2,<3",
   "protobuf>=6.31.1",
   "pydantic>=2.9",
   "pydantic-extra-types>=2.9",

--- a/src/busylib/client/__init__.py
+++ b/src/busylib/client/__init__.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import logging
 
-import httpx
+import httpx2
 
 from .. import versioning
 from .base import DEFAULT_BACKOFF
@@ -55,10 +55,10 @@ class BusyBar(
         addr: str | None = None,
         *,
         token: str | None = None,
-        timeout: float | httpx.Timeout | None = None,
+        timeout: float | httpx2.Timeout | None = None,
         max_retries: int = 2,
         backoff: float = DEFAULT_BACKOFF,
-        transport: httpx.BaseTransport | None = None,
+        transport: httpx2.BaseTransport | None = None,
         api_version: str | None = None,
         compatibility_mode: versioning.CompatibilityMode = "warn",
         is_cloud: bool | None = None,
@@ -145,10 +145,10 @@ class AsyncBusyBar(
         addr: str | None = None,
         *,
         token: str | None = None,
-        timeout: float | httpx.Timeout | None = None,
+        timeout: float | httpx2.Timeout | None = None,
         max_retries: int = 2,
         backoff: float = DEFAULT_BACKOFF,
-        transport: httpx.AsyncBaseTransport | None = None,
+        transport: httpx2.AsyncBaseTransport | None = None,
         api_version: str | None = None,
         compatibility_mode: versioning.CompatibilityMode = "warn",
         is_cloud: bool | None = None,

--- a/src/busylib/client/assets.py
+++ b/src/busylib/client/assets.py
@@ -2,13 +2,13 @@ from __future__ import annotations
 
 import logging
 
-import httpx
+import httpx2
 
 from .. import types
 from .base import AsyncClientBase, SyncClientBase
 
 logger = logging.getLogger(__name__)
-ASSET_UPLOAD_TIMEOUT = httpx.Timeout(
+ASSET_UPLOAD_TIMEOUT = httpx2.Timeout(
     120.0,
     connect=5.0,
     read=120.0,
@@ -28,7 +28,7 @@ class AssetsMixin(SyncClientBase):
         filename: str,
         data: bytes,
         *,
-        timeout: float | httpx.Timeout | None = ASSET_UPLOAD_TIMEOUT,
+        timeout: float | httpx2.Timeout | None = ASSET_UPLOAD_TIMEOUT,
     ) -> types.SuccessResponse:
         """
         Upload an asset file for the given application.
@@ -72,7 +72,7 @@ class AsyncAssetsMixin(AsyncClientBase):
         filename: str,
         data: bytes,
         *,
-        timeout: float | httpx.Timeout | None = ASSET_UPLOAD_TIMEOUT,
+        timeout: float | httpx2.Timeout | None = ASSET_UPLOAD_TIMEOUT,
     ) -> types.SuccessResponse:
         """
         Upload an asset file for the given application.

--- a/src/busylib/client/base.py
+++ b/src/busylib/client/base.py
@@ -8,7 +8,7 @@ import uuid
 from collections.abc import AsyncIterable, Iterable
 from typing import Any, Literal, TypedDict
 
-import httpx
+import httpx2
 from pydantic import BaseModel, ConfigDict, Field
 
 from .. import exceptions, versioning
@@ -29,12 +29,12 @@ class RequestKwargs(TypedDict, total=False):
     headers: dict[str, str]
     session_id: str | None
     application_name: str | None
-    timeout: float | httpx.Timeout | None
+    timeout: float | httpx2.Timeout | None
 
 
-DEFAULT_TIMEOUT = httpx.Timeout(10.0, connect=5.0, read=10.0, write=10.0, pool=5.0)
+DEFAULT_TIMEOUT = httpx2.Timeout(10.0, connect=5.0, read=10.0, write=10.0, pool=5.0)
 DEFAULT_BACKOFF = 0.25
-LOCAL_CHECK_TIMEOUT = httpx.Timeout(1.5, connect=0.5, read=1.0, write=1.0, pool=0.5)
+LOCAL_CHECK_TIMEOUT = httpx2.Timeout(1.5, connect=0.5, read=1.0, write=1.0, pool=0.5)
 SESSION_HEADER = "x-session-id"
 REQUEST_ID_HEADER = "X-Request-ID"
 
@@ -66,7 +66,7 @@ class PreparedRequest(BaseModel):
     )
     expect_bytes: bool
     allow_text: bool
-    timeout: httpx.Timeout
+    timeout: httpx2.Timeout
     request_id: str
     json_payload: JsonType | None = None
 
@@ -102,15 +102,15 @@ def _data_length(data: Any) -> int | None:
         return None
 
 
-def _as_timeout(value: float | httpx.Timeout | None) -> httpx.Timeout:
+def _as_timeout(value: float | httpx2.Timeout | None) -> httpx2.Timeout:
     """
-    Normalize timeout to an httpx.Timeout instance.
+    Normalize timeout to an httpx2.Timeout instance.
     """
     if value is None:
         return DEFAULT_TIMEOUT
-    if isinstance(value, httpx.Timeout):
+    if isinstance(value, httpx2.Timeout):
         return value
-    return httpx.Timeout(value)
+    return httpx2.Timeout(value)
 
 
 def _normalize_addr(addr: str) -> str:
@@ -206,7 +206,7 @@ def _prepare_request_payload(
     data: bytes | Iterable[bytes] | AsyncIterable[bytes] | None,
     expect_bytes: bool,
     allow_text: bool,
-    timeout: float | httpx.Timeout | None,
+    timeout: float | httpx2.Timeout | None,
     async_mode: bool,
 ) -> PreparedRequest:
     """
@@ -265,7 +265,7 @@ def _prepare_request_payload(
     )
 
 
-def _response_request_id(response: httpx.Response, fallback: str) -> str:
+def _response_request_id(response: httpx2.Response, fallback: str) -> str:
     """
     Return response request id or the caller-generated fallback id.
     """
@@ -275,7 +275,7 @@ def _response_request_id(response: httpx.Response, fallback: str) -> str:
 
 
 def _raise_api_error_from_response(
-    response: httpx.Response, *, prepared: PreparedRequest
+    response: httpx2.Response, *, prepared: PreparedRequest
 ) -> None:
     """
     Raise BusyBarAPIError built from an HTTP error response.
@@ -321,7 +321,7 @@ def _raise_api_error_from_response(
 
 
 def _decode_response_payload(
-    response: httpx.Response, *, prepared: PreparedRequest
+    response: httpx2.Response, *, prepared: PreparedRequest
 ) -> JsonType | bytes | str:
     """
     Decode successful HTTP response according to PreparedRequest flags.
@@ -377,10 +377,10 @@ class SyncClientBase:
         addr: str | None = None,
         *,
         token: str | None = None,
-        timeout: float | httpx.Timeout | None = None,
+        timeout: float | httpx2.Timeout | None = None,
         max_retries: int = 2,
         backoff: float = DEFAULT_BACKOFF,
-        transport: httpx.BaseTransport | None = None,
+        transport: httpx2.BaseTransport | None = None,
         api_version: str | None = None,
         compatibility_mode: versioning.CompatibilityMode = "warn",
     ) -> None:
@@ -411,7 +411,7 @@ class SyncClientBase:
         else:
             headers["X-API-Token"] = token
 
-        self.client = httpx.Client(
+        self.client = httpx2.Client(
             base_url=self.base_url,
             headers=headers or None,
             timeout=_as_timeout(timeout),
@@ -465,7 +465,7 @@ class SyncClientBase:
                 headers=headers,
                 timeout=LOCAL_CHECK_TIMEOUT,
             )
-        except httpx.RequestError:
+        except httpx2.RequestError:
             return False
         return response.status_code < 400
 
@@ -491,7 +491,7 @@ class SyncClientBase:
         data: bytes | Iterable[bytes] | None = None,
         expect_bytes: bool = False,
         allow_text: bool = False,
-        timeout: float | httpx.Timeout | None = None,
+        timeout: float | httpx2.Timeout | None = None,
     ) -> JsonType | bytes | str:
         """
         Execute a raw API request through the current client session.
@@ -526,7 +526,7 @@ class SyncClientBase:
         data: bytes | Iterable[bytes] | None = None,
         expect_bytes: bool = False,
         allow_text: bool = False,
-        timeout: float | httpx.Timeout | None = None,
+        timeout: float | httpx2.Timeout | None = None,
     ) -> JsonType | bytes | str:
         """
         Prepare and execute one synchronous HTTP request.
@@ -562,7 +562,7 @@ class SyncClientBase:
         data: bytes | Iterable[bytes] | None = None,
         expect_bytes: bool = False,
         allow_text: bool = False,
-        timeout: float | httpx.Timeout | None = None,
+        timeout: float | httpx2.Timeout | None = None,
     ) -> PreparedRequest:
         """
         Build a prepared request without executing network I/O.
@@ -589,12 +589,12 @@ class SyncClientBase:
         self,
         prepared: PreparedRequest,
         *,
-        client: httpx.Client | None = None,
+        client: httpx2.Client | None = None,
     ) -> JsonType | bytes | str:
         """
         Execute a previously prepared request.
 
-        By default the current `httpx.Client` is used. Callers may inject a
+        By default the current `httpx2.Client` is used. Callers may inject a
         custom client while preserving error mapping. Prepared streaming content
         is single-use and should be regenerated for repeated executions.
         """
@@ -610,7 +610,7 @@ class SyncClientBase:
                     headers=prepared.headers,
                     timeout=prepared.timeout,
                 )
-            except httpx.RequestError as exc:
+            except httpx2.RequestError as exc:
                 last_exc = exc
                 if attempt >= self.max_retries:
                     raise exceptions.BusyBarRequestError(
@@ -658,10 +658,10 @@ class AsyncClientBase:
         addr: str | None = None,
         *,
         token: str | None = None,
-        timeout: float | httpx.Timeout | None = None,
+        timeout: float | httpx2.Timeout | None = None,
         max_retries: int = 2,
         backoff: float = DEFAULT_BACKOFF,
-        transport: httpx.AsyncBaseTransport | None = None,
+        transport: httpx2.AsyncBaseTransport | None = None,
         api_version: str | None = None,
         compatibility_mode: versioning.CompatibilityMode = "warn",
     ) -> None:
@@ -692,7 +692,7 @@ class AsyncClientBase:
         else:
             headers["X-API-Token"] = token
 
-        self.client = httpx.AsyncClient(
+        self.client = httpx2.AsyncClient(
             base_url=self.base_url,
             headers=headers or None,
             timeout=_as_timeout(timeout),
@@ -746,7 +746,7 @@ class AsyncClientBase:
                 headers=headers,
                 timeout=LOCAL_CHECK_TIMEOUT,
             )
-        except httpx.RequestError:
+        except httpx2.RequestError:
             return False
         return response.status_code < 400
 
@@ -772,7 +772,7 @@ class AsyncClientBase:
         data: bytes | AsyncIterable[bytes] | None = None,
         expect_bytes: bool = False,
         allow_text: bool = False,
-        timeout: float | httpx.Timeout | None = None,
+        timeout: float | httpx2.Timeout | None = None,
     ) -> JsonType | bytes | str:
         """
         Execute a raw async API request through the current client session.
@@ -807,7 +807,7 @@ class AsyncClientBase:
         data: bytes | AsyncIterable[bytes] | None = None,
         expect_bytes: bool = False,
         allow_text: bool = False,
-        timeout: float | httpx.Timeout | None = None,
+        timeout: float | httpx2.Timeout | None = None,
     ) -> JsonType | bytes | str:
         """
         Prepare and execute one asynchronous HTTP request.
@@ -843,7 +843,7 @@ class AsyncClientBase:
         data: bytes | AsyncIterable[bytes] | None = None,
         expect_bytes: bool = False,
         allow_text: bool = False,
-        timeout: float | httpx.Timeout | None = None,
+        timeout: float | httpx2.Timeout | None = None,
     ) -> PreparedRequest:
         """
         Build a prepared async request without executing network I/O.
@@ -871,12 +871,12 @@ class AsyncClientBase:
         self,
         prepared: PreparedRequest,
         *,
-        client: httpx.AsyncClient | None = None,
+        client: httpx2.AsyncClient | None = None,
     ) -> JsonType | bytes | str:
         """
         Execute a previously prepared async request.
 
-        By default the current `httpx.AsyncClient` is used. Callers may inject
+        By default the current `httpx2.AsyncClient` is used. Callers may inject
         a custom client while preserving error mapping. Prepared streaming
         content is single-use and should be regenerated for repeated executions.
         """
@@ -892,7 +892,7 @@ class AsyncClientBase:
                     headers=prepared.headers,
                     timeout=prepared.timeout,
                 )
-            except httpx.RequestError as exc:
+            except httpx2.RequestError as exc:
                 last_exc = exc
                 if attempt >= self.max_retries:
                     raise exceptions.BusyBarRequestError(

--- a/tests/busylib/client/test_access_tokens.py
+++ b/tests/busylib/client/test_access_tokens.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-import httpx
+import httpx2
 import pytest
 
 from busylib import AsyncBusyBar, BusyBar, types
@@ -16,12 +16,14 @@ TOKEN_PAYLOAD = {
 
 
 def _client(responder) -> BusyBar:
-    return BusyBar(addr="http://device.local", transport=httpx.MockTransport(responder))
+    return BusyBar(
+        addr="http://device.local", transport=httpx2.MockTransport(responder)
+    )
 
 
 def _async_client(responder) -> AsyncBusyBar:
     return AsyncBusyBar(
-        addr="http://device.local", transport=httpx.MockTransport(responder)
+        addr="http://device.local", transport=httpx2.MockTransport(responder)
     )
 
 
@@ -31,10 +33,10 @@ def test_tokens_list_parses_the_collection() -> None:
     """
     seen: dict[str, str] = {}
 
-    def responder(request: httpx.Request) -> httpx.Response:
+    def responder(request: httpx2.Request) -> httpx2.Response:
         seen["path"] = request.url.path
         seen["method"] = request.method
-        return httpx.Response(200, json={"tokens": [TOKEN_PAYLOAD]})
+        return httpx2.Response(200, json={"tokens": [TOKEN_PAYLOAD]})
 
     info = _client(responder).access_tokens_list()
 
@@ -49,10 +51,10 @@ def test_token_mint_sends_the_name_and_returns_the_secret() -> None:
     """
     seen: dict[str, object] = {}
 
-    def responder(request: httpx.Request) -> httpx.Response:
+    def responder(request: httpx2.Request) -> httpx2.Response:
         seen["path"] = request.url.path
         seen["body"] = request.content
-        return httpx.Response(200, json=TOKEN_PAYLOAD)
+        return httpx2.Response(200, json=TOKEN_PAYLOAD)
 
     token = _client(responder).access_token_mint("laptop")
 
@@ -69,8 +71,8 @@ def test_token_without_a_secret_parses() -> None:
     """
     payload = {k: v for k, v in TOKEN_PAYLOAD.items() if k != "token"}
 
-    def responder(_request: httpx.Request) -> httpx.Response:
-        return httpx.Response(200, json={"tokens": [payload]})
+    def responder(_request: httpx2.Request) -> httpx2.Response:
+        return httpx2.Response(200, json={"tokens": [payload]})
 
     info = _client(responder).access_tokens_list()
 
@@ -83,10 +85,10 @@ def test_tokens_delete_all_uses_delete_on_the_collection() -> None:
     """
     seen: dict[str, str] = {}
 
-    def responder(request: httpx.Request) -> httpx.Response:
+    def responder(request: httpx2.Request) -> httpx2.Response:
         seen["path"] = request.url.path
         seen["method"] = request.method
-        return httpx.Response(200, json={"result": "OK"})
+        return httpx2.Response(200, json={"result": "OK"})
 
     assert _client(responder).access_tokens_delete_all().result == "OK"
     assert seen == {"path": "/api/access/tokens", "method": "DELETE"}
@@ -98,10 +100,10 @@ def test_tokens_revoke_addresses_a_single_token() -> None:
     """
     seen: dict[str, str] = {}
 
-    def responder(request: httpx.Request) -> httpx.Response:
+    def responder(request: httpx2.Request) -> httpx2.Response:
         seen["path"] = request.url.path
         seen["method"] = request.method
-        return httpx.Response(200, json={"result": "OK"})
+        return httpx2.Response(200, json={"result": "OK"})
 
     _client(responder).access_tokens_revoke("ab12")
 
@@ -115,13 +117,13 @@ async def test_async_token_helpers_hit_the_same_endpoints() -> None:
     """
     seen: list[tuple[str, str]] = []
 
-    def responder(request: httpx.Request) -> httpx.Response:
+    def responder(request: httpx2.Request) -> httpx2.Response:
         seen.append((request.method, request.url.path))
         if request.method == "GET":
-            return httpx.Response(200, json={"tokens": []})
+            return httpx2.Response(200, json={"tokens": []})
         if request.method == "POST":
-            return httpx.Response(200, json=TOKEN_PAYLOAD)
-        return httpx.Response(200, json={"result": "OK"})
+            return httpx2.Response(200, json=TOKEN_PAYLOAD)
+        return httpx2.Response(200, json={"result": "OK"})
 
     client = _async_client(responder)
     await client.access_tokens_list()

--- a/tests/busylib/client/test_audio.py
+++ b/tests/busylib/client/test_audio.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import json
 
-import httpx
+import httpx2
 import pytest
 from busylib import AsyncBusyBar, BusyBar, types
 from busylib import exceptions
@@ -12,7 +12,7 @@ def _make_sync_client(responder) -> BusyBar:
     """
     Build a BusyBar client with a mock transport responder.
     """
-    transport = httpx.MockTransport(responder)
+    transport = httpx2.MockTransport(responder)
     return BusyBar(addr="http://device.local", transport=transport)
 
 
@@ -20,7 +20,7 @@ def _make_async_client(responder) -> AsyncBusyBar:
     """
     Build an AsyncBusyBar client with a mock transport responder.
     """
-    transport = httpx.MockTransport(responder)
+    transport = httpx2.MockTransport(responder)
     return AsyncBusyBar(addr="http://device.local", transport=transport)
 
 
@@ -30,7 +30,7 @@ def test_audio_play_stop_volume_sync() -> None:
     """
     seen: list[dict[str, object]] = []
 
-    def responder(request: httpx.Request) -> httpx.Response:
+    def responder(request: httpx2.Request) -> httpx2.Response:
         seen.append(
             {
                 "path": request.url.path,
@@ -40,8 +40,8 @@ def test_audio_play_stop_volume_sync() -> None:
             }
         )
         if request.url.path == "/api/audio/volume" and request.method == "GET":
-            return httpx.Response(200, json={"volume": 42.0})
-        return httpx.Response(200, json={"result": "OK"})
+            return httpx2.Response(200, json={"volume": 42.0})
+        return httpx2.Response(200, json={"result": "OK"})
 
     client = _make_sync_client(responder)
     resp = client.audio_play(application_name="app", path="/ext/app.wav")
@@ -81,9 +81,9 @@ def test_audio_play_sync_supports_session_header() -> None:
     """
     seen: dict[str, str] = {}
 
-    def responder(request: httpx.Request) -> httpx.Response:
+    def responder(request: httpx2.Request) -> httpx2.Response:
         seen["session"] = request.headers.get("x-session-id", "")
-        return httpx.Response(200, json={"result": "OK"})
+        return httpx2.Response(200, json={"result": "OK"})
 
     client = _make_sync_client(responder)
     resp = client.audio_play(
@@ -101,9 +101,9 @@ def test_audio_play_sync_supports_stock_path_payload() -> None:
     """
     seen: dict[str, object] = {}
 
-    def responder(request: httpx.Request) -> httpx.Response:
+    def responder(request: httpx2.Request) -> httpx2.Response:
         seen.update(json.loads(request.content))
-        return httpx.Response(200, json={"result": "OK"})
+        return httpx2.Response(200, json={"result": "OK"})
 
     client = _make_sync_client(responder)
     resp = client.audio_play(payload={"stock_path": "shared/sfx.snd"})
@@ -116,7 +116,7 @@ def test_audio_play_sync_rejects_payload_application_name() -> None:
     Reject application_name inside audio payload; request context owns it.
     """
     client = _make_sync_client(
-        lambda _request: httpx.Response(200, json={"result": "OK"})
+        lambda _request: httpx2.Response(200, json={"result": "OK"})
     )
     with pytest.raises(exceptions.BusyBarResponseValidationError):
         client.audio_play(
@@ -134,9 +134,9 @@ def test_audio_play_sync_keyword_arguments_override_payload() -> None:
     """
     seen: dict[str, object] = {}
 
-    def responder(request: httpx.Request) -> httpx.Response:
+    def responder(request: httpx2.Request) -> httpx2.Response:
         seen.update(json.loads(request.content))
-        return httpx.Response(200, json={"result": "OK"})
+        return httpx2.Response(200, json={"result": "OK"})
 
     client = _make_sync_client(responder)
     resp = client.audio_play(
@@ -154,7 +154,7 @@ async def test_audio_play_stop_volume_async() -> None:
     """
     seen: list[dict[str, object]] = []
 
-    async def responder(request: httpx.Request) -> httpx.Response:
+    async def responder(request: httpx2.Request) -> httpx2.Response:
         seen.append(
             {
                 "path": request.url.path,
@@ -164,8 +164,8 @@ async def test_audio_play_stop_volume_async() -> None:
             }
         )
         if request.url.path == "/api/audio/volume" and request.method == "GET":
-            return httpx.Response(200, json={"volume": 17.0})
-        return httpx.Response(200, json={"result": "OK"})
+            return httpx2.Response(200, json={"volume": 17.0})
+        return httpx2.Response(200, json={"result": "OK"})
 
     client = _make_async_client(responder)
     resp = await client.audio_play(application_name="app", path="/ext/app.wav")
@@ -207,9 +207,9 @@ async def test_audio_play_async_supports_session_header() -> None:
     """
     seen: dict[str, str] = {}
 
-    async def responder(request: httpx.Request) -> httpx.Response:
+    async def responder(request: httpx2.Request) -> httpx2.Response:
         seen["session"] = request.headers.get("x-session-id", "")
-        return httpx.Response(200, json={"result": "OK"})
+        return httpx2.Response(200, json={"result": "OK"})
 
     client = _make_async_client(responder)
     resp = await client.audio_play(
@@ -229,9 +229,9 @@ async def test_audio_play_async_supports_stock_path_payload() -> None:
     """
     seen: dict[str, object] = {}
 
-    async def responder(request: httpx.Request) -> httpx.Response:
+    async def responder(request: httpx2.Request) -> httpx2.Response:
         seen.update(json.loads(request.content))
-        return httpx.Response(200, json={"result": "OK"})
+        return httpx2.Response(200, json={"result": "OK"})
 
     client = _make_async_client(responder)
     resp = await client.audio_play(payload={"stock_path": "shared/sfx.snd"})

--- a/tests/busylib/client/test_base.py
+++ b/tests/busylib/client/test_base.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import json
 import uuid
 
-import httpx
+import httpx2
 import pytest
 
 from busylib import exceptions
@@ -16,7 +16,9 @@ class _SyncBaseClient(base.SyncClientBase):
     Sync client wrapper to access protected _request in tests.
     """
 
-    def __init__(self, transport: httpx.BaseTransport, *, max_retries: int = 0) -> None:
+    def __init__(
+        self, transport: httpx2.BaseTransport, *, max_retries: int = 0
+    ) -> None:
         """
         Initialize the client with a custom transport and retries.
         """
@@ -33,7 +35,7 @@ class _AsyncBaseClient(base.AsyncClientBase):
     Async client wrapper to access protected _request in tests.
     """
 
-    def __init__(self, transport: httpx.AsyncBaseTransport) -> None:
+    def __init__(self, transport: httpx2.AsyncBaseTransport) -> None:
         """
         Initialize the client with a custom async transport.
         """
@@ -50,13 +52,13 @@ def test_request_json_payload_requires_json_sync() -> None:
     Validate JSON request headers and protocol error on invalid JSON response.
     """
 
-    def responder(request: httpx.Request) -> httpx.Response:
+    def responder(request: httpx2.Request) -> httpx2.Response:
         assert request.headers["content-type"].startswith("application/json")
         body = request.content.decode("utf-8")
         assert "Café" in body
-        return httpx.Response(200, text="ok", headers={"X-Request-ID": "rid-1"})
+        return httpx2.Response(200, text="ok", headers={"X-Request-ID": "rid-1"})
 
-    client = _SyncBaseClient(httpx.MockTransport(responder))
+    client = _SyncBaseClient(httpx2.MockTransport(responder))
     with pytest.raises(exceptions.BusyBarProtocolError) as exc:
         client._request("POST", "/api/test", json_payload={"msg": "Café"})
     assert exc.value.request_id == "rid-1"
@@ -70,7 +72,9 @@ def test_prepare_request_sync_returns_serialized_payload() -> None:
     This verifies request preparation can be used independently from execution.
     """
     client = _SyncBaseClient(
-        httpx.MockTransport(lambda _request: httpx.Response(200, json={"result": "OK"}))
+        httpx2.MockTransport(
+            lambda _request: httpx2.Response(200, json={"result": "OK"})
+        )
     )
     prepared = client.prepare_request(
         "POST",
@@ -96,22 +100,22 @@ def test_execute_prepared_request_with_external_sync_client() -> None:
     """
     seen: dict[str, object] = {}
 
-    def responder(request: httpx.Request) -> httpx.Response:
+    def responder(request: httpx2.Request) -> httpx2.Response:
         seen["url"] = str(request.url)
         seen["body"] = request.content.decode("utf-8")
-        return httpx.Response(200, json={"result": "OK"})
+        return httpx2.Response(200, json={"result": "OK"})
 
     client = _SyncBaseClient(
-        httpx.MockTransport(lambda _request: httpx.Response(500, text="unused"))
+        httpx2.MockTransport(lambda _request: httpx2.Response(500, text="unused"))
     )
     prepared = client.prepare_request(
         "POST",
         "/api/test",
         json_payload={"value": 7},
     )
-    with httpx.Client(
+    with httpx2.Client(
         base_url="http://external.local",
-        transport=httpx.MockTransport(responder),
+        transport=httpx2.MockTransport(responder),
     ) as external_client:
         result = client.execute_prepared_request(prepared, client=external_client)
     assert result == {"result": "OK"}
@@ -125,10 +129,10 @@ def test_request_json_payload_allow_text_sync() -> None:
     Allow plain-text success payload when explicitly requested.
     """
 
-    def responder(_request: httpx.Request) -> httpx.Response:
-        return httpx.Response(200, text="ok")
+    def responder(_request: httpx2.Request) -> httpx2.Response:
+        return httpx2.Response(200, text="ok")
 
-    client = _SyncBaseClient(httpx.MockTransport(responder))
+    client = _SyncBaseClient(httpx2.MockTransport(responder))
     result = client._request("GET", "/api/test", allow_text=True)
     assert result == "ok"
 
@@ -138,16 +142,16 @@ def test_api_request_uses_client_session_sync() -> None:
     Exposes raw API requests through the same client session.
     """
 
-    def responder(request: httpx.Request) -> httpx.Response:
+    def responder(request: httpx2.Request) -> httpx2.Response:
         assert request.url.path == "/api/custom"
         assert request.headers["x-session-id"] == "bar-1"
         assert json.loads(request.content) == {
             "value": 1,
             "application_name": "app",
         }
-        return httpx.Response(200, json={"result": "OK"})
+        return httpx2.Response(200, json={"result": "OK"})
 
-    client = _SyncBaseClient(httpx.MockTransport(responder))
+    client = _SyncBaseClient(httpx2.MockTransport(responder))
     result = client.api_request(
         "POST",
         "/api/custom",
@@ -163,12 +167,12 @@ def test_request_applies_common_session_and_application_name_sync() -> None:
     Adds shared request context as session header and application query param.
     """
 
-    def responder(request: httpx.Request) -> httpx.Response:
+    def responder(request: httpx2.Request) -> httpx2.Response:
         assert request.headers["x-session-id"] == "bar-1"
         assert dict(request.url.params) == {"application_name": "app"}
-        return httpx.Response(200, json={"result": "OK"})
+        return httpx2.Response(200, json={"result": "OK"})
 
-    client = _SyncBaseClient(httpx.MockTransport(responder))
+    client = _SyncBaseClient(httpx2.MockTransport(responder))
     result = client._request(
         "GET",
         "/api/test",
@@ -187,11 +191,11 @@ def test_request_generates_request_id_sync(
 
     monkeypatch.setattr(uuid, "uuid4", lambda: uuid.UUID(int=1))
 
-    def responder(request: httpx.Request) -> httpx.Response:
+    def responder(request: httpx2.Request) -> httpx2.Response:
         assert request.headers["x-request-id"] == uuid.UUID(int=1).hex
-        return httpx.Response(200, json={"result": "OK"})
+        return httpx2.Response(200, json={"result": "OK"})
 
-    client = _SyncBaseClient(httpx.MockTransport(responder))
+    client = _SyncBaseClient(httpx2.MockTransport(responder))
     result = client._request("GET", "/api/test")
     assert result == {"result": "OK"}
 
@@ -201,11 +205,11 @@ def test_request_preserves_caller_request_id_sync() -> None:
     Keeps caller-provided X-Request-ID instead of generating a new value.
     """
 
-    def responder(request: httpx.Request) -> httpx.Response:
+    def responder(request: httpx2.Request) -> httpx2.Response:
         assert request.headers["x-request-id"] == "caller-rid"
-        return httpx.Response(200, json={"result": "OK"})
+        return httpx2.Response(200, json={"result": "OK"})
 
-    client = _SyncBaseClient(httpx.MockTransport(responder))
+    client = _SyncBaseClient(httpx2.MockTransport(responder))
     result = client._request(
         "GET",
         "/api/test",
@@ -223,10 +227,10 @@ def test_request_uses_generated_request_id_in_api_error_sync(
 
     monkeypatch.setattr(uuid, "uuid4", lambda: uuid.UUID(int=2))
 
-    def responder(_request: httpx.Request) -> httpx.Response:
-        return httpx.Response(400, json={"error": "bad request"})
+    def responder(_request: httpx2.Request) -> httpx2.Response:
+        return httpx2.Response(400, json={"error": "bad request"})
 
-    client = _SyncBaseClient(httpx.MockTransport(responder))
+    client = _SyncBaseClient(httpx2.MockTransport(responder))
     with pytest.raises(exceptions.BusyBarAPIError) as exc:
         client._request("POST", "/api/test", json_payload={"x": 1})
     assert exc.value.request_id == uuid.UUID(int=2).hex
@@ -241,10 +245,10 @@ def test_request_uses_generated_request_id_in_transport_error_sync(
 
     monkeypatch.setattr(uuid, "uuid4", lambda: uuid.UUID(int=3))
 
-    def responder(request: httpx.Request) -> httpx.Response:
-        raise httpx.ConnectError("boom", request=request)
+    def responder(request: httpx2.Request) -> httpx2.Response:
+        raise httpx2.ConnectError("boom", request=request)
 
-    client = _SyncBaseClient(httpx.MockTransport(responder))
+    client = _SyncBaseClient(httpx2.MockTransport(responder))
     with pytest.raises(exceptions.BusyBarRequestError) as exc:
         client._request("GET", "/api/fail")
     assert exc.value.request_id == uuid.UUID(int=3).hex
@@ -255,14 +259,14 @@ def test_request_applies_application_name_to_json_sync() -> None:
     Adds application_name to JSON payload for mutating object requests.
     """
 
-    def responder(request: httpx.Request) -> httpx.Response:
+    def responder(request: httpx2.Request) -> httpx2.Response:
         assert json.loads(request.content) == {
             "path": "/ext/app.wav",
             "application_name": "app",
         }
-        return httpx.Response(200, json={"result": "OK"})
+        return httpx2.Response(200, json={"result": "OK"})
 
-    client = _SyncBaseClient(httpx.MockTransport(responder))
+    client = _SyncBaseClient(httpx2.MockTransport(responder))
     result = client._request(
         "POST",
         "/api/test",
@@ -277,12 +281,12 @@ def test_request_keeps_application_name_in_params_for_binary_post_sync() -> None
     Adds application_name to query params when POST has no object JSON body.
     """
 
-    def responder(request: httpx.Request) -> httpx.Response:
+    def responder(request: httpx2.Request) -> httpx2.Response:
         assert dict(request.url.params) == {"application_name": "app"}
         assert request.content == b"payload"
-        return httpx.Response(200, json={"result": "OK"})
+        return httpx2.Response(200, json={"result": "OK"})
 
-    client = _SyncBaseClient(httpx.MockTransport(responder))
+    client = _SyncBaseClient(httpx2.MockTransport(responder))
     result = client._request(
         "POST",
         "/api/test",
@@ -297,10 +301,10 @@ def test_request_expect_bytes_sync() -> None:
     Return raw bytes when expect_bytes is True.
     """
 
-    def responder(_request: httpx.Request) -> httpx.Response:
-        return httpx.Response(200, content=b"bin")
+    def responder(_request: httpx2.Request) -> httpx2.Response:
+        return httpx2.Response(200, content=b"bin")
 
-    client = _SyncBaseClient(httpx.MockTransport(responder))
+    client = _SyncBaseClient(httpx2.MockTransport(responder))
     result = client._request("GET", "/api/bin", expect_bytes=True)
     assert result == b"bin"
 
@@ -310,10 +314,10 @@ def test_request_transport_error_sync() -> None:
     Convert transport errors into BusyBarRequestError when retries are exhausted.
     """
 
-    def responder(request: httpx.Request) -> httpx.Response:
-        raise httpx.ConnectError("boom", request=request)
+    def responder(request: httpx2.Request) -> httpx2.Response:
+        raise httpx2.ConnectError("boom", request=request)
 
-    client = _SyncBaseClient(httpx.MockTransport(responder))
+    client = _SyncBaseClient(httpx2.MockTransport(responder))
     with pytest.raises(exceptions.BusyBarRequestError) as exc:
         client._request("GET", "/api/fail")
     assert exc.value.method == "GET"
@@ -328,11 +332,11 @@ def test_cloud_mode_sets_bearer_header() -> None:
     This keeps cloud traffic on the Authorization header.
     """
 
-    def responder(request: httpx.Request) -> httpx.Response:
+    def responder(request: httpx2.Request) -> httpx2.Response:
         assert request.headers.get("authorization") == "Bearer token"
-        return httpx.Response(200, json={"result": "OK"})
+        return httpx2.Response(200, json={"result": "OK"})
 
-    transport = httpx.MockTransport(responder)
+    transport = httpx2.MockTransport(responder)
     client = base.SyncClientBase(
         addr=None,
         token="token",
@@ -352,13 +356,13 @@ def test_local_available_uses_base_url(monkeypatch: pytest.MonkeyPatch) -> None:
     This avoids mixing current client base_url with local probing.
     """
 
-    def responder(request: httpx.Request) -> httpx.Response:
+    def responder(request: httpx2.Request) -> httpx2.Response:
         assert str(request.url) == "http://device.local/api/version"
         assert request.headers.get("x-api-token") == "token"
-        return httpx.Response(200, json={"api_semver": "2.0.0"})
+        return httpx2.Response(200, json={"api_semver": "2.0.0"})
 
     monkeypatch.setattr(settings, "base_url", "http://device.local")
-    transport = httpx.MockTransport(responder)
+    transport = httpx2.MockTransport(responder)
     client = base.SyncClientBase(
         addr="http://other.local",
         token="token",
@@ -376,10 +380,10 @@ async def test_request_text_fallback_async() -> None:
     Validate async request raises protocol error when JSON decoding fails.
     """
 
-    async def responder(_request: httpx.Request) -> httpx.Response:
-        return httpx.Response(200, text="ok")
+    async def responder(_request: httpx2.Request) -> httpx2.Response:
+        return httpx2.Response(200, text="ok")
 
-    client = _AsyncBaseClient(httpx.MockTransport(responder))
+    client = _AsyncBaseClient(httpx2.MockTransport(responder))
     with pytest.raises(exceptions.BusyBarProtocolError):
         await client._request("GET", "/api/test")
     await client.aclose()
@@ -393,7 +397,9 @@ async def test_prepare_request_async_returns_serialized_payload() -> None:
     This verifies async request preparation works without network execution.
     """
     client = _AsyncBaseClient(
-        httpx.MockTransport(lambda _request: httpx.Response(200, json={"result": "OK"}))
+        httpx2.MockTransport(
+            lambda _request: httpx2.Response(200, json={"result": "OK"})
+        )
     )
     prepared = client.prepare_request(
         "POST",
@@ -420,22 +426,22 @@ async def test_execute_prepared_request_with_external_async_client() -> None:
     """
     seen: dict[str, object] = {}
 
-    async def responder(request: httpx.Request) -> httpx.Response:
+    async def responder(request: httpx2.Request) -> httpx2.Response:
         seen["url"] = str(request.url)
         seen["body"] = request.content.decode("utf-8")
-        return httpx.Response(200, json={"result": "OK"})
+        return httpx2.Response(200, json={"result": "OK"})
 
     client = _AsyncBaseClient(
-        httpx.MockTransport(lambda _request: httpx.Response(500, text="unused"))
+        httpx2.MockTransport(lambda _request: httpx2.Response(500, text="unused"))
     )
     prepared = client.prepare_request(
         "POST",
         "/api/test",
         json_payload={"value": 7},
     )
-    async with httpx.AsyncClient(
+    async with httpx2.AsyncClient(
         base_url="http://external.local",
-        transport=httpx.MockTransport(responder),
+        transport=httpx2.MockTransport(responder),
     ) as external_client:
         result = await client.execute_prepared_request(prepared, client=external_client)
     assert result == {"result": "OK"}
@@ -450,10 +456,10 @@ async def test_request_allow_text_async() -> None:
     Allow plain-text success payload in async mode when explicitly requested.
     """
 
-    async def responder(_request: httpx.Request) -> httpx.Response:
-        return httpx.Response(200, text="ok")
+    async def responder(_request: httpx2.Request) -> httpx2.Response:
+        return httpx2.Response(200, text="ok")
 
-    client = _AsyncBaseClient(httpx.MockTransport(responder))
+    client = _AsyncBaseClient(httpx2.MockTransport(responder))
     result = await client._request("GET", "/api/test", allow_text=True)
     assert result == "ok"
     await client.aclose()
@@ -465,16 +471,16 @@ async def test_api_request_uses_client_session_async() -> None:
     Exposes raw async API requests through the same client session.
     """
 
-    async def responder(request: httpx.Request) -> httpx.Response:
+    async def responder(request: httpx2.Request) -> httpx2.Response:
         assert request.url.path == "/api/custom"
         assert request.headers["x-session-id"] == "bar-2"
         assert json.loads(request.content) == {
             "value": 2,
             "application_name": "app",
         }
-        return httpx.Response(200, json={"result": "OK"})
+        return httpx2.Response(200, json={"result": "OK"})
 
-    client = _AsyncBaseClient(httpx.MockTransport(responder))
+    client = _AsyncBaseClient(httpx2.MockTransport(responder))
     result = await client.api_request(
         "POST",
         "/api/custom",
@@ -492,10 +498,10 @@ async def test_request_expect_bytes_async() -> None:
     Return raw bytes for async requests when expect_bytes is True.
     """
 
-    async def responder(_request: httpx.Request) -> httpx.Response:
-        return httpx.Response(200, content=b"bin")
+    async def responder(_request: httpx2.Request) -> httpx2.Response:
+        return httpx2.Response(200, content=b"bin")
 
-    client = _AsyncBaseClient(httpx.MockTransport(responder))
+    client = _AsyncBaseClient(httpx2.MockTransport(responder))
     result = await client._request("GET", "/api/bin", expect_bytes=True)
     assert result == b"bin"
     await client.aclose()
@@ -507,13 +513,13 @@ async def test_local_available_async(monkeypatch: pytest.MonkeyPatch) -> None:
     Ensure async local availability check hits the configured base URL.
     """
 
-    async def responder(request: httpx.Request) -> httpx.Response:
+    async def responder(request: httpx2.Request) -> httpx2.Response:
         assert str(request.url) == "http://device.local/api/version"
         assert request.headers.get("x-api-token") == "token"
-        return httpx.Response(200, json={"api_semver": "2.0.0"})
+        return httpx2.Response(200, json={"api_semver": "2.0.0"})
 
     monkeypatch.setattr(settings, "base_url", "http://device.local")
-    transport = httpx.MockTransport(responder)
+    transport = httpx2.MockTransport(responder)
     client = base.AsyncClientBase(
         addr="http://other.local",
         token="token",

--- a/tests/busylib/client/test_client.py
+++ b/tests/busylib/client/test_client.py
@@ -1,13 +1,13 @@
 import json
 from collections.abc import Callable
 
-import httpx
+import httpx2
 import pytest
 from pydantic import ValidationError
 
 from busylib import BusyBar, exceptions, types
 
-Responder = Callable[[httpx.Request], httpx.Response]
+Responder = Callable[[httpx2.Request], httpx2.Response]
 
 
 def make_client(responder: Responder, **kwargs) -> BusyBar:
@@ -16,7 +16,7 @@ def make_client(responder: Responder, **kwargs) -> BusyBar:
 
     Keeps transport setup consistent across tests.
     """
-    transport = httpx.MockTransport(responder)
+    transport = httpx2.MockTransport(responder)
     return BusyBar(addr="http://device.local", transport=transport, **kwargs)
 
 
@@ -28,7 +28,7 @@ def test_init_defaults_local():
     """
     client = BusyBar()
     assert client.base_url == "http://10.0.4.20"
-    assert client.client.base_url == httpx.URL("http://10.0.4.20")
+    assert client.client.base_url == httpx2.URL("http://10.0.4.20")
 
 
 def test_init_token_sets_cloud_base_and_header():
@@ -51,9 +51,9 @@ def test_version_success():
     Confirms the version and branch fields are mapped.
     """
 
-    def responder(request: httpx.Request) -> httpx.Response:
+    def responder(request: httpx2.Request) -> httpx2.Response:
         assert request.url.path == "/api/version"
-        return httpx.Response(
+        return httpx2.Response(
             200,
             json={
                 "api_semver": "1.2.0",
@@ -75,9 +75,9 @@ def test_version_default_api_version_remains_device_semver() -> None:
     """
     seen: dict[str, str | None] = {}
 
-    def responder(request: httpx.Request) -> httpx.Response:
+    def responder(request: httpx2.Request) -> httpx2.Response:
         seen["header"] = request.headers.get("x-busy-api-version")
-        return httpx.Response(200, json={"api_semver": "25.0.0"})
+        return httpx2.Response(200, json={"api_semver": "25.0.0"})
 
     client = make_client(responder)
     result = client.version()
@@ -93,12 +93,12 @@ def test_name_and_time():
     Verifies both responses are parsed correctly.
     """
 
-    def responder(request: httpx.Request) -> httpx.Response:
+    def responder(request: httpx2.Request) -> httpx2.Response:
         if request.url.path == "/api/name":
-            return httpx.Response(200, json={"name": "BusyBar"})
+            return httpx2.Response(200, json={"name": "BusyBar"})
         if request.url.path == "/api/time":
-            return httpx.Response(200, json={"timestamp": "2024-01-01T10:00:00"})
-        return httpx.Response(404, json={"error": "missing", "code": 404})
+            return httpx2.Response(200, json={"timestamp": "2024-01-01T10:00:00"})
+        return httpx2.Response(404, json={"error": "missing", "code": 404})
 
     client = make_client(responder)
     name = client.name()
@@ -113,11 +113,11 @@ def test_name_set() -> None:
     """
     seen: dict[str, object] = {}
 
-    def responder(request: httpx.Request) -> httpx.Response:
+    def responder(request: httpx2.Request) -> httpx2.Response:
         seen["path"] = request.url.path
         seen["method"] = request.method
         seen["body"] = json.loads(request.content)
-        return httpx.Response(200, json={"result": "OK"})
+        return httpx2.Response(200, json={"result": "OK"})
 
     client = make_client(responder)
     resp = client.name_set("Busy Desk")
@@ -131,7 +131,7 @@ def test_name_set_rejects_empty() -> None:
     """
     Reject empty device names before sending request.
     """
-    client = make_client(lambda _request: httpx.Response(200, json={"result": "OK"}))
+    client = make_client(lambda _request: httpx2.Response(200, json={"result": "OK"}))
     with pytest.raises(ValueError):
         client.name_set("")
 
@@ -141,9 +141,9 @@ def test_account_info():
     Parse linked account info from the client.
     """
 
-    def responder(request: httpx.Request) -> httpx.Response:
+    def responder(request: httpx2.Request) -> httpx2.Response:
         assert request.url.path == "/api/account/info"
-        return httpx.Response(200, json={"linked": True, "email": "name@example.com"})
+        return httpx2.Response(200, json={"linked": True, "email": "name@example.com"})
 
     client = make_client(responder)
     result = client.account_info()
@@ -156,9 +156,9 @@ def test_account_link():
     Parse account link response from the client.
     """
 
-    def responder(request: httpx.Request) -> httpx.Response:
+    def responder(request: httpx2.Request) -> httpx2.Response:
         assert request.url.path == "/api/account/link"
-        return httpx.Response(200, json={"code": "ABCD", "expires_at": 1700000000})
+        return httpx2.Response(200, json={"code": "ABCD", "expires_at": 1700000000})
 
     client = make_client(responder)
     result = client.account_link()
@@ -173,8 +173,8 @@ def test_error_response_raises_api_error():
     Ensures error payload is surfaced through the exception.
     """
 
-    def responder(request: httpx.Request) -> httpx.Response:
-        return httpx.Response(
+    def responder(request: httpx2.Request) -> httpx2.Response:
+        return httpx2.Response(
             500,
             json={"error": "fail", "code": 500},
             headers={"X-Request-ID": "req-500"},
@@ -197,9 +197,9 @@ def test_api_error_has_truncated_excerpt() -> None:
     Keep response excerpt compact for diagnostic fields in API errors.
     """
 
-    def responder(_request: httpx.Request) -> httpx.Response:
+    def responder(_request: httpx2.Request) -> httpx2.Response:
         long_text = "x" * 400
-        return httpx.Response(503, text=long_text)
+        return httpx2.Response(503, text=long_text)
 
     client = make_client(responder)
     with pytest.raises(exceptions.BusyBarAPIError) as exc:
@@ -216,8 +216,8 @@ def test_plain_text_error_response():
     Confirms non-JSON failures still propagate with HTTP status.
     """
 
-    def responder(request: httpx.Request) -> httpx.Response:
-        return httpx.Response(404, text="not found")
+    def responder(request: httpx2.Request) -> httpx2.Response:
+        return httpx2.Response(404, text="not found")
 
     client = make_client(responder)
     with pytest.raises(exceptions.BusyBarAPIError) as exc:
@@ -233,8 +233,8 @@ def test_version_incompatible_warns_by_default(
     Warn by default instead of blocking callers on API version mismatch.
     """
 
-    def responder(request: httpx.Request) -> httpx.Response:
-        return httpx.Response(200, json={"api_semver": "0.9.0"})
+    def responder(request: httpx2.Request) -> httpx2.Response:
+        return httpx2.Response(200, json={"api_semver": "0.9.0"})
 
     client = make_client(responder, api_version="1.0.0")
     result = client.version()
@@ -250,8 +250,8 @@ def test_version_incompatible_strict_requires_device_update():
     Ensures the version guard raises a dedicated error.
     """
 
-    def responder(request: httpx.Request) -> httpx.Response:
-        return httpx.Response(200, json={"api_semver": "0.9.0"})
+    def responder(request: httpx2.Request) -> httpx2.Response:
+        return httpx2.Response(200, json={"api_semver": "0.9.0"})
 
     client = make_client(
         responder,
@@ -268,8 +268,8 @@ def test_version_incompatible_can_skip_compatibility_check() -> None:
     Allow callers to opt out from compatibility checks.
     """
 
-    def responder(request: httpx.Request) -> httpx.Response:
-        return httpx.Response(200, json={"api_semver": "0.9.0"})
+    def responder(request: httpx2.Request) -> httpx2.Response:
+        return httpx2.Response(200, json={"api_semver": "0.9.0"})
 
     client = make_client(
         responder,
@@ -286,14 +286,14 @@ def test_client_rejects_unknown_compatibility_mode() -> None:
     Validate compatibility policy names at client construction.
     """
     with pytest.raises(ValueError):
-        make_client(lambda _request: httpx.Response(200), compatibility_mode="fail")
+        make_client(lambda _request: httpx2.Response(200), compatibility_mode="fail")
 
 
 def test_method_compatibility_metadata() -> None:
     """
     Expose declarative OpenAPI metadata for version-gated helpers.
     """
-    client = make_client(lambda _request: httpx.Response(200, json={"result": "OK"}))
+    client = make_client(lambda _request: httpx2.Response(200, json={"result": "OK"}))
     metadata = client.method_compatibility("log_dump")
 
     assert metadata == {
@@ -313,9 +313,9 @@ def test_log_dump_empty_body_returns_ok() -> None:
     """
     seen = {}
 
-    def responder(request: httpx.Request) -> httpx.Response:
+    def responder(request: httpx2.Request) -> httpx2.Response:
         seen["params"] = dict(request.url.params)
-        return httpx.Response(200)
+        return httpx2.Response(200)
 
     client = make_client(responder)
     result = client.log_dump(filename="dump")
@@ -332,9 +332,9 @@ def test_log_dump_no_filename_omits_params() -> None:
     """
     seen = {}
 
-    def responder(request: httpx.Request) -> httpx.Response:
+    def responder(request: httpx2.Request) -> httpx2.Response:
         seen["params"] = dict(request.url.params)
-        return httpx.Response(200, json={"result": "OK"})
+        return httpx2.Response(200, json={"result": "OK"})
 
     client = make_client(responder)
     result = client.log_dump()
@@ -350,7 +350,7 @@ def test_log_dump_rejects_legacy_path_kwarg() -> None:
     A caller still using the old keyword must fail loudly at the call site
     instead of getting an HTTP 400 from the device.
     """
-    client = make_client(lambda _request: httpx.Response(200, json={"result": "OK"}))
+    client = make_client(lambda _request: httpx2.Response(200, json={"result": "OK"}))
 
     with pytest.raises(TypeError):
         client.log_dump(path="/ext/dump.log")  # type: ignore[call-arg]
@@ -364,9 +364,9 @@ def test_request_carries_api_version_header():
     """
     seen = {}
 
-    def responder(request: httpx.Request) -> httpx.Response:
+    def responder(request: httpx2.Request) -> httpx2.Response:
         seen["header"] = request.headers.get("x-busy-api-version")
-        return httpx.Response(200, json={"result": "OK"})
+        return httpx2.Response(200, json={"result": "OK"})
 
     client = make_client(responder, api_version="1.1.0")
     resp = client.wifi_disconnect()
@@ -382,11 +382,11 @@ def test_retry_on_transport_error():
     """
     calls = {"count": 0}
 
-    def responder(request: httpx.Request) -> httpx.Response:
+    def responder(request: httpx2.Request) -> httpx2.Response:
         calls["count"] += 1
         if calls["count"] == 1:
-            raise httpx.ConnectError("boom", request=request)
-        return httpx.Response(200, json={"result": "OK"})
+            raise httpx2.ConnectError("boom", request=request)
+        return httpx2.Response(200, json={"result": "OK"})
 
     client = make_client(responder, max_retries=1, backoff=0.0)
     resp = client.wifi_disconnect()
@@ -399,9 +399,9 @@ def test_response_validation_error_is_wrapped() -> None:
     Wrap model validation failures into BusyBarResponseValidationError.
     """
 
-    def responder(request: httpx.Request) -> httpx.Response:
+    def responder(request: httpx2.Request) -> httpx2.Response:
         assert request.url.path == "/api/version"
-        return httpx.Response(
+        return httpx2.Response(
             200,
             json={"api_semver": "1.2.0", "build_date": {"invalid": True}},
         )
@@ -490,11 +490,11 @@ def test_display_draw_sends_utf8_body():
         ],
     }
 
-    def responder(request: httpx.Request) -> httpx.Response:
+    def responder(request: httpx2.Request) -> httpx2.Response:
         assert request.headers["content-type"].startswith("application/json")
         body = request.content.decode("utf-8")
         assert "Cafe creme" in body  # ensure ensure_ascii=False
-        return httpx.Response(200, json={"result": "OK"})
+        return httpx2.Response(200, json={"result": "OK"})
 
     client = make_client(responder)
     resp = client.display_draw(payload)
@@ -508,7 +508,7 @@ def test_display_draw_and_clear_params() -> None:
 
     seen: list[dict[str, object]] = []
 
-    def responder(request: httpx.Request) -> httpx.Response:
+    def responder(request: httpx2.Request) -> httpx2.Response:
         seen.append(
             {
                 "path": request.url.path,
@@ -517,7 +517,7 @@ def test_display_draw_and_clear_params() -> None:
                 "session": request.headers.get("x-session-id"),
             }
         )
-        return httpx.Response(200, json={"result": "OK"})
+        return httpx2.Response(200, json={"result": "OK"})
 
     client = make_client(responder)
     payload = {
@@ -549,9 +549,9 @@ def test_display_draw_can_clear_before_draw() -> None:
 
     seen: list[tuple[str, str, dict[str, str]]] = []
 
-    def responder(request: httpx.Request) -> httpx.Response:
+    def responder(request: httpx2.Request) -> httpx2.Response:
         seen.append((request.method, request.url.path, dict(request.url.params)))
-        return httpx.Response(200, json={"result": "OK"})
+        return httpx2.Response(200, json={"result": "OK"})
 
     client = make_client(responder)
     payload = {
@@ -577,7 +577,7 @@ def test_display_can_clear_draw_and_audio_play() -> None:
 
     seen: list[dict[str, object]] = []
 
-    def responder(request: httpx.Request) -> httpx.Response:
+    def responder(request: httpx2.Request) -> httpx2.Response:
         seen.append(
             {
                 "method": request.method,
@@ -587,7 +587,7 @@ def test_display_can_clear_draw_and_audio_play() -> None:
                 "session": request.headers.get("x-session-id"),
             }
         )
-        return httpx.Response(200, json={"result": "OK"})
+        return httpx2.Response(200, json={"result": "OK"})
 
     client = make_client(responder)
     payload = {
@@ -650,10 +650,10 @@ def test_display_draw_can_sanitize_text_payload(caplog) -> None:
 
     seen: dict[str, str] = {}
 
-    def responder(request: httpx.Request) -> httpx.Response:
+    def responder(request: httpx2.Request) -> httpx2.Response:
         body = request.content.decode("utf-8")
         seen["body"] = body
-        return httpx.Response(200, json={"result": "OK"})
+        return httpx2.Response(200, json={"result": "OK"})
 
     client = make_client(responder)
     caplog.set_level("WARNING", logger="busylib.client.display")
@@ -692,10 +692,10 @@ def test_screen_returns_decoded_rgb_bytes():
     spec = display.get_display_spec(1)
     packed = bytes([0x21]) * ((spec.width * spec.height) // 2)
 
-    def responder(request: httpx.Request) -> httpx.Response:
+    def responder(request: httpx2.Request) -> httpx2.Response:
         assert request.url.path == "/api/screen"
         assert request.url.params["display"] == "1"
-        return httpx.Response(200, content=base64.b64encode(packed))
+        return httpx2.Response(200, content=base64.b64encode(packed))
 
     client = make_client(responder)
     data = client.screen(1)
@@ -710,8 +710,8 @@ def test_screen_raises_when_the_frame_cannot_be_decoded():
     base64 text as if it were pixels.
     """
 
-    def responder(_request: httpx.Request) -> httpx.Response:
-        return httpx.Response(200, content=b"\x00\x01\x02")
+    def responder(_request: httpx2.Request) -> httpx2.Response:
+        return httpx2.Response(200, content=b"\x00\x01\x02")
 
     client = make_client(responder)
     with pytest.raises(exceptions.BusyBarProtocolError, match="screen frame"):
@@ -729,9 +729,9 @@ def test_screen_accepts_a_display_spec():
     spec = display.get_display_spec(0)
     device_order = bytes([3, 2, 1]) * (spec.width * spec.height)
 
-    def responder(request: httpx.Request) -> httpx.Response:
+    def responder(request: httpx2.Request) -> httpx2.Response:
         assert request.url.params["display"] == "0"
-        return httpx.Response(200, content=base64.b64encode(device_order))
+        return httpx2.Response(200, content=base64.b64encode(device_order))
 
     client = make_client(responder)
     # Returned as RGB; the device orders the three bytes BGR.
@@ -760,9 +760,9 @@ def test_simple_success_methods(method: str, path: str):
     Covers a set of API methods with uniform response handling.
     """
 
-    def responder(request: httpx.Request) -> httpx.Response:
+    def responder(request: httpx2.Request) -> httpx2.Response:
         assert request.url.path == path
-        return httpx.Response(200, json={"result": "OK"})
+        return httpx2.Response(200, json={"result": "OK"})
 
     client = make_client(responder)
     func = getattr(client, method)
@@ -788,9 +788,9 @@ def test_wifi_connect_serialization():
     """
     seen = {}
 
-    def responder(request: httpx.Request) -> httpx.Response:
+    def responder(request: httpx2.Request) -> httpx2.Response:
         seen["body"] = json.loads(request.content)
-        return httpx.Response(200, json={"result": "OK"})
+        return httpx2.Response(200, json={"result": "OK"})
 
     cfg = {"ssid": "TestNetwork", "password": "secret", "security": "WPA2"}
     client = make_client(responder)
@@ -808,10 +808,10 @@ def test_display_brightness_validation_and_payload():
     """
     seen = {}
 
-    def responder(request: httpx.Request) -> httpx.Response:
+    def responder(request: httpx2.Request) -> httpx2.Response:
         seen["params"] = dict(request.url.params)
         seen["content"] = request.content
-        return httpx.Response(200, json={"result": "OK"})
+        return httpx2.Response(200, json={"result": "OK"})
 
     client = make_client(responder)
     resp = client.display_brightness_set("auto")
@@ -831,10 +831,10 @@ def test_audio_volume_set_params():
     """
     seen = {}
 
-    def responder(request: httpx.Request) -> httpx.Response:
+    def responder(request: httpx2.Request) -> httpx2.Response:
         seen["params"] = dict(request.url.params)
         seen["content"] = request.content
-        return httpx.Response(200, json={"result": "OK"})
+        return httpx2.Response(200, json={"result": "OK"})
 
     client = make_client(responder)
     resp = client.audio_volume_set(42.5)
@@ -852,9 +852,9 @@ def test_display_draw_color_serialization():
     """
     seen = {}
 
-    def responder(request: httpx.Request) -> httpx.Response:
+    def responder(request: httpx2.Request) -> httpx2.Response:
         seen["body"] = json.loads(request.content)
-        return httpx.Response(200, json={"result": "OK"})
+        return httpx2.Response(200, json={"result": "OK"})
 
     client = make_client(responder)
     elements: list[types.DisplayElement] = [
@@ -932,9 +932,9 @@ def test_display_draw_color_tuple_alpha():
     """
     seen = {}
 
-    def responder(request: httpx.Request) -> httpx.Response:
+    def responder(request: httpx2.Request) -> httpx2.Response:
         seen["body"] = json.loads(request.content)
-        return httpx.Response(200, json={"result": "OK"})
+        return httpx2.Response(200, json={"result": "OK"})
 
     client = make_client(responder)
     elements: list[types.DisplayElement] = [
@@ -972,9 +972,9 @@ def test_removed_endpoints_raise_instead_of_calling_the_device(method_name: str)
     """
     called: list[str] = []
 
-    def responder(request: httpx.Request) -> httpx.Response:
+    def responder(request: httpx2.Request) -> httpx2.Response:
         called.append(request.url.path)
-        return httpx.Response(404, json={"error": "Not Found"})
+        return httpx2.Response(404, json={"error": "Not Found"})
 
     client = make_client(responder)
     with pytest.raises(exceptions.BusyBarRemovedEndpointError) as exc:
@@ -988,7 +988,7 @@ def test_removed_endpoints_are_declared_in_compatibility_metadata():
     """
     `method_compatibility` reports the removal and what to use instead.
     """
-    client = make_client(lambda _r: httpx.Response(200, json={"result": "OK"}))
+    client = make_client(lambda _r: httpx2.Response(200, json={"result": "OK"}))
 
     metadata = client.method_compatibility("account_profile")
 

--- a/tests/busylib/client/test_client_async.py
+++ b/tests/busylib/client/test_client_async.py
@@ -1,6 +1,6 @@
 import json
 
-import httpx
+import httpx2
 import pytest
 
 from busylib import AsyncBusyBar, exceptions, types
@@ -12,7 +12,7 @@ def make_client(async_responder, **kwargs) -> AsyncBusyBar:
 
     Uses async responders without extra transport configuration.
     """
-    transport = httpx.MockTransport(async_responder)
+    transport = httpx2.MockTransport(async_responder)
     return AsyncBusyBar(addr="http://device.local", transport=transport, **kwargs)
 
 
@@ -24,9 +24,9 @@ async def test_version_success_async():
     Ensures the response is mapped to VersionInfo.
     """
 
-    async def responder(request: httpx.Request) -> httpx.Response:
+    async def responder(request: httpx2.Request) -> httpx2.Response:
         assert request.url.path == "/api/version"
-        return httpx.Response(200, json={"api_semver": "2.0.0", "branch": "dev"})
+        return httpx2.Response(200, json={"api_semver": "2.0.0", "branch": "dev"})
 
     client = make_client(responder, api_version="2.0.0")
     result = await client.version()
@@ -43,12 +43,12 @@ async def test_name_and_time_async():
     Confirms both endpoints return parsed models.
     """
 
-    async def responder(request: httpx.Request) -> httpx.Response:
+    async def responder(request: httpx2.Request) -> httpx2.Response:
         if request.url.path == "/api/name":
-            return httpx.Response(200, json={"name": "BusyBar"})
+            return httpx2.Response(200, json={"name": "BusyBar"})
         if request.url.path == "/api/time":
-            return httpx.Response(200, json={"timestamp": "2024-01-01T10:00:00"})
-        return httpx.Response(404, json={"error": "missing", "code": 404})
+            return httpx2.Response(200, json={"timestamp": "2024-01-01T10:00:00"})
+        return httpx2.Response(404, json={"error": "missing", "code": 404})
 
     client = make_client(responder)
     name = await client.name()
@@ -65,11 +65,11 @@ async def test_name_set_async() -> None:
     """
     seen: dict[str, object] = {}
 
-    async def responder(request: httpx.Request) -> httpx.Response:
+    async def responder(request: httpx2.Request) -> httpx2.Response:
         seen["path"] = request.url.path
         seen["method"] = request.method
         seen["body"] = json.loads(request.content)
-        return httpx.Response(200, json={"result": "OK"})
+        return httpx2.Response(200, json={"result": "OK"})
 
     client = make_client(responder)
     resp = await client.name_set("Busy Desk")
@@ -85,7 +85,7 @@ async def test_name_set_async_rejects_empty() -> None:
     """
     Reject empty device names before async request send.
     """
-    client = make_client(lambda _request: httpx.Response(200, json={"result": "OK"}))
+    client = make_client(lambda _request: httpx2.Response(200, json={"result": "OK"}))
     with pytest.raises(ValueError):
         await client.name_set("")
     await client.aclose()
@@ -97,9 +97,9 @@ async def test_account_info_async():
     Parse linked account info from the async client.
     """
 
-    async def responder(request: httpx.Request) -> httpx.Response:
+    async def responder(request: httpx2.Request) -> httpx2.Response:
         assert request.url.path == "/api/account/info"
-        return httpx.Response(200, json={"linked": False, "email": "name@example.com"})
+        return httpx2.Response(200, json={"linked": False, "email": "name@example.com"})
 
     client = make_client(responder)
     result = await client.account_info()
@@ -114,9 +114,9 @@ async def test_account_status_async():
     Parse MQTT account state from the async client.
     """
 
-    async def responder(request: httpx.Request) -> httpx.Response:
+    async def responder(request: httpx2.Request) -> httpx2.Response:
         assert request.url.path == "/api/account/status"
-        return httpx.Response(200, json={"state": "connected"})
+        return httpx2.Response(200, json={"state": "connected"})
 
     client = make_client(responder)
     result = await client.account_status()
@@ -130,9 +130,9 @@ async def test_account_link_async():
     Parse account link response from the async client.
     """
 
-    async def responder(request: httpx.Request) -> httpx.Response:
+    async def responder(request: httpx2.Request) -> httpx2.Response:
         assert request.url.path == "/api/account/link"
-        return httpx.Response(200, json={"code": "EFGH", "expires_at": 1700000001})
+        return httpx2.Response(200, json={"code": "EFGH", "expires_at": 1700000001})
 
     client = make_client(responder)
     result = await client.account_link()
@@ -150,11 +150,11 @@ async def test_async_retry_on_transport_error():
     """
     calls = {"count": 0}
 
-    async def responder(request: httpx.Request) -> httpx.Response:
+    async def responder(request: httpx2.Request) -> httpx2.Response:
         calls["count"] += 1
         if calls["count"] == 1:
-            raise httpx.ConnectError("fail", request=request)
-        return httpx.Response(200, json={"result": "OK"})
+            raise httpx2.ConnectError("fail", request=request)
+        return httpx2.Response(200, json={"result": "OK"})
 
     client = make_client(responder, max_retries=1, backoff=0.0)
     resp = await client.wifi_disconnect()
@@ -185,11 +185,11 @@ async def test_display_draw_utf8_async():
         ],
     }
 
-    async def responder(request: httpx.Request) -> httpx.Response:
+    async def responder(request: httpx2.Request) -> httpx2.Response:
         body = request.content.decode()
         assert "Café" in body
         assert "\\u00e9" not in body
-        return httpx.Response(200, json={"result": "OK"})
+        return httpx2.Response(200, json={"result": "OK"})
 
     client = make_client(responder)
     resp = await client.display_draw(payload)
@@ -205,7 +205,7 @@ async def test_display_draw_and_clear_params_async() -> None:
 
     seen: list[dict[str, object]] = []
 
-    async def responder(request: httpx.Request) -> httpx.Response:
+    async def responder(request: httpx2.Request) -> httpx2.Response:
         seen.append(
             {
                 "path": request.url.path,
@@ -214,7 +214,7 @@ async def test_display_draw_and_clear_params_async() -> None:
                 "session": request.headers.get("x-session-id"),
             }
         )
-        return httpx.Response(200, json={"result": "OK"})
+        return httpx2.Response(200, json={"result": "OK"})
 
     client = make_client(responder)
     payload = {
@@ -248,9 +248,9 @@ async def test_display_draw_can_clear_before_draw_async() -> None:
 
     seen: list[tuple[str, str, dict[str, str]]] = []
 
-    async def responder(request: httpx.Request) -> httpx.Response:
+    async def responder(request: httpx2.Request) -> httpx2.Response:
         seen.append((request.method, request.url.path, dict(request.url.params)))
-        return httpx.Response(200, json={"result": "OK"})
+        return httpx2.Response(200, json={"result": "OK"})
 
     client = make_client(responder)
     payload = {
@@ -278,7 +278,7 @@ async def test_display_can_clear_draw_and_audio_play_async() -> None:
 
     seen: list[dict[str, object]] = []
 
-    async def responder(request: httpx.Request) -> httpx.Response:
+    async def responder(request: httpx2.Request) -> httpx2.Response:
         seen.append(
             {
                 "method": request.method,
@@ -288,7 +288,7 @@ async def test_display_can_clear_draw_and_audio_play_async() -> None:
                 "session": request.headers.get("x-session-id"),
             }
         )
-        return httpx.Response(200, json={"result": "OK"})
+        return httpx2.Response(200, json={"result": "OK"})
 
     client = make_client(responder)
     payload = {
@@ -353,9 +353,9 @@ async def test_display_draw_can_sanitize_text_payload_async(caplog) -> None:
 
     seen: dict[str, str] = {}
 
-    async def responder(request: httpx.Request) -> httpx.Response:
+    async def responder(request: httpx2.Request) -> httpx2.Response:
         seen["body"] = request.content.decode("utf-8")
-        return httpx.Response(200, json={"result": "OK"})
+        return httpx2.Response(200, json={"result": "OK"})
 
     client = make_client(responder)
     caplog.set_level("WARNING", logger="busylib.client.display")
@@ -392,8 +392,8 @@ async def test_error_response_raises_api_error_async():
     Confirms JSON error payloads are surfaced.
     """
 
-    async def responder(request: httpx.Request) -> httpx.Response:
-        return httpx.Response(400, json={"error": "bad request", "code": 400})
+    async def responder(request: httpx2.Request) -> httpx2.Response:
+        return httpx2.Response(400, json={"error": "bad request", "code": 400})
 
     client = make_client(responder)
     with pytest.raises(exceptions.BusyBarAPIError):
@@ -410,10 +410,10 @@ async def test_async_display_brightness_set_params():
     """
     seen = {}
 
-    async def responder(request: httpx.Request) -> httpx.Response:
+    async def responder(request: httpx2.Request) -> httpx2.Response:
         seen["params"] = dict(request.url.params)
         seen["content"] = request.content
-        return httpx.Response(200, json={"result": "OK"})
+        return httpx2.Response(200, json={"result": "OK"})
 
     client = make_client(responder)
     resp = await client.display_brightness_set("auto")
@@ -433,9 +433,9 @@ async def test_async_log_dump_empty_body_returns_ok():
     """
     seen = {}
 
-    async def responder(request: httpx.Request) -> httpx.Response:
+    async def responder(request: httpx2.Request) -> httpx2.Response:
         seen["params"] = dict(request.url.params)
-        return httpx.Response(200)
+        return httpx2.Response(200)
 
     client = make_client(responder)
     result = await client.log_dump(filename="dump")
@@ -456,8 +456,8 @@ async def test_async_log_dump_rejects_legacy_path_kwarg():
     instead of getting an HTTP 400 from the device.
     """
 
-    async def responder(request: httpx.Request) -> httpx.Response:
-        return httpx.Response(200, json={"result": "OK"})
+    async def responder(request: httpx2.Request) -> httpx2.Response:
+        return httpx2.Response(200, json={"result": "OK"})
 
     client = make_client(responder)
     with pytest.raises(TypeError):

--- a/tests/busylib/client/test_client_mixins.py
+++ b/tests/busylib/client/test_client_mixins.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import base64
 
-import httpx
+import httpx2
 import pytest
 
 from busylib import AsyncBusyBar, BusyBar
@@ -15,7 +15,7 @@ def _make_sync_client(responder) -> BusyBar:
     """
     Build a BusyBar client with a mock transport responder.
     """
-    transport = httpx.MockTransport(responder)
+    transport = httpx2.MockTransport(responder)
     return BusyBar(addr="http://device.local", transport=transport)
 
 
@@ -23,7 +23,7 @@ def _make_async_client(responder) -> AsyncBusyBar:
     """
     Build an AsyncBusyBar client with a mock transport responder.
     """
-    transport = httpx.MockTransport(responder)
+    transport = httpx2.MockTransport(responder)
     return AsyncBusyBar(addr="http://device.local", transport=transport)
 
 
@@ -33,11 +33,11 @@ def test_assets_upload_and_delete_sync() -> None:
     """
     seen: dict[str, object] = {}
 
-    def responder(request: httpx.Request) -> httpx.Response:
+    def responder(request: httpx2.Request) -> httpx2.Response:
         seen["path"] = request.url.path
         seen["params"] = dict(request.url.params)
         seen["body"] = request.content
-        return httpx.Response(200, json={"result": "OK"})
+        return httpx2.Response(200, json={"result": "OK"})
 
     client = _make_sync_client(responder)
     resp = client.assets_upload("app", "file.bin", b"data")
@@ -57,7 +57,7 @@ def test_assets_upload_sync_uses_extended_timeout_by_default(
     Ensure sync asset upload passes the mixin default upload timeout.
     """
     client = _make_sync_client(
-        lambda _request: httpx.Response(200, json={"result": "OK"})
+        lambda _request: httpx2.Response(200, json={"result": "OK"})
     )
     captured: dict[str, object] = {}
 
@@ -81,7 +81,7 @@ def test_assets_upload_sync_allows_timeout_override(
     Ensure sync asset upload accepts an explicit timeout override.
     """
     client = _make_sync_client(
-        lambda _request: httpx.Response(200, json={"result": "OK"})
+        lambda _request: httpx2.Response(200, json={"result": "OK"})
     )
     captured: dict[str, object] = {}
 
@@ -105,7 +105,7 @@ async def test_assets_upload_and_delete_async() -> None:
     """
     seen: list[dict[str, object]] = []
 
-    async def responder(request: httpx.Request) -> httpx.Response:
+    async def responder(request: httpx2.Request) -> httpx2.Response:
         seen.append(
             {
                 "path": request.url.path,
@@ -113,7 +113,7 @@ async def test_assets_upload_and_delete_async() -> None:
                 "body": request.content,
             }
         )
-        return httpx.Response(200, json={"result": "OK"})
+        return httpx2.Response(200, json={"result": "OK"})
 
     client = _make_async_client(responder)
     resp = await client.assets_upload("app", "file.bin", b"data")
@@ -135,7 +135,7 @@ async def test_assets_upload_async_uses_extended_timeout_by_default(
     Ensure async asset upload passes the mixin default upload timeout.
     """
     client = _make_async_client(
-        lambda _request: httpx.Response(200, json={"result": "OK"})
+        lambda _request: httpx2.Response(200, json={"result": "OK"})
     )
     captured: dict[str, object] = {}
 
@@ -161,7 +161,7 @@ async def test_assets_upload_async_allows_timeout_override(
     Ensure async asset upload accepts an explicit timeout override.
     """
     client = _make_async_client(
-        lambda _request: httpx.Response(200, json={"result": "OK"})
+        lambda _request: httpx2.Response(200, json={"result": "OK"})
     )
     captured: dict[str, object] = {}
 
@@ -185,15 +185,15 @@ def test_ble_and_wifi_status_sync() -> None:
     """
     seen: list[str] = []
 
-    def responder(request: httpx.Request) -> httpx.Response:
+    def responder(request: httpx2.Request) -> httpx2.Response:
         seen.append(request.url.path)
         if request.url.path == "/api/ble/status":
-            return httpx.Response(200, json={"state": "on"})
+            return httpx2.Response(200, json={"state": "on"})
         if request.url.path == "/api/wifi/status":
-            return httpx.Response(200, json={"state": "connected", "ssid": "Test"})
+            return httpx2.Response(200, json={"state": "connected", "ssid": "Test"})
         if request.url.path == "/api/wifi/networks":
-            return httpx.Response(200, json={"count": 0, "networks": []})
-        return httpx.Response(200, json={"result": "OK"})
+            return httpx2.Response(200, json={"count": 0, "networks": []})
+        return httpx2.Response(200, json={"result": "OK"})
 
     client = _make_sync_client(responder)
     ble = client.ble_status()
@@ -211,13 +211,13 @@ def test_access_mode_sync() -> None:
     """
     seen: list[dict[str, object]] = []
 
-    def responder(request: httpx.Request) -> httpx.Response:
+    def responder(request: httpx2.Request) -> httpx2.Response:
         seen.append({"path": request.url.path, "params": dict(request.url.params)})
         if request.url.path == "/api/access":
             if request.method == "GET":
-                return httpx.Response(200, json={"mode": "key", "key_valid": True})
-            return httpx.Response(200, json={"result": "OK"})
-        return httpx.Response(200, json={"result": "OK"})
+                return httpx2.Response(200, json={"mode": "key", "key_valid": True})
+            return httpx2.Response(200, json={"result": "OK"})
+        return httpx2.Response(200, json={"result": "OK"})
 
     client = _make_sync_client(responder)
     info = client.access()
@@ -237,11 +237,11 @@ def test_busy_snapshot_sync() -> None:
     """
     seen: list[dict[str, object]] = []
 
-    def responder(request: httpx.Request) -> httpx.Response:
+    def responder(request: httpx2.Request) -> httpx2.Response:
         seen.append({"path": request.url.path, "body": request.content})
         if request.url.path == "/api/busy/snapshot":
             if request.method == "GET":
-                return httpx.Response(
+                return httpx2.Response(
                     200,
                     json={
                         "snapshot": {
@@ -253,8 +253,8 @@ def test_busy_snapshot_sync() -> None:
                         "snapshot_timestamp_ms": 123,
                     },
                 )
-            return httpx.Response(200, json={"result": "OK"})
-        return httpx.Response(200, json={"result": "OK"})
+            return httpx2.Response(200, json={"result": "OK"})
+        return httpx2.Response(200, json={"result": "OK"})
 
     client = _make_sync_client(responder)
     snapshot = client.busy_snapshot()
@@ -276,15 +276,15 @@ async def test_ble_and_wifi_status_async() -> None:
     """
     seen: list[str] = []
 
-    async def responder(request: httpx.Request) -> httpx.Response:
+    async def responder(request: httpx2.Request) -> httpx2.Response:
         seen.append(request.url.path)
         if request.url.path == "/api/ble/status":
-            return httpx.Response(200, json={"state": "on"})
+            return httpx2.Response(200, json={"state": "on"})
         if request.url.path == "/api/wifi/status":
-            return httpx.Response(200, json={"state": "connected", "ssid": "Test"})
+            return httpx2.Response(200, json={"state": "connected", "ssid": "Test"})
         if request.url.path == "/api/wifi/networks":
-            return httpx.Response(200, json={"count": 0, "networks": []})
-        return httpx.Response(200, json={"result": "OK"})
+            return httpx2.Response(200, json={"count": 0, "networks": []})
+        return httpx2.Response(200, json={"result": "OK"})
 
     client = _make_async_client(responder)
     ble = await client.ble_status()
@@ -304,13 +304,13 @@ async def test_access_mode_async() -> None:
     """
     seen: list[dict[str, object]] = []
 
-    async def responder(request: httpx.Request) -> httpx.Response:
+    async def responder(request: httpx2.Request) -> httpx2.Response:
         seen.append({"path": request.url.path, "params": dict(request.url.params)})
         if request.url.path == "/api/access":
             if request.method == "GET":
-                return httpx.Response(200, json={"mode": "key", "key_valid": True})
-            return httpx.Response(200, json={"result": "OK"})
-        return httpx.Response(200, json={"result": "OK"})
+                return httpx2.Response(200, json={"mode": "key", "key_valid": True})
+            return httpx2.Response(200, json={"result": "OK"})
+        return httpx2.Response(200, json={"result": "OK"})
 
     client = _make_async_client(responder)
     info = await client.access()
@@ -332,11 +332,11 @@ async def test_busy_snapshot_async() -> None:
     """
     seen: list[dict[str, object]] = []
 
-    async def responder(request: httpx.Request) -> httpx.Response:
+    async def responder(request: httpx2.Request) -> httpx2.Response:
         seen.append({"path": request.url.path, "body": request.content})
         if request.url.path == "/api/busy/snapshot":
             if request.method == "GET":
-                return httpx.Response(
+                return httpx2.Response(
                     200,
                     json={
                         "snapshot": {
@@ -348,8 +348,8 @@ async def test_busy_snapshot_async() -> None:
                         "snapshot_timestamp_ms": 123,
                     },
                 )
-            return httpx.Response(200, json={"result": "OK"})
-        return httpx.Response(200, json={"result": "OK"})
+            return httpx2.Response(200, json={"result": "OK"})
+        return httpx2.Response(200, json={"result": "OK"})
 
     client = _make_async_client(responder)
     snapshot = await client.busy_snapshot()
@@ -371,10 +371,10 @@ def test_updater_update_sync() -> None:
     """
     seen: dict[str, object] = {}
 
-    def responder(request: httpx.Request) -> httpx.Response:
+    def responder(request: httpx2.Request) -> httpx2.Response:
         seen["params"] = dict(request.url.params)
         seen["body"] = request.content
-        return httpx.Response(200, json={"result": "OK"})
+        return httpx2.Response(200, json={"result": "OK"})
 
     client = _make_sync_client(responder)
     resp = client.update(b"fw")
@@ -389,9 +389,9 @@ def test_time_endpoints_sync() -> None:
     """
     seen: list[dict[str, object]] = []
 
-    def responder(request: httpx.Request) -> httpx.Response:
+    def responder(request: httpx2.Request) -> httpx2.Response:
         seen.append({"path": request.url.path, "params": dict(request.url.params)})
-        return httpx.Response(200, json={"result": "OK"})
+        return httpx2.Response(200, json={"result": "OK"})
 
     client = _make_sync_client(responder)
     resp = client.time_timestamp("2025-10-02T14:30:45+04:00")
@@ -413,10 +413,10 @@ async def test_updater_update_async() -> None:
     Ensure async firmware update omits params.
     """
 
-    async def responder(request: httpx.Request) -> httpx.Response:
+    async def responder(request: httpx2.Request) -> httpx2.Response:
         assert dict(request.url.params) == {}
         assert request.content == b"fw"
-        return httpx.Response(200, json={"result": "OK"})
+        return httpx2.Response(200, json={"result": "OK"})
 
     client = _make_async_client(responder)
     resp = await client.update(b"fw")
@@ -431,9 +431,9 @@ async def test_time_endpoints_async() -> None:
     """
     seen: list[dict[str, object]] = []
 
-    async def responder(request: httpx.Request) -> httpx.Response:
+    async def responder(request: httpx2.Request) -> httpx2.Response:
         seen.append({"path": request.url.path, "params": dict(request.url.params)})
-        return httpx.Response(200, json={"result": "OK"})
+        return httpx2.Response(200, json={"result": "OK"})
 
     client = _make_async_client(responder)
     resp = await client.time_timestamp("2025-10-02T14:30:45+04:00")
@@ -456,14 +456,14 @@ def test_updater_check_status_and_changelog_sync() -> None:
     """
     seen: list[str] = []
 
-    def responder(request: httpx.Request) -> httpx.Response:
+    def responder(request: httpx2.Request) -> httpx2.Response:
         seen.append(request.url.path)
         if request.url.path == "/api/update/status":
-            return httpx.Response(200, json={"install": {"status": "ok"}})
+            return httpx2.Response(200, json={"install": {"status": "ok"}})
         if request.url.path == "/api/update/changelog":
             assert dict(request.url.params) == {"version": "1.2.3"}
-            return httpx.Response(200, json={"changelog": "Fixes"})
-        return httpx.Response(200, json={"result": "OK"})
+            return httpx2.Response(200, json={"changelog": "Fixes"})
+        return httpx2.Response(200, json={"result": "OK"})
 
     client = _make_sync_client(responder)
     resp = client.update_check()
@@ -492,14 +492,14 @@ async def test_updater_check_status_and_changelog_async() -> None:
     """
     seen: list[str] = []
 
-    async def responder(request: httpx.Request) -> httpx.Response:
+    async def responder(request: httpx2.Request) -> httpx2.Response:
         seen.append(request.url.path)
         if request.url.path == "/api/update/status":
-            return httpx.Response(200, json={"check": {"result": "available"}})
+            return httpx2.Response(200, json={"check": {"result": "available"}})
         if request.url.path == "/api/update/changelog":
             assert dict(request.url.params) == {"version": "2.0.0"}
-            return httpx.Response(200, json={"changelog": "New"})
-        return httpx.Response(200, json={"result": "OK"})
+            return httpx2.Response(200, json={"changelog": "New"})
+        return httpx2.Response(200, json={"result": "OK"})
 
     client = _make_async_client(responder)
     resp = await client.update_check()

--- a/tests/busylib/client/test_input.py
+++ b/tests/busylib/client/test_input.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-import httpx
+import httpx2
 import pytest
 
 from busylib import AsyncBusyBar, BusyBar, types
@@ -10,7 +10,7 @@ def _make_sync_client(responder) -> BusyBar:
     """
     Build a BusyBar client with a mock transport responder.
     """
-    transport = httpx.MockTransport(responder)
+    transport = httpx2.MockTransport(responder)
     return BusyBar(addr="http://device.local", transport=transport)
 
 
@@ -18,7 +18,7 @@ def _make_async_client(responder) -> AsyncBusyBar:
     """
     Build an AsyncBusyBar client with a mock transport responder.
     """
-    transport = httpx.MockTransport(responder)
+    transport = httpx2.MockTransport(responder)
     return AsyncBusyBar(addr="http://device.local", transport=transport)
 
 
@@ -28,7 +28,7 @@ def test_input_sync() -> None:
     """
     seen: list[dict[str, object]] = []
 
-    def responder(request: httpx.Request) -> httpx.Response:
+    def responder(request: httpx2.Request) -> httpx2.Response:
         seen.append(
             {
                 "path": request.url.path,
@@ -36,7 +36,7 @@ def test_input_sync() -> None:
                 "method": request.method,
             }
         )
-        return httpx.Response(200, json={"result": "OK"})
+        return httpx2.Response(200, json={"result": "OK"})
 
     client = _make_sync_client(responder)
     resp = client.input(types.InputKey.OK)
@@ -51,7 +51,7 @@ async def test_input_async() -> None:
     """
     seen: list[dict[str, object]] = []
 
-    async def responder(request: httpx.Request) -> httpx.Response:
+    async def responder(request: httpx2.Request) -> httpx2.Response:
         seen.append(
             {
                 "path": request.url.path,
@@ -59,7 +59,7 @@ async def test_input_async() -> None:
                 "method": request.method,
             }
         )
-        return httpx.Response(200, json={"result": "OK"})
+        return httpx2.Response(200, json={"result": "OK"})
 
     client = _make_async_client(responder)
     resp = await client.input(types.InputKey.OK)

--- a/tests/busylib/client/test_openapi_sync.py
+++ b/tests/busylib/client/test_openapi_sync.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import json
 
-import httpx
+import httpx2
 import pytest
 
 from busylib import AsyncBusyBar, BusyBar, exceptions, types
@@ -12,7 +12,7 @@ def _make_sync_client(responder) -> BusyBar:
     """
     Build a sync client with a mock transport responder.
     """
-    transport = httpx.MockTransport(responder)
+    transport = httpx2.MockTransport(responder)
     return BusyBar(addr="http://device.local", transport=transport)
 
 
@@ -20,7 +20,7 @@ def _make_async_client(responder) -> AsyncBusyBar:
     """
     Build an async client with a mock transport responder.
     """
-    transport = httpx.MockTransport(responder)
+    transport = httpx2.MockTransport(responder)
     return AsyncBusyBar(addr="http://device.local", transport=transport)
 
 
@@ -48,7 +48,7 @@ def test_account_backend_sync_requests_match_openapi() -> None:
     """
     seen: list[dict[str, object]] = []
 
-    def responder(request: httpx.Request) -> httpx.Response:
+    def responder(request: httpx2.Request) -> httpx2.Response:
         seen.append(
             {
                 "method": request.method,
@@ -57,7 +57,7 @@ def test_account_backend_sync_requests_match_openapi() -> None:
             }
         )
         if request.method == "GET":
-            return httpx.Response(
+            return httpx2.Response(
                 200,
                 json={
                     "server_url": "default",
@@ -65,7 +65,7 @@ def test_account_backend_sync_requests_match_openapi() -> None:
                     "ignore_server_cert": False,
                 },
             )
-        return httpx.Response(200, json={"result": "OK"})
+        return httpx2.Response(200, json={"result": "OK"})
 
     client = _make_sync_client(responder)
     backend = client.account_backend()
@@ -97,7 +97,7 @@ def test_busy_profile_sync_requests_match_openapi() -> None:
     """
     seen: list[dict[str, object]] = []
 
-    def responder(request: httpx.Request) -> httpx.Response:
+    def responder(request: httpx2.Request) -> httpx2.Response:
         seen.append(
             {
                 "method": request.method,
@@ -106,8 +106,8 @@ def test_busy_profile_sync_requests_match_openapi() -> None:
             }
         )
         if request.method == "GET":
-            return httpx.Response(200, json=_busy_profile_payload())
-        return httpx.Response(200, json={"result": "OK"})
+            return httpx2.Response(200, json=_busy_profile_payload())
+        return httpx2.Response(200, json={"result": "OK"})
 
     client = _make_sync_client(responder)
     profile = client.busy_profile("busy")
@@ -133,7 +133,7 @@ def test_system_time_update_and_storage_endpoints_match_openapi() -> None:
     """
     seen: list[dict[str, object]] = []
 
-    def responder(request: httpx.Request) -> httpx.Response:
+    def responder(request: httpx2.Request) -> httpx2.Response:
         seen.append(
             {
                 "method": request.method,
@@ -143,9 +143,9 @@ def test_system_time_update_and_storage_endpoints_match_openapi() -> None:
             }
         )
         if request.url.path == "/api/transport":
-            return httpx.Response(200, json={"type": "wifi"})
+            return httpx2.Response(200, json={"type": "wifi"})
         if request.url.path == "/api/status/device":
-            return httpx.Response(
+            return httpx2.Response(
                 200,
                 json={
                     "serial_number": "203638485431500400123456",
@@ -155,7 +155,7 @@ def test_system_time_update_and_storage_endpoints_match_openapi() -> None:
                 },
             )
         if request.url.path == "/api/status/firmware":
-            return httpx.Response(
+            return httpx2.Response(
                 200,
                 json={
                     "version": "1.0.0",
@@ -167,17 +167,17 @@ def test_system_time_update_and_storage_endpoints_match_openapi() -> None:
                 },
             )
         if request.url.path == "/api/time/timezone" and request.method == "GET":
-            return httpx.Response(
+            return httpx2.Response(
                 200,
                 json={"name": "Bangalore", "offset": "+05:30", "abbr": "IST"},
             )
         if request.url.path == "/api/time/tzlist":
-            return httpx.Response(
+            return httpx2.Response(
                 200,
                 json={"list": [{"name": "UTC", "offset": "+00:00", "abbr": "UTC"}]},
             )
         if request.url.path == "/api/update/autoupdate" and request.method == "GET":
-            return httpx.Response(
+            return httpx2.Response(
                 200,
                 json={
                     "is_enabled": True,
@@ -186,11 +186,11 @@ def test_system_time_update_and_storage_endpoints_match_openapi() -> None:
                 },
             )
         if request.url.path == "/api/log_dump":
-            return httpx.Response(
+            return httpx2.Response(
                 200,
                 json={"result": "OK", "path": "/ext/dump.txt"},
             )
-        return httpx.Response(200, json={"result": "OK"})
+        return httpx2.Response(200, json={"result": "OK"})
 
     client = _make_sync_client(responder)
     assert client.transport().type == "wifi"
@@ -243,7 +243,7 @@ def test_display_rectangle_payload_matches_openapi() -> None:
     """
     seen: list[dict[str, object]] = []
 
-    def responder(request: httpx.Request) -> httpx.Response:
+    def responder(request: httpx2.Request) -> httpx2.Response:
         seen.append(
             {
                 "method": request.method,
@@ -251,7 +251,7 @@ def test_display_rectangle_payload_matches_openapi() -> None:
                 "body": request.content,
             }
         )
-        return httpx.Response(200, json={"result": "OK"})
+        return httpx2.Response(200, json={"result": "OK"})
 
     client = _make_sync_client(responder)
     response = client.display_draw(
@@ -410,7 +410,7 @@ def test_smart_home_sync_requests_match_openapi() -> None:
     """
     seen: list[dict[str, object]] = []
 
-    def responder(request: httpx.Request) -> httpx.Response:
+    def responder(request: httpx2.Request) -> httpx2.Response:
         seen.append(
             {
                 "method": request.method,
@@ -419,7 +419,7 @@ def test_smart_home_sync_requests_match_openapi() -> None:
             }
         )
         if request.url.path == "/api/smart_home/pairing" and request.method == "GET":
-            return httpx.Response(
+            return httpx2.Response(
                 200,
                 json={
                     "fabric_count": 1,
@@ -430,7 +430,7 @@ def test_smart_home_sync_requests_match_openapi() -> None:
                 },
             )
         if request.url.path == "/api/smart_home/pairing" and request.method == "POST":
-            return httpx.Response(
+            return httpx2.Response(
                 200,
                 json={
                     "available_until": "1769437579000",
@@ -439,8 +439,8 @@ def test_smart_home_sync_requests_match_openapi() -> None:
                 },
             )
         if request.url.path == "/api/smart_home/switch" and request.method == "GET":
-            return httpx.Response(200, json={"state": False})
-        return httpx.Response(200, json={"result": "OK"})
+            return httpx2.Response(200, json={"state": False})
+        return httpx2.Response(200, json={"result": "OK"})
 
     client = _make_sync_client(responder)
     assert client.smart_home_pairing().fabric_count == 1
@@ -468,10 +468,10 @@ async def test_async_new_openapi_helpers() -> None:
     """
     seen: list[str] = []
 
-    async def responder(request: httpx.Request) -> httpx.Response:
+    async def responder(request: httpx2.Request) -> httpx2.Response:
         seen.append(f"{request.method} {request.url.path}")
         if request.url.path == "/api/account/backend":
-            return httpx.Response(
+            return httpx2.Response(
                 200,
                 json={
                     "server_url": "default",
@@ -480,12 +480,12 @@ async def test_async_new_openapi_helpers() -> None:
                 },
             )
         if request.url.path == "/api/busy/profiles/busy":
-            return httpx.Response(200, json=_busy_profile_payload())
+            return httpx2.Response(200, json=_busy_profile_payload())
         if request.url.path == "/api/smart_home/switch":
-            return httpx.Response(200, json={"state": True})
+            return httpx2.Response(200, json={"state": True})
         if request.url.path == "/api/log_dump":
-            return httpx.Response(200, json={"result": "OK", "path": "/ext/log.txt"})
-        return httpx.Response(200, json={"result": "OK"})
+            return httpx2.Response(200, json={"result": "OK", "path": "/ext/log.txt"})
+        return httpx2.Response(200, json={"result": "OK"})
 
     client = _make_async_client(responder)
     assert (await client.account_backend()).server_url == "default"

--- a/tests/busylib/client/test_storage.py
+++ b/tests/busylib/client/test_storage.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from collections.abc import AsyncIterable, Iterable
 
-import httpx
+import httpx2
 import pytest
 
 from busylib import exceptions, types
@@ -34,7 +34,7 @@ class _DummyStorage(StorageMixin):
         data: bytes | Iterable[bytes] | None = None,
         expect_bytes: bool = False,
         allow_text: bool = False,
-        timeout: float | httpx.Timeout | None = None,
+        timeout: float | httpx2.Timeout | None = None,
     ) -> JsonType | bytes | str:
         """
         Record request arguments and return a success payload.
@@ -88,7 +88,7 @@ class _DummyAsyncStorage(AsyncStorageMixin):
         data: bytes | AsyncIterable[bytes] | None = None,
         expect_bytes: bool = False,
         allow_text: bool = False,
-        timeout: float | httpx.Timeout | None = None,
+        timeout: float | httpx2.Timeout | None = None,
     ) -> JsonType | bytes | str:
         """
         Record async request arguments and return a success payload.

--- a/tests/busylib/test_cloud_mode.py
+++ b/tests/busylib/test_cloud_mode.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-import httpx
+import httpx2
 import pytest
 
 from busylib import AsyncBusyBar, BusyBar
@@ -39,11 +39,11 @@ def test_cloud_client_requests_the_cloud_path() -> None:
     """
     seen: list[str] = []
 
-    def responder(request: httpx.Request) -> httpx.Response:
+    def responder(request: httpx2.Request) -> httpx2.Response:
         seen.append(request.url.path)
-        return httpx.Response(200, json={"api_semver": "25.0.0"})
+        return httpx2.Response(200, json={"api_semver": "25.0.0"})
 
-    client = BusyBar(token="secret", transport=httpx.MockTransport(responder))
+    client = BusyBar(token="secret", transport=httpx2.MockTransport(responder))
     client.version()
 
     assert seen == ["/busybar/version"]
@@ -55,11 +55,11 @@ def test_device_client_keeps_the_device_path() -> None:
     """
     seen: list[str] = []
 
-    def responder(request: httpx.Request) -> httpx.Response:
+    def responder(request: httpx2.Request) -> httpx2.Response:
         seen.append(request.url.path)
-        return httpx.Response(200, json={"api_semver": "25.0.0"})
+        return httpx2.Response(200, json={"api_semver": "25.0.0"})
 
-    client = BusyBar(addr="10.0.4.20", transport=httpx.MockTransport(responder))
+    client = BusyBar(addr="10.0.4.20", transport=httpx2.MockTransport(responder))
     client.version()
 
     assert seen == ["/api/version"]
@@ -72,11 +72,11 @@ async def test_async_cloud_client_requests_the_cloud_path() -> None:
     """
     seen: list[str] = []
 
-    def responder(request: httpx.Request) -> httpx.Response:
+    def responder(request: httpx2.Request) -> httpx2.Response:
         seen.append(request.url.path)
-        return httpx.Response(200, json={"api_semver": "25.0.0"})
+        return httpx2.Response(200, json={"api_semver": "25.0.0"})
 
-    client = AsyncBusyBar(token="secret", transport=httpx.MockTransport(responder))
+    client = AsyncBusyBar(token="secret", transport=httpx2.MockTransport(responder))
     await client.version()
     await client.aclose()
 

--- a/tests/busylib/test_connection_mode.py
+++ b/tests/busylib/test_connection_mode.py
@@ -9,7 +9,7 @@ token header and the device's `/api` paths. `is_cloud` states it instead.
 
 from __future__ import annotations
 
-import httpx
+import httpx2
 import pytest
 
 from busylib import AsyncBusyBar, BusyBar
@@ -17,7 +17,7 @@ from busylib import AsyncBusyBar, BusyBar
 
 def _client(**kwargs) -> BusyBar:
     return BusyBar(
-        transport=httpx.MockTransport(lambda _r: httpx.Response(200)), **kwargs
+        transport=httpx2.MockTransport(lambda _r: httpx2.Response(200)), **kwargs
     )
 
 
@@ -95,7 +95,7 @@ async def test_the_async_client_agrees() -> None:
         addr="https://api.stage.busy.app",
         token="s",
         is_cloud=True,
-        transport=httpx.MockTransport(lambda _r: httpx.Response(200)),
+        transport=httpx2.MockTransport(lambda _r: httpx2.Response(200)),
     )
 
     assert client.connection_type == "cloud"

--- a/tests/busylib/test_versioning_tags.py
+++ b/tests/busylib/test_versioning_tags.py
@@ -83,7 +83,7 @@ def test_experimental_helpers_still_call_the_device(name: str) -> None:
 
     Unlike a removed endpoint, this one works against firmware that has it.
     """
-    import httpx
+    import httpx2
 
     seen: list[str] = []
 
@@ -100,12 +100,12 @@ def test_experimental_helpers_still_call_the_device(name: str) -> None:
         "access_tokens_revoke": {"result": "OK"},
     }
 
-    def responder(request: httpx.Request) -> httpx.Response:
+    def responder(request: httpx2.Request) -> httpx2.Response:
         seen.append(request.url.path)
-        return httpx.Response(200, json=bodies[name])
+        return httpx2.Response(200, json=bodies[name])
 
     client = BusyBar(
-        addr="http://device.local", transport=httpx.MockTransport(responder)
+        addr="http://device.local", transport=httpx2.MockTransport(responder)
     )
     getattr(client, name)("x") if name in (
         "access_token_mint",

--- a/tests/busylib/test_wire_format.py
+++ b/tests/busylib/test_wire_format.py
@@ -8,19 +8,21 @@ noticed that the device did not.
 
 from __future__ import annotations
 
-import httpx
+import httpx2
 import pytest
 
 from busylib import BusyBar, types
 
 
 def _client(seen: dict[str, object]) -> BusyBar:
-    def responder(request: httpx.Request) -> httpx.Response:
+    def responder(request: httpx2.Request) -> httpx2.Response:
         seen["path"] = request.url.path
         seen["params"] = dict(request.url.params)
-        return httpx.Response(200, json={"result": "OK"})
+        return httpx2.Response(200, json={"result": "OK"})
 
-    return BusyBar(addr="http://device.local", transport=httpx.MockTransport(responder))
+    return BusyBar(
+        addr="http://device.local", transport=httpx2.MockTransport(responder)
+    )
 
 
 @pytest.mark.parametrize(

--- a/tests/examples/remote/test_name_set.py
+++ b/tests/examples/remote/test_name_set.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-import httpx
+import httpx2
 import pytest
 
 from busylib import AsyncBusyBar
@@ -70,14 +70,14 @@ async def test_name_set_posts_name_to_device() -> None:
     """
     seen: dict[str, object] = {}
 
-    def responder(request: httpx.Request) -> httpx.Response:
+    def responder(request: httpx2.Request) -> httpx2.Response:
         seen["path"] = request.url.path
         seen["body"] = request.content
-        return httpx.Response(200, json={"result": "OK"})
+        return httpx2.Response(200, json={"result": "OK"})
 
     client = AsyncBusyBar(
         addr="http://device.local",
-        transport=httpx.MockTransport(responder),
+        transport=httpx2.MockTransport(responder),
     )
     messages: list[str] = []
     command = NameSetCommand(client, messages.append)
@@ -99,13 +99,13 @@ async def test_name_set_rejects_invalid_name_without_calling_device() -> None:
     """
     calls: list[str] = []
 
-    def responder(request: httpx.Request) -> httpx.Response:
+    def responder(request: httpx2.Request) -> httpx2.Response:
         calls.append(request.url.path)
-        return httpx.Response(200, json={"result": "OK"})
+        return httpx2.Response(200, json={"result": "OK"})
 
     client = AsyncBusyBar(
         addr="http://device.local",
-        transport=httpx.MockTransport(responder),
+        transport=httpx2.MockTransport(responder),
     )
     messages: list[str] = []
     command = NameSetCommand(client, messages.append)
@@ -124,12 +124,12 @@ async def test_name_set_reports_api_failure() -> None:
     Surface an API failure as a status message instead of raising.
     """
 
-    def responder(_request: httpx.Request) -> httpx.Response:
-        return httpx.Response(403, json={"error": "Forbidden"})
+    def responder(_request: httpx2.Request) -> httpx2.Response:
+        return httpx2.Response(403, json={"error": "Forbidden"})
 
     client = AsyncBusyBar(
         addr="http://device.local",
-        transport=httpx.MockTransport(responder),
+        transport=httpx2.MockTransport(responder),
     )
     messages: list[str] = []
     command = NameSetCommand(client, messages.append)

--- a/tests/test_readme_examples.py
+++ b/tests/test_readme_examples.py
@@ -9,7 +9,7 @@ import zlib
 from pathlib import Path
 from typing import Any
 
-import httpx
+import httpx2
 import pytest
 from PIL import Image
 
@@ -40,7 +40,7 @@ def test_readme_onboarding_separates_terminal_and_python() -> None:
     assert "does not run Python examples from this guide" in readme
 
 
-def _responder(request: httpx.Request) -> httpx.Response:
+def _responder(request: httpx2.Request) -> httpx2.Response:
     """
     Answer the endpoints the README touches with realistic payloads.
     """
@@ -60,10 +60,10 @@ def _responder(request: httpx.Request) -> httpx.Response:
         "/api/storage/list": {"list": [{"name": "d.txt", "type": "file", "size": 13}]},
     }
     if path in bodies:
-        return httpx.Response(200, json=bodies[path])
+        return httpx2.Response(200, json=bodies[path])
     if path == "/api/storage/read":
-        return httpx.Response(200, content=b"Hello, world!")
-    return httpx.Response(200, json={"result": "OK"})
+        return httpx2.Response(200, content=b"Hello, world!")
+    return httpx2.Response(200, json={"result": "OK"})
 
 
 @pytest.fixture
@@ -112,7 +112,7 @@ def test_readme_examples_run_without_warnings(
     coordinate or a skipped media conversion shows up as a busylib warning,
     which is exactly how the previous examples were broken.
     """
-    transport = httpx.MockTransport(_responder)
+    transport = httpx2.MockTransport(_responder)
     original_init = BusyBar.__init__
 
     def patched_init(self, *args, **kwargs):


### PR DESCRIPTION
Closes #62. The mechanical migration is @Kilo59's work from #63, brought up to date with `main` — files added since that PR opened still imported `httpx`, and the dependency is now bounded at `>=2,<3`.

Breaking, which is why it waits for 2.0: `timeout=`, `transport=` and `execute_prepared_request(client=)` are public and typed with the import name, so anyone passing `httpx.Timeout` or a transport must switch. Transitively `certifi` is replaced by `truststore`, so TLS now uses the system trust store.

Verified against a real bar over USB, LAN and cloud: 42 passed, 6 skipped.