### PR TITLE
Point the README hero at an absolute URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,13 @@
 <p class="repository-hero" align="center">
   <picture>
-    <source media="(prefers-color-scheme: light)" srcset="assets/brand/busylib-py-hero-light.png">
-    <source media="(prefers-color-scheme: dark)" srcset="assets/brand/busylib-py-hero-dark.png">
-    <!-- Width only: GitHub constrains images with max-width and no height:auto,
-         so an explicit height attribute stays fixed while the width shrinks and
-         squashes the image on a phone. -->
-    <img alt="BUSY Bar: official Python library for connecting, controlling, and automating." width="830" src="assets/brand/busylib-py-hero-light.png">
+    <source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/busy-app/busylib-py/main/assets/brand/busylib-py-hero-light.png">
+    <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/busy-app/busylib-py/main/assets/brand/busylib-py-hero-dark.png">
+    <!-- Absolute, and width only. PyPI renders this README on its own domain
+         without rewriting relative paths, so `assets/...` resolved to a PyPI
+         page and the image broke; it also strips <source>, so this img is the
+         only variant seen there. GitHub constrains images with max-width and
+         no height:auto, which is why no height attribute. -->
+    <img alt="BUSY Bar: official Python library for connecting, controlling, and automating." width="830" src="https://raw.githubusercontent.com/busy-app/busylib-py/main/assets/brand/busylib-py-hero-light.png">
   </picture>
 </p>
 

--- a/tests/test_readme_examples.py
+++ b/tests/test_readme_examples.py
@@ -40,6 +40,24 @@ def test_readme_onboarding_separates_terminal_and_python() -> None:
     assert "does not run Python examples from this guide" in readme
 
 
+def test_readme_images_are_absolute() -> None:
+    """
+    Every image in the README is reachable from off-site.
+
+    PyPI renders this file on its own domain without rewriting relative
+    paths, so `assets/...` resolved to a PyPI page - served as HTML with a
+    200, which shows up as a broken image rather than a 404. It also strips
+    `<source>`, so the `<img>` fallback is the only variant seen there.
+    """
+    readme = README.read_text(encoding="utf-8")
+
+    references = re.findall(r'(?:src|srcset)="([^"]+)"', readme)
+
+    assert references, "no image references found in README.md"
+    relative = [ref for ref in references if not ref.startswith("https://")]
+    assert not relative, f"these must be absolute for PyPI: {relative}"
+
+
 def _responder(request: httpx2.Request) -> httpx2.Response:
     """
     Answer the endpoints the README touches with realistic payloads.


### PR DESCRIPTION
The banner was broken on the PyPI project page: PyPI renders the README on its own domain without rewriting relative paths, so `assets/...` resolved to a PyPI page — returned as HTML with a 200, which a browser shows as a broken image rather than a 404. GitHub and the docs site were unaffected, which is why it went unnoticed.

Verified with `readme_renderer`, the renderer PyPI itself uses; it also strips `<source>`, so the `<img>` fallback is the only variant seen there. A test now fails on any relative image reference.

Only future releases pick this up — the description is release metadata, so 2.0.0's page keeps the broken image.