### PR TITLE
Discover bars via _http._tcp instead of the retired _busybar service

### DIFF
--- a/README.md
+++ b/README.md
@@ -511,7 +511,7 @@ USB address instead.
 Both the `remote` and `setup` examples use this automatically when no address is
 given: they discover devices via mDNS, let you pick one by name if more than one
 is found, and prompt for the access key if the bar needs one. Shipped firmware
-doesn't advertise the `_busybar._tcp` service yet, so if nothing is found they
+doesn't advertise itself under `_http._tcp` yet, so if nothing is found they
 fall back to the well-known USB address `10.0.4.20`.
 
 ### Working with storage

--- a/docs/api/discovery.md
+++ b/docs/api/discovery.md
@@ -21,7 +21,7 @@ were discovered, not that the library failed; use `10.0.4.20` for a
 USB-connected bar in that case.
 
 !!! note
-    Shipped firmware doesn't advertise the `_busybar._tcp` service yet, so
+    Shipped firmware doesn't advertise itself under `_http._tcp` yet, so
     `discover()` can legitimately return an empty list. A USB-connected bar
     is still reachable at its well-known static address, `10.0.4.20`.
 

--- a/docs/guides/connecting.md
+++ b/docs/guides/connecting.md
@@ -86,14 +86,15 @@ Each line is the advertised device name and Wi-Fi address. No output is normal
 on firmware that does not advertise the service; a USB-connected bar remains
 available at `10.0.4.20`.
 
-Discovery browses for the `_busybar._tcp` mDNS service and classifies each
+Discovery browses for the `_http._tcp` mDNS service and classifies each
 address it finds: anything in `10.0.4.*` is treated as the USB link, everything
-else as Wi-Fi.
+else as Wi-Fi. Only instances whose name starts with `busybar-` are treated as
+bars; other, unrelated `_http._tcp` services on the network are ignored.
 
 !!! warning
-    Shipped firmware does not advertise `_busybar._tcp` yet, so `discover()`
-    can legitimately return an empty list. The `remote` and `setup` examples
-    fall back to `10.0.4.20` in that case.
+    Shipped firmware does not advertise itself under `_http._tcp` yet, so
+    `discover()` can legitimately return an empty list. The `remote` and
+    `setup` examples fall back to `10.0.4.20` in that case.
 
 ## Closing the client
 

--- a/examples/shared/discovery.py
+++ b/examples/shared/discovery.py
@@ -9,8 +9,8 @@ from busylib.types import HttpAccessInfo
 DISCOVERY_TIMEOUT_SECONDS = 1.5
 
 # Well-known static address of a USB-connected bar. Falls back to this when
-# mDNS discovery finds nothing - factory firmware doesn't advertise
-# `_busybar._tcp` yet (that feature isn't merged/released), so a bar
+# mDNS discovery finds nothing - factory firmware doesn't advertise itself
+# under `_http._tcp` yet (that feature isn't merged/released), so a bar
 # connected over USB is otherwise unreachable without an explicit --addr.
 USB_FALLBACK_ADDRESS = "10.0.4.20"
 

--- a/src/busylib/devices.py
+++ b/src/busylib/devices.py
@@ -17,7 +17,11 @@ from zeroconf import (
 )
 from zeroconf.asyncio import AsyncServiceBrowser, AsyncServiceInfo, AsyncZeroconf
 
-BUSYBAR_SERVICE = "_busybar._tcp.local."
+BUSYBAR_SERVICE = "_http._tcp.local."
+# Firmware advertises the bar's unique instance name as "busybar-<mac>" under
+# the shared _http service (not a dedicated _busybar service), so it must be
+# stripped to recover the device id.
+BUSYBAR_INSTANCE_NAME_PREFIX = "busybar-"
 BUSYBAR_USB_SUBNET = "10.0.4."
 BUSYBAR_DEFAULT_NAME = b"BUSY Bar"
 TIMEOUT = 1.5
@@ -112,8 +116,15 @@ class _DeviceCollector:
     def _record(self, info: ServiceInfo) -> None:
         """
         Fold one resolved service record into the collected devices.
+
+        `_http._tcp` is a generic service type, so other, unrelated HTTP
+        servers on the network may answer too; only instances following the
+        bar's naming convention are treated as bars.
         """
-        device_id = info.name.split(".")[0]
+        instance_name = info.name.split(".")[0]
+        if not instance_name.startswith(BUSYBAR_INSTANCE_NAME_PREFIX):
+            return
+        device_id = instance_name.removeprefix(BUSYBAR_INSTANCE_NAME_PREFIX)
         addresses = (
             BusyBarDeviceDiscoverer._ip_address_to_our(addr.compressed)
             for addr in info.ip_addresses_by_version(IPVersion.V4Only)

--- a/tests/busylib/test_devices.py
+++ b/tests/busylib/test_devices.py
@@ -12,6 +12,7 @@ from busylib.devices import (
     AsyncBusyBarDeviceDiscoverer,
     BusyBarDeviceDiscoverer,
     BusyBarDevices,
+    _DeviceCollector,
 )
 
 USB_IP = "10.0.4.20"
@@ -97,6 +98,70 @@ def test_client_factories_return_none_without_an_address() -> None:
 
     assert device.to_sync_client("over_usb") is None
     assert device.to_async_client("over_usb") is None
+
+
+class FakeIPAddress:
+    def __init__(self, compressed: str) -> None:
+        self.compressed = compressed
+
+
+class FakeServiceInfo:
+    """
+    Stands in for a resolved `zeroconf.ServiceInfo`/`AsyncServiceInfo`.
+    """
+
+    def __init__(
+        self,
+        *,
+        name: str,
+        addresses: list[str] | None = None,
+        device_name: bytes | None = None,
+    ) -> None:
+        self.name = name
+        self._addresses = [FakeIPAddress(addr) for addr in (addresses or [])]
+        self.properties: dict[bytes, bytes] = {}
+        if device_name is not None:
+            self.properties[b"name"] = device_name
+
+    def ip_addresses_by_version(self, _version: object) -> list[FakeIPAddress]:
+        return self._addresses
+
+
+def test_record_accepts_a_busybar_instance_and_strips_the_prefix() -> None:
+    """
+    `_http._tcp` is shared with other services, so only the bar's own
+    naming convention ("busybar-<id>") is recognized, and the prefix is
+    stripped to recover the plain device id.
+    """
+    collector = _DeviceCollector()
+    info = FakeServiceInfo(
+        name="busybar-aabbcc._http._tcp.local.",
+        addresses=[WIFI_IP],
+        device_name=b"Front desk",
+    )
+
+    collector._record(info)  # type: ignore[arg-type]
+
+    devices = collector.collected()
+    assert len(devices) == 1
+    assert devices[0].device_id == "aabbcc"
+    assert devices[0].name == "Front desk"
+
+
+def test_record_ignores_unrelated_http_services() -> None:
+    """
+    An unrelated `_http._tcp` responder on the network must not be
+    mistaken for a bar.
+    """
+    collector = _DeviceCollector()
+    info = FakeServiceInfo(
+        name="some-printer._http._tcp.local.",
+        addresses=[WIFI_IP],
+    )
+
+    collector._record(info)  # type: ignore[arg-type]
+
+    assert collector.collected() == []
 
 
 class RecordingZeroconf:

--- a/tests/examples/shared/test_discovery.py
+++ b/tests/examples/shared/test_discovery.py
@@ -39,7 +39,7 @@ def test_resolve_connection_falls_back_to_usb_address(
     """
     Use the well-known USB address when mDNS discovery finds nothing but
     that address is reachable (e.g. a USB-connected bar on firmware that
-    doesn't advertise `_busybar._tcp` yet).
+    doesn't advertise itself under `_http._tcp` yet).
     """
     monkeypatch.setattr(discovery.BusyBarDevices, "discover", lambda timeout=1.5: [])
     monkeypatch.setattr(


### PR DESCRIPTION
busybar-firmware#999 drops the dedicated `_busybar` mDNS service and folds the bar's unique instance name (`busybar-<mac>`) into the existing `_http` service instead, fixing two bars on the same network colliding on the previously static `"httpd"` instance name.

This updates discovery to browse `_http._tcp` and recognize bars by the `busybar-` instance name prefix, ignoring other unrelated `_http._tcp` responders on the network. Docs/README/examples comments updated accordingly.

# Verification
`uv run pytest` — full suite green, including two new unit tests for `_DeviceCollector._record` (accepts `busybar-*` instances and strips the prefix, ignores other `_http._tcp` services).